### PR TITLE
Add explicit state arena read/write bank semantics

### DIFF
--- a/.migration/seams.md
+++ b/.migration/seams.md
@@ -30,13 +30,12 @@
   Why seam: Canonical descriptor contract is now explicit (`packing`, `laneStride`, `componentStride`) but producers/consumers still run AoS packing.
   Proposed change: flip runtime/compiler descriptor emission + read/write helpers to SoA packing and migrate remaining AoS consumers.
 
-- [S8] Code location: src/runtime/RuntimeState.ts:665
-  Why seam: Persistent state is now arena-backed (`stateArena` + view), but frame semantics still model single-bank writes only.
-  Proposed change: introduce explicit read/write bank semantics on state arena segment for full ping-pong ownership.
-
 ## Resolved (Delta)
 - [S7] Code location: src/compiler/ir/program.ts:347
   Resolution: Removed `scalarExprToArenaOffset` from production compiler/runtime contracts and execution context wiring; canonical `scalarExprToArenaAddress` is now the only scalar arena metadata path in production modules.
+
+- [S8] Code location: src/runtime/RuntimeState.ts:665
+  Resolution: Added explicit read/write state banks in the arena segment (`state` + `stateWrite`) and frame-level prepare/commit bank-swap semantics in both frame executors; compile boundary now synchronizes both banks.
 
 ## Class 2
 - none

--- a/src/__tests__/forbidden-patterns.test.ts
+++ b/src/__tests__/forbidden-patterns.test.ts
@@ -1481,6 +1481,29 @@ describe('Forbidden Patterns (Type System Invariants)', () => {
       ).toEqual([]);
     });
 
