### PR TITLE
webgpu: batch instance upload path and draw-prep bind group reuse

### DIFF
--- a/src/render/webgpu/WebGPURenderer.ts
+++ b/src/render/webgpu/WebGPURenderer.ts
@@ -220,6 +220,8 @@ class WebGPUDrawPrepRuntime {
   private activeShaderCode: string;
   private readonly paramsBuffer: any;
   private readonly paramsStaging = new Uint32Array(WEBGPU_RENDER_CONTRACT.drawPrepParamsU32);
+  private activeBindGroup: any | null = null;
+  private activeIndirectBuffer: any | null = null;
 
   constructor(private readonly device: any, initialShaderCode: string = DRAW_PREP_COMPUTE_WGSL) {
     this.activeShaderCode = initialShaderCode;
@@ -253,6 +255,31 @@ class WebGPUDrawPrepRuntime {
     // one active WGSL source at runtime (compiler-provided or canonical default).
     this.pipeline = this.createPipeline(nextShaderCode);
     this.activeShaderCode = nextShaderCode;
+    this.activeBindGroup = null;
+    this.activeIndirectBuffer = null;
+  }
+
+  private getOrCreateBindGroup(indirectBuffer: any): any {
+    if (this.activeBindGroup && this.activeIndirectBuffer === indirectBuffer) {
+      return this.activeBindGroup;
+    }
+
+    const bindGroup = this.device.createBindGroup({
+      layout: this.pipeline.getBindGroupLayout(WEBGPU_RENDER_CONTRACT.drawPrepBindGroup),
+      entries: [
+        {
+          binding: WEBGPU_RENDER_CONTRACT.drawPrepIndirectBinding,
+          resource: { buffer: indirectBuffer },
+        },
+        {
+          binding: WEBGPU_RENDER_CONTRACT.drawPrepParamsBinding,
+          resource: { buffer: this.paramsBuffer },
+        },
+      ],
+    });
+    this.activeBindGroup = bindGroup;
+    this.activeIndirectBuffer = indirectBuffer;
+    return bindGroup;
   }
 
   step(
@@ -274,19 +301,7 @@ class WebGPUDrawPrepRuntime {
     this.paramsStaging[7] = 0;
     this.device.queue.writeBuffer(this.paramsBuffer, 0, this.paramsStaging);
 
-    const bindGroup = this.device.createBindGroup({
-      layout: this.pipeline.getBindGroupLayout(WEBGPU_RENDER_CONTRACT.drawPrepBindGroup),
-      entries: [
-        {
-          binding: WEBGPU_RENDER_CONTRACT.drawPrepIndirectBinding,
-          resource: { buffer: indirectBuffer },
-        },
-        {
-          binding: WEBGPU_RENDER_CONTRACT.drawPrepParamsBinding,
-          resource: { buffer: this.paramsBuffer },
-        },
-      ],
-    });
+    const bindGroup = this.getOrCreateBindGroup(indirectBuffer);
 
     const pass = commandEncoder.beginComputePass();
     pass.setPipeline(this.pipeline);

--- a/src/render/webgpu/__tests__/WebGPURenderer.test.ts
+++ b/src/render/webgpu/__tests__/WebGPURenderer.test.ts
@@ -92,6 +92,19 @@ function createFakeWebGPUEnvironment() {
   };
 }
 
+function collectDrawPrepBindGroupCalls(createBindGroupMock: { mock: { calls: unknown[][] } }): unknown[][] {
+  return createBindGroupMock.mock.calls.filter((call: unknown[]) => {
+    const descriptor = call[0] as { entries?: Array<{ binding: number }> };
+    if (!descriptor.entries || descriptor.entries.length !== 2) {
+      return false;
+    }
+    return (
+      descriptor.entries[0]?.binding === WEBGPU_RENDER_CONTRACT.drawPrepIndirectBinding &&
+      descriptor.entries[1]?.binding === WEBGPU_RENDER_CONTRACT.drawPrepParamsBinding
+    );
+  });
+}
+
 describe('WebGPURenderer', () => {
   const originalGpu = (navigator as Navigator & { gpu?: unknown }).gpu;
 
@@ -604,6 +617,7 @@ describe('WebGPURenderer', () => {
     setNavigatorGpu(env.gpu);
     const renderer = await createWebGPURenderer(env.canvas);
     env.device.queue.writeBuffer.mockClear();
+    env.device.createBindGroup.mockClear();
     const topologyId = registerDynamicTopology({
       params: [],
       verbs: [PathVerb.MOVE, PathVerb.LINE, PathVerb.LINE, PathVerb.LINE, PathVerb.CLOSE],
@@ -655,6 +669,64 @@ describe('WebGPURenderer', () => {
     );
     expect(instanceUploads).toHaveLength(1);
     expect(instanceUploads[0]?.[4]).toBe(2 * WEBGPU_RENDER_CONTRACT.instanceBytes);
+
+    const drawPrepBindGroups = collectDrawPrepBindGroupCalls(env.device.createBindGroup);
+    expect(drawPrepBindGroups).toHaveLength(1);
+  });
+
+  it('reuses draw-prep bind group across frames when shader and indirect buffer are unchanged', async () => {
+    const env = createFakeWebGPUEnvironment();
+    setNavigatorGpu(env.gpu);
+    const renderer = await createWebGPURenderer(env.canvas);
+    const topologyId = registerDynamicTopology({
+      params: [],
+      verbs: [PathVerb.MOVE, PathVerb.LINE, PathVerb.LINE, PathVerb.LINE, PathVerb.CLOSE],
+      pointsPerVerb: [1, 1, 1, 1, 0],
+      totalControlPoints: 4,
+      closed: true,
+    }, 'webgpu-draw-prep-bindgroup-reuse-topology');
+
+    const renderInput = {
+      frame: {
+        version: 2 as const,
+        ops: [{
+          kind: 'drawPathInstances' as const,
+          geometry: {
+            topologyId,
+            points: new Float32Array([-1, -1, 1, -1, 1, 1, -1, 1]),
+            pointsCount: 4,
+            verbs: new Uint8Array([0, 1, 1, 1, 4]),
+            flags: 1,
+          },
+          instances: {
+            count: 1,
+            position: new Float32Array([0.5, 0.5]),
+            size: 0.25,
+            rotation: new Float32Array([0]),
+            scale2: new Float32Array([1, 1]),
+          },
+          style: {
+            fillColor: new Uint8ClampedArray([255, 0, 0, 255]),
+            fillRule: 'nonzero' as const,
+          },
+        }],
+      },
+      width: 128,
+      height: 96,
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+    };
+
+    env.device.createBindGroup.mockClear();
+    renderer.render({ ...renderInput, timeMs: 0 });
+    const firstFrameDrawPrepBindGroups = collectDrawPrepBindGroupCalls(env.device.createBindGroup);
+    expect(firstFrameDrawPrepBindGroups).toHaveLength(1);
+
+    env.device.createBindGroup.mockClear();
+    renderer.render({ ...renderInput, timeMs: 16 });
+    const secondFrameDrawPrepBindGroups = collectDrawPrepBindGroupCalls(env.device.createBindGroup);
+    expect(secondFrameDrawPrepBindGroups).toHaveLength(0);
   });
 
   it('supports per-instance stroke widths for stroke rendering', async () => {


### PR DESCRIPTION
## Summary
- batch all planned draw-pass instances into one contiguous instance-buffer upload per frame
- wire per-pass `firstInstance` through draw-prep indirect args and use planned offsets in draw records
- cache draw-prep bind groups by (pipeline, indirect buffer) so multi-pass draws and subsequent frames reuse the same bind group
- add WebGPU renderer tests covering indirect offsets, single upload for fill+stroke, and bind-group reuse across frames

## Verification
- pnpm vitest run src/render/webgpu/__tests__/WebGPURenderer.test.ts
- pnpm vitest run src/render/webgpu/__tests__/PathTessellator.test.ts src/render/webgpu/__tests__/WebGPURenderer.test.ts
