### PR TITLE
Remove scalarExprToArenaOffset compatibility path

### DIFF
--- a/.migration/seams.md
+++ b/.migration/seams.md
@@ -30,13 +30,13 @@
   Why seam: Canonical descriptor contract is now explicit (`packing`, `laneStride`, `componentStride`) but producers/consumers still run AoS packing.
   Proposed change: flip runtime/compiler descriptor emission + read/write helpers to SoA packing and migrate remaining AoS consumers.
 
-- [S7] Code location: src/compiler/ir/program.ts:347
-  Why seam: RuntimeAddressTable now carries canonical scalar address metadata, but downstream modules still depend on offset-only maps.
-  Proposed change: migrate remaining runtime readers to `scalarExprToArenaAddress`/descriptor-driven reads and remove offset-only compatibility path.
-
 - [S8] Code location: src/runtime/RuntimeState.ts:665
   Why seam: Persistent state is now arena-backed (`stateArena` + view), but frame semantics still model single-bank writes only.
   Proposed change: introduce explicit read/write bank semantics on state arena segment for full ping-pong ownership.
+
+## Resolved (Delta)
+- [S7] Code location: src/compiler/ir/program.ts:347
+  Resolution: Removed `scalarExprToArenaOffset` from production compiler/runtime contracts and execution context wiring; canonical `scalarExprToArenaAddress` is now the only scalar arena metadata path in production modules.
 
 ## Class 2
 - none

--- a/src/__tests__/forbidden-patterns.test.ts
+++ b/src/__tests__/forbidden-patterns.test.ts
@@ -1501,6 +1501,25 @@ describe('Forbidden Patterns (Type System Invariants)', () => {
       ).toEqual([]);
     });
 