+    it('runtime state constructor must allocate explicit dual state banks in arena', () => {
+      const rawMatches = grepSrc('createArena\\(arenaTotalFloats \\+ stateSlotCount\\)', 'src/runtime/RuntimeState.ts');
+      const filtered = filterAllowlist(rawMatches, [/\.test\./, /__tests__/]);
+      expect(
+        filtered,
+        'RuntimeState must allocate explicit read/write state banks in arena (not single-bank stateSlotCount sizing).\n' +
+        'Found violations:\n' + filtered.join('\n')
+      ).toEqual([]);
+    });
+
+    it('frame executors must not write primitive state through read-bank alias', () => {
+      const rawMatches = [
+        ...grepSrc('state\\.state\\[[^\\]]+\\]\\s*=', 'src/runtime/ScheduleExecutor.ts'),
+        ...grepSrc('state\\.state\\[[^\\]]+\\]\\s*=', 'src/runtime/executeFrameStepped.ts'),
+      ];
+      const filtered = filterAllowlist(rawMatches, [/\.test\./, /__tests__/]);
+      expect(
+        filtered,
+        'Phase-2 primitive writes must target state.write bank and commit via bank swap, not mutate read-bank alias.\n' +
+        'Found violations:\n' + filtered.join('\n')
+      ).toEqual([]);
+    });
+
     it('scalar extract evaluator must not fall back to offset-only arena maps', () => {
       const rawMatches = grepSrc('scalarExprToArenaOffset', 'src/runtime/ValueExprScalarEvaluator.ts');
       const filtered = filterAllowlist(rawMatches, [/\.test\./, /__tests__/]);

--- a/src/runtime/RuntimeState.ts
+++ b/src/runtime/RuntimeState.ts
@@ -114,7 +114,7 @@ export const RUNTIME_FRAME_SEGMENT_OWNERSHIP: Readonly<
     writes: ['events', 'eventScalars'],
   },
   'phase1-value-pre-event': {
-    reads: ['arena', 'state', 'eventScalars', 'externalChannels.snapshot'],
+    reads: ['arena', 'state.readBank', 'eventScalars', 'externalChannels.snapshot'],
     writes: ['arena', 'cache.scalarValueExprValues', 'cache.scalarValueExprStamps'],
   },
   'phase1-continuity-map': {
@@ -122,7 +122,7 @@ export const RUNTIME_FRAME_SEGMENT_OWNERSHIP: Readonly<
     writes: ['continuity.prevDomains', 'continuity.mappings', 'continuity.changedInstancesThisFrame'],
   },
   'phase1-value-after-map': {
-    reads: ['arena', 'state', 'eventScalars', 'externalChannels.snapshot'],
+    reads: ['arena', 'state.readBank', 'eventScalars', 'externalChannels.snapshot'],
     writes: ['arena', 'cache.scalarValueExprValues', 'cache.scalarValueExprStamps'],
   },
   'phase1-continuity-apply': {
@@ -134,7 +134,7 @@ export const RUNTIME_FRAME_SEGMENT_OWNERSHIP: Readonly<
     writes: ['eventScalars', 'events', 'eventWrapPredicate'],
   },
   'phase1-value-post-event': {
-    reads: ['arena', 'state', 'eventScalars', 'externalChannels.snapshot'],
+    reads: ['arena', 'state.readBank', 'eventScalars', 'externalChannels.snapshot'],
     writes: ['arena', 'cache.scalarValueExprValues', 'cache.scalarValueExprStamps'],
   },
   'phase1-render-collect': {
@@ -150,8 +150,8 @@ export const RUNTIME_FRAME_SEGMENT_OWNERSHIP: Readonly<
     writes: ['lastRenderFrame'],
   },
   'phase2-state-write': {
-    reads: ['arena', 'state mappings'],
-    writes: ['state'],
+    reads: ['arena', 'state.readBank', 'state mappings'],
+    writes: ['state.writeBank'],
   },
   'continuity-finalize': {
     reads: ['time'],
@@ -640,6 +640,12 @@ export interface ProgramState {
   stateArena: {
     readonly offset: number;
     readonly length: number;
+    /** Length of each state bank (read/write) in floats. */
+    readonly bankLength?: number;
+    /** Active read-bank offset in `arena` (for diagnostics/debug only). */
+    readOffset?: number;
+    /** Active write-bank offset in `arena` (for diagnostics/debug only). */
+    writeOffset?: number;
   };
 
   /** Frame cache (per-frame memoization) - cache owns frameId */
@@ -653,6 +659,9 @@ export interface ProgramState {
 
   /** Stateful primitive state (migrated via StableStateIds on hot-swap) */
   state: Float32Array;
+
+  /** Phase-2 state write target bank (committed via end-of-frame swap). */
+  stateWrite: Float32Array;
 
   /** Event scalar storage (0=not fired, 1=fired this tick). Cleared each frame. */
   eventScalars: Uint8Array;
@@ -699,6 +708,12 @@ export interface RuntimeState {
   stateArena: {
     readonly offset: number;
     readonly length: number;
+    /** Length of each state bank (read/write) in floats. */
+    readonly bankLength?: number;
+    /** Active read-bank offset in `arena` (for diagnostics/debug only). */
+    readOffset?: number;
+    /** Active write-bank offset in `arena` (for diagnostics/debug only). */
+    writeOffset?: number;
   };
 
   /** Frame cache (per-frame memoization) - cache owns frameId */
@@ -712,6 +727,9 @@ export interface RuntimeState {
 
   /** Stateful primitive state (migrated via StableStateIds on hot-swap) */
   state: Float32Array;
+
+  /** Phase-2 state write target bank (committed via end-of-frame swap). */
+  stateWrite?: Float32Array;
 
   /** Event scalar storage (0=not fired, 1=fired this tick). Cleared each frame. */
   eventScalars: Uint8Array;
@@ -786,17 +804,26 @@ export function createProgramState(
   // signatures converge on ValueExpr-driven sizing.
   void eventExprCount;
   const stateArenaOffset = arenaTotalFloats;
-  const arena = createArena(arenaTotalFloats + stateSlotCount);
-  const stateView = arena.subarray(stateArenaOffset, stateArenaOffset + stateSlotCount);
+  // [LAW:one-source-of-truth] Persistent primitive state ownership is explicit:
+  // one read bank + one write bank in a single arena segment.
+  const stateBankLength = stateSlotCount;
+  const readOffset = stateArenaOffset;
+  const writeOffset = stateArenaOffset + stateBankLength;
+  const arena = createArena(arenaTotalFloats + stateBankLength * 2);
+  const stateReadView = arena.subarray(readOffset, readOffset + stateBankLength);
+  const stateWriteView = arena.subarray(writeOffset, writeOffset + stateBankLength);
   return {
     values: createValueStore(shape2dSlotCount),
     lastRenderFrame: null,
     arena,
     // [LAW:one-source-of-truth] Persistent state ownership is anchored to one
-    // arena segment contract; `state` is a view over that canonical segment.
+    // arena segment contract with explicit read/write bank metadata.
     stateArena: {
       offset: stateArenaOffset,
-      length: stateSlotCount,
+      length: stateBankLength * 2,
+      bankLength: stateBankLength,
+      readOffset,
+      writeOffset,
     },
     cache: createFrameCache(valueExprCount),
     frameSemantics: {
@@ -804,7 +831,8 @@ export function createProgramState(
       segments: [],
     },
     time: null,
-    state: stateView,
+    state: stateReadView,
+    stateWrite: stateWriteView,
     eventScalars: new Uint8Array(eventSlotCount),
     eventWrapPredicate: new Uint8Array(valueExprCount),
     events: new Map(),
@@ -876,6 +904,7 @@ export function createRuntimeStateFromSession(
     frameSemantics: program.frameSemantics,
     time: program.time,
     state: program.state,
+    stateWrite: program.stateWrite,
     eventScalars: program.eventScalars,
     eventWrapPredicate: program.eventWrapPredicate,
     events: program.events,
@@ -887,6 +916,48 @@ export function createRuntimeStateFromSession(
     continuityConfig: session.continuityConfig,
     tap: session.tap,
   };
+}
+
+/**
+ * Prepare the state write bank for Phase 2.
+ *
+ * Copies the active read bank into the write bank so unchanged state slots
+ * preserve previous-frame values when not explicitly rewritten this frame.
+ */
+export function prepareStateWriteBank(state: RuntimeState): void {
+  const write = state.stateWrite ?? state.state;
+  if (write.length !== state.state.length) {
+    throw new Error(
+      'prepareStateWriteBank: read/write bank length mismatch (read=' +
+        state.state.length +
+        ', write=' +
+        write.length +
+        ')',
+    );
+  }
+  write.set(state.state);
+  if (!state.stateWrite) {
+    state.stateWrite = write;
+  }
+}
+
+/**
+ * Commit Phase-2 state writes by swapping read/write bank ownership.
+ */
+export function commitStateWriteBank(state: RuntimeState): void {
+  const write = state.stateWrite;
+  if (!write || write === state.state) {
+    return;
+  }
+  const previousRead = state.state;
+  state.state = write;
+  state.stateWrite = previousRead;
+  const readOffset = state.stateArena.readOffset;
+  const writeOffset = state.stateArena.writeOffset;
+  if (readOffset !== undefined && writeOffset !== undefined) {
+    state.stateArena.readOffset = writeOffset;
+    state.stateArena.writeOffset = readOffset;
+  }
 }
 
 /**

--- a/src/runtime/ScheduleExecutor.ts
+++ b/src/runtime/ScheduleExecutor.ts
@@ -18,6 +18,8 @@ import {
   writeShape2D,
   beginRuntimeFrameSemantics,
   enterRuntimeFrameSegment,
+  prepareStateWriteBank,
+  commitStateWriteBank,
   type RuntimeFrameSegment,
 } from './RuntimeState';
 import {
@@ -538,6 +540,9 @@ export function executeFrame(
   // PHASE 2: Execute all stateWrite steps
   // This ensures state reads in Phase 1 saw previous frame's values
   enterRuntimeFrameSegment(state, 'phase2-state-write');
+  // [LAW:dataflow-not-control-flow] Phase 2 always prepares the write bank first;
+  // per-step variability is encoded in written values, not whether prep runs.
+  prepareStateWriteBank(state);
   for (const step of steps) {
     if (step.kind === 'stateWrite') {
       const mapping = stateSlotToMapping.get(step.stateSlot as number);
@@ -557,7 +562,7 @@ export function executeFrame(
       const baseSlot = step.stateSlot as number;
       for (let c = 0; c < stride; c++) {
         const fallback = mapping?.initial[c] ?? 0;
-        state.state[baseSlot + c] = applyStateWritePolicy(mapping, oneValue[c] ?? fallback);
+        state.stateWrite![baseSlot + c] = applyStateWritePolicy(mapping, oneValue[c] ?? fallback);
       }
     }
     if (step.kind === 'fieldStateWrite') {
@@ -591,14 +596,15 @@ export function executeFrame(
         const dstLaneBase = baseSlot + lane * mapping.stride;
         const srcLaneBase = lane * srcStride;
         for (let c = 0; c < copyStride; c++) {
-          state.state[dstLaneBase + c] = applyStateWritePolicy(mapping, src[srcLaneBase + c] ?? 0);
+          state.stateWrite![dstLaneBase + c] = applyStateWritePolicy(mapping, src[srcLaneBase + c] ?? 0);
         }
         for (let c = copyStride; c < mapping.stride; c++) {
-          state.state[dstLaneBase + c] = applyStateWritePolicy(mapping, mapping.initial[c] ?? 0);
+          state.stateWrite![dstLaneBase + c] = applyStateWritePolicy(mapping, mapping.initial[c] ?? 0);
         }
       }
     }
   }
+  commitStateWriteBank(state);
 
   // Reset scratch allocator after all materialized buffers have been consumed.
   MATERIALIZE_SCRATCH.reset();

--- a/src/runtime/__tests__/RuntimeState-banks.test.ts
+++ b/src/runtime/__tests__/RuntimeState-banks.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createRuntimeState,
+  prepareStateWriteBank,
+  commitStateWriteBank,
+} from '../RuntimeState';
+
+describe('RuntimeState state-bank ownership', () => {
+  it('allocates explicit read/write banks for persistent state', () => {
+    const state = createRuntimeState(
+      0, // slotCount (compat arg)
+      4, // stateSlotCount
+      0, // eventSlotCount
+      0, // eventExprCount
+      0, // valueExprCount
+      10, // arenaTotalFloats
+      0, // shape2dSlotCount
+    );
+
+    expect(state.state.length).toBe(4);
+    expect(state.stateWrite?.length).toBe(4);
+    expect(state.stateWrite).toBeDefined();
+    expect(state.stateWrite).not.toBe(state.state);
+    expect(state.stateArena.bankLength).toBe(4);
+    expect(state.stateArena.length).toBe(8);
+    expect(state.stateArena.readOffset).toBe(10);
+    expect(state.stateArena.writeOffset).toBe(14);
+  });
+
+  it('prepares and commits phase-2 state writes via bank swap', () => {
+    const state = createRuntimeState(0, 3, 0, 0, 0, 5, 0);
+    state.state[0] = 1;
+    state.state[1] = 2;
+    state.state[2] = 3;
+
+    const initialReadOffset = state.stateArena.readOffset;
+    const initialWriteOffset = state.stateArena.writeOffset;
+
+    prepareStateWriteBank(state);
+    expect(Array.from(state.stateWrite ?? [])).toEqual([1, 2, 3]);
+
+    state.stateWrite![1] = 99;
+    commitStateWriteBank(state);
+
+    expect(Array.from(state.state)).toEqual([1, 99, 3]);
+    expect(state.stateWrite?.[1]).toBe(2);
+    expect(state.stateArena.readOffset).toBe(initialWriteOffset);
+    expect(state.stateArena.writeOffset).toBe(initialReadOffset);
+  });
+});
+

--- a/src/runtime/executeFrameStepped.ts
+++ b/src/runtime/executeFrameStepped.ts
@@ -22,7 +22,7 @@ import type { RenderFrameIR } from '../render/types';
 import type { RenderBufferArena } from '../render/RenderBufferArena';
 import { createMaterializeScratch } from './MaterializeScratch';
 import { resolveTime } from './timeResolution';
-import { writeShape2D } from './RuntimeState';
+import { writeShape2D, prepareStateWriteBank, commitStateWriteBank } from './RuntimeState';
 import { detectDomainChange, recordDomainTransition } from './ContinuityMapping';
 import { applyContinuity, finalizeContinuityFrame } from './ContinuityApply';
 import { createStableDomainInstance, createUnstableDomainInstance } from './DomainIdentity';
@@ -464,6 +464,7 @@ export function* executeFrameStepped(
   yield buildSnapshot(-1, null, 'phase-boundary', totalSteps, program, state, tAbsMs, new Map(), prevValues);
 
   // --- PHASE 2: State writes ---
+  prepareStateWriteBank(state);
   for (let stepIdx = 0; stepIdx < steps.length; stepIdx++) {
     const step = steps[stepIdx];
 
@@ -483,13 +484,13 @@ export function* executeFrameStepped(
       const baseSlot = step.stateSlot as number;
       for (let c = 0; c < stride; c++) {
         const fallback = mapping?.initial[c] ?? 0;
-        state.state[baseSlot + c] = applyStateWritePolicy(mapping, oneValue[c] ?? fallback);
+        state.stateWrite![baseSlot + c] = applyStateWritePolicy(mapping, oneValue[c] ?? fallback);
       }
 
       const writtenStateSlots = new Map<StateSlotId, StateSlotValue>();
       writtenStateSlots.set(step.stateSlot, {
         kind: 'scalar',
-        value: state.state[step.stateSlot as number] ?? 0,
+        value: state.stateWrite![step.stateSlot as number] ?? 0,
         stateId: (() => {
           if (!mapping?.stateId) throw new Error(`State slot ${step.stateSlot} has no mapping — incomplete compiler metadata`);
           return mapping.stateId;
@@ -527,13 +528,13 @@ export function* executeFrameStepped(
           for (let c = 0; c < copyStride; c++) {
             const value = src[srcLaneBase + c] ?? 0;
             const normalized = applyStateWritePolicy(mapping, value);
-            state.state[dstLaneBase + c] = normalized;
+            state.stateWrite![dstLaneBase + c] = normalized;
             writtenValues.push(normalized);
           }
           for (let c = copyStride; c < mapping.stride; c++) {
             const value = mapping.initial[c] ?? 0;
             const normalized = applyStateWritePolicy(mapping, value);
-            state.state[dstLaneBase + c] = normalized;
+            state.stateWrite![dstLaneBase + c] = normalized;
             writtenValues.push(normalized);
           }
         }
@@ -552,6 +553,7 @@ export function* executeFrameStepped(
       yield buildSnapshot(stepIdx, step, 'phase2', totalSteps, program, state, tAbsMs, new Map(), prevValues, writtenStateSlots);
     }
   }
+  commitStateWriteBank(state);
 
   // --- POST-FRAME: Finalize continuity ---
   finalizeContinuityFrame(state);

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -26,6 +26,8 @@ export {
   createRuntimeStateFromSession,
   extractSessionState,
   createContinuityConfig,
+  prepareStateWriteBank,
+  commitStateWriteBank,
   advanceFrame,
 } from './RuntimeState';
 export {

--- a/src/services/CompileOrchestrator.ts
+++ b/src/services/CompileOrchestrator.ts
@@ -28,6 +28,7 @@ import {
   createRuntimeStateFromSession,
   migrateState,
   createInitialState,
+  prepareStateWriteBank,
   reconcilePhaseOffsets,
   type SessionState,
 } from '../runtime';
@@ -381,6 +382,9 @@ export async function compileAndSwap(
     const initialState = createInitialState(newStateSlotCount, newStateMappings);
     state.currentState.state.set(initialState);
   }
+  // [LAW:one-source-of-truth] Keep read/write state banks synchronized at
+  // compile boundary so first post-swap frame has deterministic bank ownership.
+  prepareStateWriteBank(state.currentState);
 
   // Reconcile phase offsets when time model periods change (hot-swap continuity)
   if (!isInitial && state.currentProgram?.schedule) {


### PR DESCRIPTION
## Summary
- implement explicit persistent-state read/write bank ownership in runtime state (`state` read bank + `stateWrite` write bank)
- allocate dual state banks in the arena segment and add deterministic prepare/commit bank-swap helpers
- route phase-2 writes in both frame executors to the write bank and commit swap at end of phase
- synchronize read/write banks at compile swap boundary after state migration or initial state setup
- add regression gates for dual-bank allocation and write-bank-only state writes
- add focused runtime bank behavior tests and mark seam S8 resolved in migration inventory

## Validation
- pnpm -s vitest run src/runtime/__tests__/RuntimeState-banks.test.ts src/runtime/__tests__/StateMigration.test.ts src/runtime/__tests__/project-policy-domain-change.test.ts src/runtime/__tests__/ExprAddressTable.test.ts src/runtime/__tests__/RenderAssembler.test.ts src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts src/runtime/__tests__/CameraResolver.test.ts src/services/mapDebugEdges.test.ts src/__tests__/forbidden-patterns.test.ts
- pnpm -s tsc -p tsconfig.json --noEmit (fails in current tree due missing modules: earcut, bezier-js, simplex-noise)

## Notes
- broader runtime integration suites that import noise kernels currently fail to load in this environment for the same missing `simplex-noise` dependency.
