### PR TITLE
webgpu: fail fast when simulation cardinality exceeds capacity

### DIFF
--- a/src/render/webgpu/WebGPURenderer.ts
+++ b/src/render/webgpu/WebGPURenderer.ts
@@ -452,7 +452,9 @@ export class WebGPURenderer {
     this.lastFrameTimeMs = input.timeMs;
 
     const commandEncoder = this.device.createCommandEncoder();
-    this.computeRuntime.step(commandEncoder, this.countSimulationInstances(drawPlan), dtSeconds);
+    const simulationInstanceCount = this.countSimulationInstances(drawPlan);
+    this.assertSimulationCapacity(simulationInstanceCount);
+    this.computeRuntime.step(commandEncoder, simulationInstanceCount, dtSeconds);
     const totalInstances = this.countPlannedInstances(drawPlan);
     this.ensureInstanceCapacity(totalInstances);
     const packedInstances = this.packDrawPlanInstances(drawPlan);
@@ -697,6 +699,16 @@ export class WebGPURenderer {
       total += prepared.instanceCount;
     }
     return total;
+  }
+
+  private assertSimulationCapacity(activeCount: number): void {
+    // [LAW:no-silent-fallbacks] Simulation capacity overruns are explicit
+    // contract violations; fail fast instead of silently clipping active lanes.
+    if (activeCount > SIMULATION_CAPACITY) {
+      throw new Error(
+        `WebGPURenderer: simulation instance count ${activeCount} exceeds capacity ${SIMULATION_CAPACITY}`
+      );
+    }
   }
 
   private packDrawPlanInstances(drawPlan: readonly PreparedDrawPathOp[]): number {

--- a/src/render/webgpu/__tests__/WebGPURenderer.test.ts
+++ b/src/render/webgpu/__tests__/WebGPURenderer.test.ts
@@ -731,6 +731,55 @@ describe('WebGPURenderer', () => {
     expect(env.computePass.dispatchWorkgroups.mock.calls[0]?.[0]).toBe(2);
   });
 
+  it('fails fast when simulation instance count exceeds contract capacity', async () => {
+    const env = createFakeWebGPUEnvironment();
+    setNavigatorGpu(env.gpu);
+    const renderer = await createWebGPURenderer(env.canvas);
+    const overflowCount = WEBGPU_RENDER_CONTRACT.simulationCapacity + 1;
+    const topologyId = registerDynamicTopology({
+      params: [],
+      verbs: [PathVerb.MOVE, PathVerb.LINE, PathVerb.LINE, PathVerb.LINE, PathVerb.CLOSE],
+      pointsPerVerb: [1, 1, 1, 1, 0],
+      totalControlPoints: 4,
+      closed: true,
+    }, 'webgpu-simulation-capacity-overflow-topology');
+
+    expect(() => renderer.render({
+      frame: {
+        version: 2,
+        ops: [{
+          kind: 'drawPathInstances',
+          geometry: {
+            topologyId,
+            points: new Float32Array([-1, -1, 1, -1, 1, 1, -1, 1]),
+            pointsCount: 4,
+            verbs: new Uint8Array([0, 1, 1, 1, 4]),
+            flags: 1,
+          },
+          instances: {
+            count: overflowCount,
+            position: new Float32Array(overflowCount * 2),
+            size: 0.25,
+            rotation: new Float32Array(overflowCount),
+            scale2: new Float32Array(overflowCount * 2).fill(1),
+          },
+          style: {
+            fillColor: new Uint8ClampedArray([255, 0, 0, 255]),
+            fillRule: 'nonzero',
+          },
+        }],
+      },
+      width: 128,
+      height: 96,
+      zoom: 1,
+      panX: 0,
+      panY: 0,
+      timeMs: 0,
+    })).toThrow(/simulation instance count .* exceeds capacity/i);
+
+    expect(env.computePass.dispatchWorkgroups).not.toHaveBeenCalled();
+  });
+
   it('reuses draw-prep bind group across frames when shader and indirect buffer are unchanged', async () => {
     const env = createFakeWebGPUEnvironment();
     setNavigatorGpu(env.gpu);


### PR DESCRIPTION
## Summary
- Add an explicit simulation-capacity guard in `WebGPURenderer`.
- Replace silent clipping behavior with a clear contract error when active simulation lanes exceed `WEBGPU_RENDER_CONTRACT.simulationCapacity`.
- Add regression coverage for overflow behavior.

## Details
- In `render()`, derive simulation instance count from draw plan, assert capacity, then dispatch compute.
- New guard throws:
  - `WebGPURenderer: simulation instance count <n> exceeds capacity <limit>`
- Added test:
  - `fails fast when simulation instance count exceeds contract capacity`
  - verifies render throws and simulation compute dispatch is not invoked.

## Verification
- `pnpm vitest run src/render/webgpu/__tests__/WebGPURenderer.test.ts`
- `pnpm vitest run src/render/webgpu/__tests__/PathTessellator.test.ts src/render/webgpu/__tests__/WebGPURenderer.test.ts`