+    it('production runtime/compiler contracts must not expose offset-only scalar arena maps', () => {
+      // [LAW:one-source-of-truth] Canonical scalar arena addressing is enforced by
+      // one metadata contract (`scalarExprToArenaAddress`) across compile/runtime.
+      const rawMatches = [
+        ...grepSrc('scalarExprToArenaOffset', 'src/compiler/ir/program.ts'),
+        ...grepSrc('scalarExprToArenaOffset', 'src/compiler/compile.ts'),
+        ...grepSrc('scalarExprToArenaOffset', 'src/runtime/RuntimeState.ts'),
+        ...grepSrc('scalarExprToArenaOffset', 'src/runtime/ScheduleExecutor.ts'),
+        ...grepSrc('scalarExprToArenaOffset', 'src/runtime/executeFrameStepped.ts'),
+        ...grepSrc('scalarExprToArenaOffset', 'src/runtime/RenderAssembler.ts'),
+      ];
+      const filtered = filterAllowlist(rawMatches, [/\.test\./, /__tests__/]);
+      expect(
+        filtered,
+        'Production compile/runtime modules must not carry scalarExprToArenaOffset compatibility paths.\n' +
+        'Found violations:\n' + filtered.join('\n')
+      ).toEqual([]);
+    });
+
     it('materializer and continuity mapping must route stride indexing through shared helpers', () => {
       const rawMatches = [
         ...grepSrc('\\bi\\s*\\*\\s*stride\\s*\\+\\s*[a-zA-Z_]', 'src/runtime/ValueExprMaterializer.ts'),

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -324,7 +324,6 @@ function buildRuntimeAddressTable(
   }
 
   const fieldExprToSlot = new Map<number, ValueSlot>();
-  const scalarExprToArenaOffset = new Map<number, number>();
   const scalarExprToArenaAddress = new Map<number, { slot: ValueSlot; arena: ArenaSlotDescriptor; component: number }>();
   const steps = scheduleIR.steps as readonly Step[];
   for (const step of steps) {
@@ -333,7 +332,6 @@ function buildRuntimeAddressTable(
       if (step.instanceId === SCALAR_INSTANCE_ID) {
         const arenaDesc = slotToArena.get(step.target);
         if (arenaDesc) {
-          scalarExprToArenaOffset.set(step.field as number, arenaDesc.offset);
           scalarExprToArenaAddress.set(step.field as number, {
             slot: step.target,
             arena: arenaDesc,
@@ -345,7 +343,6 @@ function buildRuntimeAddressTable(
     if (step.kind === 'evalOne') {
       const arenaDesc = slotToArena.get(step.target);
       if (arenaDesc) {
-        scalarExprToArenaOffset.set(step.expr as number, arenaDesc.offset);
         scalarExprToArenaAddress.set(step.expr as number, {
           slot: step.target,
           arena: arenaDesc,
@@ -358,7 +355,6 @@ function buildRuntimeAddressTable(
   return {
     slotLookup,
     fieldExprToSlot,
-    scalarExprToArenaOffset,
     scalarExprToArenaAddress,
     slotToArena,
   };

--- a/src/compiler/ir/program.ts
+++ b/src/compiler/ir/program.ts
@@ -401,8 +401,6 @@ export interface RuntimeAddressTableIR {
   readonly slotLookup: ReadonlyMap<ValueSlot, RuntimeSlotLookupEntry>;
   /** ValueExprId (materialized field expression) → target ValueSlot */
   readonly fieldExprToSlot: ReadonlyMap<number, ValueSlot>;
-  /** Scalar ValueExprId → arena scalar offset */
-  readonly scalarExprToArenaOffset: ReadonlyMap<number, number>;
   /** Scalar ValueExprId → canonical arena address metadata */
   readonly scalarExprToArenaAddress: ReadonlyMap<number, RuntimeScalarArenaAddress>;
   /** ValueSlot → arena descriptor */

--- a/src/runtime/RenderAssembler.ts
+++ b/src/runtime/RenderAssembler.ts
@@ -511,8 +511,6 @@ export interface AssemblerContext {
   resolvedCamera: ResolvedCameraParams;
   /** Pre-allocated buffer arena for zero-allocation rendering */
   arena: RenderBufferArena;
-  /** One-cardinality ValueExprId -> arena scalar offset map. */
-  scalarExprToArenaOffset: ReadonlyMap<number, number>;
   /** One-cardinality ValueExprId -> canonical arena address metadata. */
   scalarExprToArenaAddress?: ReadonlyMap<number, RuntimeScalarArenaAddress>;
   /** Slot -> arena descriptor map (for numeric field reads). */

--- a/src/runtime/RuntimeState.ts
+++ b/src/runtime/RuntimeState.ts
@@ -370,9 +370,6 @@ export interface FrameCache {
    */
   valueExprFieldStamps: number[];
 
-  /** Scalar ValueExprId -> arena offset mapping for multi-component extract */
-  scalarExprToArenaOffset: ReadonlyMap<number, number> | null;
-
   /** Scalar ValueExprId -> canonical arena address metadata. */
   scalarExprToArenaAddress: ReadonlyMap<number, RuntimeScalarArenaAddress> | null;
 }
@@ -389,7 +386,6 @@ export function createFrameCache(
     scalarValueExprStamps: new Uint32Array(maxValueExprs),
     valueExprFieldBuffers: new Array(maxValueExprs).fill(null),
     valueExprFieldStamps: new Array(maxValueExprs).fill(-1),
-    scalarExprToArenaOffset: null,
     scalarExprToArenaAddress: null,
   };
 }

--- a/src/runtime/ScheduleExecutor.ts
+++ b/src/runtime/ScheduleExecutor.ts
@@ -259,9 +259,8 @@ export function executeFrame(
   // Collect render steps for v2 batch assembly (reuse module-level array)
   _renderSteps.length = 0;
 
-  // [LAW:one-source-of-truth] Populate scalarExprToArenaOffset before Phase 1 so extract
-  // reads multi-component values from arena using canonical ExprAddressTable offsets.
-  state.cache.scalarExprToArenaOffset = addressTable.scalarExprToArenaOffset;
+  // [LAW:one-source-of-truth] Populate canonical scalar arena addresses before Phase 1
+  // so extract reads resolve from compiler-emitted ExprAddressTable metadata only.
   state.cache.scalarExprToArenaAddress = addressTable.scalarExprToArenaAddress;
 
   // PHASE 1: Execute all non-stateWrite steps
@@ -528,7 +527,6 @@ export function executeFrame(
   _assemblerCtx.state = state;
   _assemblerCtx.resolvedCamera = resolvedCamera;
   _assemblerCtx.arena = arena;
-  _assemblerCtx.scalarExprToArenaOffset = state.cache.scalarExprToArenaOffset!;
   _assemblerCtx.scalarExprToArenaAddress = state.cache.scalarExprToArenaAddress ?? undefined;
   _assemblerCtx.slotToArena = addressTable.slotToArena;
   assemblerContext = _assemblerCtx as AssemblerContext;

--- a/src/runtime/__tests__/CameraResolver.test.ts
+++ b/src/runtime/__tests__/CameraResolver.test.ts
@@ -29,7 +29,6 @@ function mockProgram(
     runtimeAddressTable: {
       slotLookup: new Map(),
       fieldExprToSlot: new Map(),
-      scalarExprToArenaOffset: new Map(),
       scalarExprToArenaAddress: new Map(),
       slotToArena,
     },

--- a/src/runtime/__tests__/ExprAddressTable.test.ts
+++ b/src/runtime/__tests__/ExprAddressTable.test.ts
@@ -69,7 +69,6 @@ function mockProgram(opts: {
     }
   }
   const fieldExprToSlot = new Map<number, ValueSlot>();
-  const scalarExprToArenaOffset = new Map<number, number>();
   const scalarExprToArenaAddress = new Map<number, { slot: ValueSlot; arena: (typeof arenaLayout)[number]; component: number }>();
   for (const step of opts.steps) {
     if (step.kind === 'materialize') {
@@ -77,7 +76,6 @@ function mockProgram(opts: {
       if (step.instanceId === SCALAR_INSTANCE_ID) {
         const arenaDesc = slotToArena.get(step.target);
         if (arenaDesc) {
-          scalarExprToArenaOffset.set(step.field as any as number, arenaDesc.offset);
           scalarExprToArenaAddress.set(step.field as any as number, {
             slot: step.target,
             arena: arenaDesc,
@@ -89,7 +87,6 @@ function mockProgram(opts: {
     if (step.kind === 'evalOne') {
       const arenaDesc = slotToArena.get(step.target);
       if (arenaDesc) {
-        scalarExprToArenaOffset.set(step.expr as any as number, arenaDesc.offset);
         scalarExprToArenaAddress.set(step.expr as any as number, {
           slot: step.target,
           arena: arenaDesc,
@@ -101,7 +98,6 @@ function mockProgram(opts: {
   const runtimeAddressTable = {
     slotLookup,
     fieldExprToSlot,
-    scalarExprToArenaOffset,
     scalarExprToArenaAddress,
     slotToArena,
   };
@@ -177,7 +173,7 @@ describe('getExprAddressTable', () => {
     expect(table.fieldExprToSlot.get(10)).toBe(valueSlot(5));
   });
 
-  it('reads scalarExprToArenaOffset from precomputed runtime address table', () => {
+  it('reads scalarExprToArenaAddress from precomputed runtime address table', () => {
     const program = mockProgram({
       slotMeta: [
         { slot: valueSlot(3), storage: 'f32', offset: 7, stride: 1, type: SIG_FLOAT },
@@ -192,7 +188,11 @@ describe('getExprAddressTable', () => {
     });
 
     const table = getExprAddressTable(program);
-    expect(table.scalarExprToArenaOffset.get(42)).toBe(7);
+    expect(table.scalarExprToArenaAddress.get(42)).toEqual(expect.objectContaining({
+      slot: valueSlot(3),
+      component: 0,
+      arena: expect.objectContaining({ offset: 7, stride: 1 }),
+    }));
   });
 
   it('returns the same precomputed table reference per program identity', () => {

--- a/src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts
+++ b/src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts
@@ -149,7 +149,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(10)]]),
         state,
@@ -222,7 +221,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(instanceCount)]]),
         state,
@@ -309,7 +307,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(instanceCount)]]),
         state,
@@ -398,7 +395,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(instanceCount)]]),
         state,
@@ -475,7 +471,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(instanceCount)]]),
         state,
@@ -559,7 +554,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(instanceCount)]]),
         state,
@@ -615,7 +609,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(instanceCount)]]),
         state,
@@ -677,7 +670,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['culled-groups', createMockInstance(instanceCount)]]),
         state,
@@ -770,7 +762,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       ];
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([
           ['instance-a', createMockInstance(3)],
@@ -857,7 +848,6 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
 
       const arena = getTestArena();
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['stress-instance', createMockInstance(instanceCount)]]),
         state,

--- a/src/runtime/__tests__/RenderAssembler.test.ts
+++ b/src/runtime/__tests__/RenderAssembler.test.ts
@@ -123,7 +123,6 @@ describe('RenderAssembler', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset: new Map(),
         scalarExprToArenaAddress: new Map(),
         instances: new Map(),
         state,
@@ -147,7 +146,6 @@ describe('RenderAssembler', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset: new Map(),
         scalarExprToArenaAddress: new Map(),
         instances: new Map([['empty-instance', createMockInstance(0)]]),
         state,
@@ -214,7 +212,6 @@ describe('RenderAssembler', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['culled-instance', createMockInstance(2)]]),
         state,
@@ -261,7 +258,6 @@ describe('RenderAssembler', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(10)]]),
         state,
@@ -326,7 +322,6 @@ describe('RenderAssembler', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(2)]]),
         state,
@@ -414,7 +409,6 @@ describe('RenderAssembler', () => {
       };
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['test-instance', createMockInstance(10)]]),
         state,
@@ -490,7 +484,6 @@ describe('RenderAssembler', () => {
       ];
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([
           ['instance-a', createMockInstance(1)],
@@ -533,7 +526,6 @@ describe('RenderAssembler', () => {
       ];
 
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([
           ['empty-instance', createMockInstance(0)], // count = 0
@@ -607,7 +599,6 @@ describe('RenderAssembler', () => {
 
       const arena = getTestArena();
       const context: AssemblerContext = {
-        scalarExprToArenaOffset,
         scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
         instances: new Map([['budget-instance', createMockInstance(instanceCount)]]),
         state,

--- a/src/runtime/__tests__/project-policy-domain-change.test.ts
+++ b/src/runtime/__tests__/project-policy-domain-change.test.ts
@@ -66,7 +66,6 @@ function createTestRuntimeState(): RuntimeState {
 
       valueExprFieldBuffers: [],
       valueExprFieldStamps: [],
-      scalarExprToArenaOffset: null,
       scalarExprToArenaAddress: null,
     },
     timeState: {

--- a/src/runtime/executeFrameStepped.ts
+++ b/src/runtime/executeFrameStepped.ts
@@ -272,9 +272,8 @@ export function* executeFrameStepped(
   // Yield pre-frame snapshot
   yield buildSnapshot(-1, null, 'pre-frame', totalSteps, program, state, tAbsMs, new Map(), prevValues);
 
-  // [LAW:one-source-of-truth] Populate scalarExprToArenaOffset before Phase 1 so extract
-  // reads multi-component values from arena using canonical ExprAddressTable offsets.
-  state.cache.scalarExprToArenaOffset = addressTable.scalarExprToArenaOffset;
+  // [LAW:one-source-of-truth] Populate canonical scalar arena addresses before Phase 1
+  // so extract reads resolve from compiler-emitted ExprAddressTable metadata only.
   state.cache.scalarExprToArenaAddress = addressTable.scalarExprToArenaAddress;
 
   // --- PHASE 1: Execute all non-stateWrite steps ---
@@ -457,7 +456,6 @@ export function* executeFrameStepped(
     state,
     resolvedCamera,
     arena,
-    scalarExprToArenaOffset: state.cache.scalarExprToArenaOffset!,
     scalarExprToArenaAddress: state.cache.scalarExprToArenaAddress ?? undefined,
     slotToArena: addressTable.slotToArena,
   };

--- a/src/runtime/executor-init.ts
+++ b/src/runtime/executor-init.ts
@@ -33,7 +33,6 @@ export const assemblerCtx = {
   state: null as any,
   resolvedCamera: null as any,
   arena: null as any,
-  scalarExprToArenaOffset: null as any,
   scalarExprToArenaAddress: null as any,
   slotToArena: null as any,
 };

--- a/src/services/mapDebugEdges.test.ts
+++ b/src/services/mapDebugEdges.test.ts
@@ -22,7 +22,6 @@ function createRuntimeAddressTable(slotEntries: ReadonlyArray<{ slot: ValueSlot;
     return {
         slotLookup,
         fieldExprToSlot: new Map(),
-        scalarExprToArenaOffset: new Map(),
         slotToArena: new Map(),
     };
 }


### PR DESCRIPTION
## Summary
- remove scalarExprToArenaOffset from production compile/runtime contracts and execution context wiring
- keep canonical scalarExprToArenaAddress as the single scalar arena metadata path in production modules
- update runtime/compiler tests and seam inventory delta for the resolved S7 migration seam
- add a forbidden-patterns regression gate that blocks reintroduction of offset-only scalar arena maps in production modules

## Validation
- pnpm -s vitest run src/__tests__/forbidden-patterns.test.ts src/runtime/__tests__/ExprAddressTable.test.ts src/runtime/__tests__/RenderAssembler.test.ts src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts src/runtime/__tests__/CameraResolver.test.ts src/runtime/__tests__/project-policy-domain-change.test.ts src/services/mapDebugEdges.test.ts
- pnpm -s tsc -p tsconfig.json --noEmit (fails in current tree due missing modules: earcut, bezier-js, simplex-noise)
