### PR TITLE
Refactor render slot naming to control points

### DIFF
--- a/src/blocks/render/render-instances-2d.ts
+++ b/src/blocks/render/render-instances-2d.ts
@@ -10,7 +10,7 @@
  *
  * Simplified wiring:
  *   Before: Array.elements → RenderInstances2D.shape
- *           Array.elements → Layout → RenderInstances2D.position
+ *           Array.elements → Layout → RenderInstances2D.controlPoints
  *   After:  Array.elements → Layout → RenderInstances2D.controlPoints (that's it!)
  *
  * The backend (schedule-program.ts) extracts instanceId from the controlPoints field

--- a/src/compiler/__tests__/arena-layout.test.ts
+++ b/src/compiler/__tests__/arena-layout.test.ts
@@ -241,10 +241,10 @@ describe('arenaLayout integration', () => {
         .filter((s): s is Extract<ScheduleIR['steps'][number], { kind: 'continuityApply' }> => s.kind === 'continuityApply')
         .map((s) => s.outputSlot),
     );
-    expect(continuityOutputSlots.has(renderStep.positionSlot)).toBe(true);
+    expect(continuityOutputSlots.has(renderStep.controlPointsSlot)).toBe(true);
     expect(continuityOutputSlots.has(renderStep.colorSlot)).toBe(true);
 
-    const positionDesc = result.program.runtimeAddressTable?.slotToArena.get(renderStep.positionSlot);
+    const positionDesc = result.program.runtimeAddressTable?.slotToArena.get(renderStep.controlPointsSlot);
     const colorDesc = result.program.runtimeAddressTable?.slotToArena.get(renderStep.colorSlot);
     expect(positionDesc?.packing).toBe('aos');
     expect(colorDesc?.packing).toBe('aos');

--- a/src/compiler/backend/continuity-pipeline.ts
+++ b/src/compiler/backend/continuity-pipeline.ts
@@ -497,7 +497,7 @@ export function allocateContinuityPipeline(
     const renderStep: StepRender = {
       kind: 'render',
       instanceId,
-      positionSlot: posSlots.outputSlot,
+      controlPointsSlot: posSlots.outputSlot,
       colorSlot: colorSlots.outputSlot,
       ...(scaleOutput && { scale: scaleOutput }),
       shape: shapeOutput,

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -438,7 +438,7 @@ function convertLinkedIRToProgram(
   const continuitySlots = new Set<ValueSlot>();
   for (const step of scheduleIR.steps) {
     if (step.kind === 'render') {
-      renderSoaSlots.add(step.positionSlot);
+      renderSoaSlots.add(step.controlPointsSlot);
       renderSoaSlots.add(step.colorSlot);
       if (step.rotationSlot !== undefined) renderSoaSlots.add(step.rotationSlot);
       if (step.scale2Slot !== undefined) renderSoaSlots.add(step.scale2Slot);
@@ -758,7 +758,7 @@ function collectComputeSlots(scheduleIR: ScheduleIR): ValueSlot[] {
         slots.add(step.outputSlot);
         break;
       case 'render':
-        slots.add(step.positionSlot);
+        slots.add(step.controlPointsSlot);
         slots.add(step.colorSlot);
         if (step.rotationSlot !== undefined) slots.add(step.rotationSlot);
         if (step.scale2Slot !== undefined) slots.add(step.scale2Slot);

--- a/src/compiler/ir/types.ts
+++ b/src/compiler/ir/types.ts
@@ -304,7 +304,7 @@ export interface StepRender {
   readonly kind: 'render';
   readonly instanceId: InstanceId;
   /** Slot containing position buffer (after continuity applied) */
-  readonly positionSlot: ValueSlot;
+  readonly controlPointsSlot: ValueSlot;
   /** Slot containing color buffer (after continuity applied) */
   readonly colorSlot: ValueSlot;
   /**

--- a/src/runtime/RenderAssembler.ts
+++ b/src/runtime/RenderAssembler.ts
@@ -1429,9 +1429,9 @@ function appendDrawPathInstancesOp(
   }
 
   // Read position buffer from slot
-  const packedPositionBuffer = resolveNumericSlotBuffer(step.positionSlot, state, slotToArena, arena, count);
+  const packedPositionBuffer = resolveNumericSlotBuffer(step.controlPointsSlot, state, slotToArena, arena, count);
   if (!packedPositionBuffer) {
-    throw new Error('RenderAssembler: Position buffer not found in slot ' + step.positionSlot);
+    throw new Error('RenderAssembler: Position buffer not found in slot ' + step.controlPointsSlot);
   }
 
   // Position must be Float32Array for v2

--- a/src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts
+++ b/src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts
@@ -142,7 +142,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'slot', slot: 3 as ValueSlot }, // Per-instance shapes
@@ -214,7 +214,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'slot', slot: 3 as ValueSlot },
@@ -300,7 +300,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'slot', slot: 3 as ValueSlot },
@@ -388,7 +388,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'slot', slot: 3 as ValueSlot },
@@ -464,7 +464,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'slot', slot: 3 as ValueSlot },
@@ -547,7 +547,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'slot', slot: 3 as ValueSlot },
@@ -602,7 +602,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'slot', slot: 3 as ValueSlot },
@@ -663,7 +663,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('culled-groups'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'slot', slot: 3 as ValueSlot },
@@ -746,7 +746,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
         {
           kind: 'render',
           instanceId: instanceId('instance-a'),
-          positionSlot: 1 as ValueSlot,
+          controlPointsSlot: 1 as ValueSlot,
           colorSlot: 2 as ValueSlot,
           scale: { k: 'one', id: 0 as ValueExprId },
           shape: { k: 'slot', slot: 3 as ValueSlot },
@@ -754,7 +754,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
         {
           kind: 'render',
           instanceId: instanceId('instance-b'),
-          positionSlot: 4 as ValueSlot,
+          controlPointsSlot: 4 as ValueSlot,
           colorSlot: 5 as ValueSlot,
           scale: { k: 'one', id: 0 as ValueExprId },
           shape: { k: 'slot', slot: 6 as ValueSlot },
@@ -840,7 +840,7 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('stress-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'slot', slot: 3 as ValueSlot },

--- a/src/runtime/__tests__/RenderAssembler.test.ts
+++ b/src/runtime/__tests__/RenderAssembler.test.ts
@@ -117,7 +117,7 @@ describe('RenderAssembler', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('missing-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         shape: { k: 'one', topologyId: 1, paramExprs: [] },
       };
@@ -140,7 +140,7 @@ describe('RenderAssembler', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('empty-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         shape: { k: 'one', topologyId: 1, paramExprs: [] },
       };
@@ -200,7 +200,7 @@ describe('RenderAssembler', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('culled-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: {
@@ -251,7 +251,7 @@ describe('RenderAssembler', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: { k: 'one', topologyId: TEST_NON_PATH_TOPOLOGY_ID, paramExprs: [1 as ValueExprId, 2 as ValueExprId] },
@@ -310,7 +310,7 @@ describe('RenderAssembler', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: {
@@ -397,7 +397,7 @@ describe('RenderAssembler', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('test-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: {
@@ -458,7 +458,7 @@ describe('RenderAssembler', () => {
         {
           kind: 'render',
           instanceId: instanceId('instance-a'),
-          positionSlot: 1 as ValueSlot,
+          controlPointsSlot: 1 as ValueSlot,
           colorSlot: 2 as ValueSlot,
           scale: { k: 'one', id: 0 as ValueExprId },
           shape: {
@@ -471,7 +471,7 @@ describe('RenderAssembler', () => {
         {
           kind: 'render',
           instanceId: instanceId('instance-b'),
-          positionSlot: 4 as ValueSlot,
+          controlPointsSlot: 4 as ValueSlot,
           colorSlot: 5 as ValueSlot,
           scale: { k: 'one', id: 0 as ValueExprId },
           shape: {
@@ -518,7 +518,7 @@ describe('RenderAssembler', () => {
         {
           kind: 'render',
           instanceId: instanceId('empty-instance'),
-          positionSlot: 1 as ValueSlot,
+          controlPointsSlot: 1 as ValueSlot,
           colorSlot: 2 as ValueSlot,
           scale: { k: 'one', id: 0 as ValueExprId },
           shape: { k: 'one', topologyId: TEST_PENTAGON_ID, paramExprs: [] },
@@ -586,7 +586,7 @@ describe('RenderAssembler', () => {
       const step: StepRender = {
         kind: 'render',
         instanceId: instanceId('budget-instance'),
-        positionSlot: 1 as ValueSlot,
+        controlPointsSlot: 1 as ValueSlot,
         colorSlot: 2 as ValueSlot,
         scale: { k: 'one', id: 0 as ValueExprId },
         shape: {


### PR DESCRIPTION
## Summary
- rename `StepRender.positionSlot` to `StepRender.controlPointsSlot`
- update compiler scheduling/runtime assembly callsites and fixtures to use control-point slot naming
- keep existing vec2->vec3 promotion path unchanged
- clean remaining RenderInstances2D wiring comment to `controlPoints`

## Validation
- `pnpm vitest run src/compiler/__tests__/compile.test.ts src/compiler/__tests__/arena-layout.test.ts src/runtime/__tests__/RenderAssembler.test.ts src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts src/runtime/__tests__/executeFrameStepped.test.ts src/demo/hcl/__tests__/hcl-demos.test.ts`
