### PR TITLE
Remove macOS leg from lockfile integrity workflow

### DIFF
--- a/.github/workflows/lockfile-integrity.yaml
+++ b/.github/workflows/lockfile-integrity.yaml
@@ -12,14 +12,7 @@ permissions:
 
 jobs:
   frozen-install:
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- remove the macOS matrix leg from the lockfile integrity workflow
- keep the lockfile integrity check running on ubuntu-latest only

## Why
- stop running the macOS lockfile integrity check while preserving lockfile guardrails