### PR TITLE
webgpu: dispatch simulation from unique draw-op instance cardinality

### DIFF
--- a/src/render/webgpu/WebGPURenderer.ts
+++ b/src/render/webgpu/WebGPURenderer.ts
@@ -442,6 +442,8 @@ export class WebGPURenderer {
     this.ensureCanvasConfiguration(input.width, input.height);
     this.syncTopologyBank();
     this.writeSceneUniforms(input);
+    this.drawPrepRuntime.useShader(input.drawPrepShaderWgsl);
+    const drawPlan = this.buildDrawPlan(input.frame);
 
     const dtSeconds =
       this.lastFrameTimeMs === null
@@ -450,9 +452,7 @@ export class WebGPURenderer {
     this.lastFrameTimeMs = input.timeMs;
 
     const commandEncoder = this.device.createCommandEncoder();
-    this.computeRuntime.step(commandEncoder, 0, dtSeconds);
-    this.drawPrepRuntime.useShader(input.drawPrepShaderWgsl);
-    const drawPlan = this.buildDrawPlan(input.frame);
+    this.computeRuntime.step(commandEncoder, this.countSimulationInstances(drawPlan), dtSeconds);
     const totalInstances = this.countPlannedInstances(drawPlan);
     this.ensureInstanceCapacity(totalInstances);
     const packedInstances = this.packDrawPlanInstances(drawPlan);
@@ -677,6 +677,21 @@ export class WebGPURenderer {
   private countPlannedInstances(drawPlan: readonly PreparedDrawPathOp[]): number {
     let total = 0;
     for (const prepared of drawPlan) {
+      total += prepared.instanceCount;
+    }
+    return total;
+  }
+
+  private countSimulationInstances(drawPlan: readonly PreparedDrawPathOp[]): number {
+    let total = 0;
+    const seenOps = new Set<DrawPathInstancesOp>();
+    // [LAW:one-source-of-truth] Simulation cardinality is derived from unique
+    // draw ops, so fill/stroke pass expansion does not double-count instances.
+    for (const prepared of drawPlan) {
+      if (seenOps.has(prepared.op)) {
+        continue;
+      }
+      seenOps.add(prepared.op);
       total += prepared.instanceCount;
     }
     return total;

--- a/src/render/webgpu/__tests__/WebGPURenderer.test.ts
+++ b/src/render/webgpu/__tests__/WebGPURenderer.test.ts
@@ -674,6 +674,58 @@ describe('WebGPURenderer', () => {
     expect(drawPrepBindGroups).toHaveLength(1);
   });
 
+  it('dispatches simulation workgroups from unique op instance count (not fill/stroke pass count)', async () => {
+    const env = createFakeWebGPUEnvironment();
+    setNavigatorGpu(env.gpu);
+    const renderer = await createWebGPURenderer(env.canvas);
+    const instanceCount = 128;
+    const topologyId = registerDynamicTopology({
+      params: [],
+      verbs: [PathVerb.MOVE, PathVerb.LINE, PathVerb.LINE, PathVerb.LINE, PathVerb.CLOSE],
+      pointsPerVerb: [1, 1, 1, 1, 0],
+      totalControlPoints: 4,
+      closed: true,
+    }, 'webgpu-simulation-count-topology');
+
+    renderer.render({
+      frame: {
+        version: 2,
+        ops: [{
+          kind: 'drawPathInstances',
+          geometry: {
+            topologyId,
+            points: new Float32Array([-1, -1, 1, -1, 1, 1, -1, 1]),
+            pointsCount: 4,
+            verbs: new Uint8Array([0, 1, 1, 1, 4]),
+            flags: 1,
+          },
+          instances: {
+            count: instanceCount,
+            position: new Float32Array(instanceCount * 2),
+            size: 0.25,
+            rotation: new Float32Array(instanceCount),
+            scale2: new Float32Array(instanceCount * 2).fill(1),
+          },
+          style: {
+            fillColor: new Uint8ClampedArray([255, 0, 0, 255]),
+            strokeColor: new Uint8ClampedArray([0, 255, 255, 255]),
+            strokeWidth: 0.02,
+            fillRule: 'nonzero',
+          },
+        }],
+      },
+      width: 128,
+      height: 96,
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      timeMs: 0,
+    });
+
+    // First compute dispatch is simulation pass (draw-prep dispatches are fixed-size 1).
+    expect(env.computePass.dispatchWorkgroups.mock.calls[0]?.[0]).toBe(2);
+  });
+
   it('reuses draw-prep bind group across frames when shader and indirect buffer are unchanged', async () => {
     const env = createFakeWebGPUEnvironment();
     setNavigatorGpu(env.gpu);


### PR DESCRIPTION
## Summary
- Compute simulation dispatch now uses real per-frame instance cardinality instead of hardcoded `activeCount=0`.
- Simulation cardinality is derived from unique draw ops, so fill+stroke pass expansion does not double-count instances.
- Added a renderer regression test that verifies workgroup dispatch uses unique-op count (not pass count).

## Details
- Moved draw-plan construction earlier in `render()` so simulation can consume current-frame cardinality.
- Added `countSimulationInstances(drawPlan)` in `WebGPURenderer` and wired it into `computeRuntime.step(...)`.
- Added test: `dispatches simulation workgroups from unique op instance count (not fill/stroke pass count)`.

## Verification
- `pnpm vitest run src/render/webgpu/__tests__/WebGPURenderer.test.ts`
