### PR TITLE
Remove backend graph-era type leakage from compiler/IR

### DIFF
--- a/src/compiler/backend/combine-utils.ts
+++ b/src/compiler/backend/combine-utils.ts
@@ -13,11 +13,11 @@
  * Updated: Multi-Input Blocks Integration (2026-01-01)
  */
 
-import type { CombineMode, Edge, CanonicalType } from "../../types";
+import type { CombineMode } from "../../types/compiler";
 import type { OrchestratorIRBuilder } from "../ir/OrchestratorIRBuilder";
 import { isExprRef, type ValueRefExpr } from "../ir/lowerTypes";
 import type { ValueExprId } from "../ir/Indices";
-import { payloadStride, requireInst } from "../../core/canonical-types";
+import { payloadStride, requireInst, type CanonicalType } from "../../core/canonical-types";
 
 // =============================================================================
 // Types
@@ -331,7 +331,14 @@ export function createCombineNode(
  * @param edges - Edges to sort
  * @returns Sorted edges (ascending sortKey, ties broken by ID)
  */
-export function sortEdgesBySortKey(edges: readonly Edge[]): Edge[] {
+// [LAW:locality-or-seam] Backend sorting consumes a minimal edge seam and does
+// not depend on graph-era Edge contracts.
+export interface SortableEdgeRef {
+  readonly id: string;
+  readonly sortKey?: number;
+}
+
+export function sortEdgesBySortKey(edges: readonly SortableEdgeRef[]): SortableEdgeRef[] {
   return [...edges].sort((a, b) => {
     // Sort by sortKey (ascending)
     const sortKeyA = a.sortKey ?? 0;

--- a/src/compiler/backend/lower-blocks.ts
+++ b/src/compiler/backend/lower-blocks.ts
@@ -3,7 +3,7 @@
  */
 
 import type { AcyclicOrLegalGraph, BlockIndex, DepGraph, SCC } from "../ir/patches";
-import type { BlockId } from "../../types";
+import type { BlockId } from "../../types/compiler";
 import type { CompilerGraphBlock as Block } from "../ir/CompilerGraph";
 
 import type { OrchestratorIRBuilder } from "../ir/OrchestratorIRBuilder";

--- a/src/compiler/backend/resolveWriters.ts
+++ b/src/compiler/backend/resolveWriters.ts
@@ -17,9 +17,8 @@
  */
 
 import type {
-  Slot,
   CombineMode,
-} from '../../types';
+} from '../../types/compiler';
 import type { CompilerGraphBlock as Block } from '../ir/CompilerGraph';
 import type { InferenceCanonicalType } from '../../core/inference-types';
 import { getBlockDefinition, type InputDef } from '../../blocks/registry';
@@ -315,7 +314,7 @@ export function resolveInput(
   endpoint: InputEndpoint,
   edges: readonly NormalizedEdge[],
   blocks: readonly Block[],
-  inputSlot: Slot,
+  inputSlot: InputDef,
   combineMode: CombineMode
 ): ResolvedInputSpec {
   // Enumerate writers (DSConst edges are included via GraphNormalizer)
@@ -327,8 +326,12 @@ export function resolveInput(
   // Resolve combine policy from explicit input policy data.
   const combine = resolveCombinePolicy(inputSlot, { combineMode });
 
-  // Get port type - inputSlot.type is CanonicalType
+  // [LAW:single-enforcer] Port type presence is enforced at the backend
+  // boundary for explicit resolveInput callers.
   const portType = inputSlot.type;
+  if (!portType) {
+    throw new Error(`resolveInput requires a typed input definition for ${endpoint.blockId}.${endpoint.slotId}`);
+  }
 
   return {
     endpoint,

--- a/src/compiler/ir/CompilerGraph.ts
+++ b/src/compiler/ir/CompilerGraph.ts
@@ -1,4 +1,4 @@
-import type { PortId } from '../../types';
+import type { PortId } from '../../types/compiler';
 
 /**
  * Compiler-owned graph node representation.
@@ -31,4 +31,3 @@ export interface CompilerGraph {
   readonly blocks: readonly CompilerGraphBlock[];
   readonly edges: readonly CompilerGraphEdge[];
 }
-

--- a/src/compiler/ir/IRBuilderImpl.ts
+++ b/src/compiler/ir/IRBuilderImpl.ts
@@ -14,7 +14,7 @@ import type {
   InstanceId,
   DomainTypeId,
 } from './Indices';
-import type { BlockId } from '../../types';
+import type { BlockId } from '../../types/compiler';
 import type { TopologyId } from '../../shapes/types';
 import type { TimeModelIR } from './schedule';
 import type {

--- a/src/compiler/ir/NormalizedPatch.ts
+++ b/src/compiler/ir/NormalizedPatch.ts
@@ -1,4 +1,4 @@
-import type { BlockId, PortId } from '../../types';
+import type { BlockId, PortId } from '../../types/compiler';
 import type { BlockIndex } from './BlockIndex';
 import type { CompilerGraph, CompilerGraphBlock } from './CompilerGraph';
 

--- a/src/compiler/ir/OrchestratorIRBuilder.ts
+++ b/src/compiler/ir/OrchestratorIRBuilder.ts
@@ -13,7 +13,7 @@
 
 import type { BlockIRBuilder } from './BlockIRBuilder';
 import type { CanonicalType } from '../../core/canonical-types';
-import type { BlockId } from '../../types';
+import type { BlockId } from '../../types/compiler';
 import type {
   ValueExprId,
   ValueSlot,

--- a/src/compiler/ir/patches.ts
+++ b/src/compiler/ir/patches.ts
@@ -17,7 +17,7 @@
 
 import type { CanonicalType } from "../../core/canonical-types";
 import type { CardinalityAcceptance } from "../../core/canonical-types/cardinality";
-import type { CombineMode } from "../../types";
+import type { CombineMode } from "../../types/compiler";
 
 export type { BlockIndex } from "./BlockIndex";
 export type { NormalizedPatch, NormalizedEdge } from "./NormalizedPatch";

--- a/src/compiler/ir/program.ts
+++ b/src/compiler/ir/program.ts
@@ -15,7 +15,7 @@ import type {
   StepId,
   ValueExprId,
 } from './Indices';
-import type { BlockId, PortId } from '../../types';
+import type { BlockId, PortId } from '../../types/compiler';
 import type { ValueExpr } from './value-expr';
 import type { KernelRegistry } from '../../runtime/KernelRegistry';
 import type { ArenaSlotDescriptor } from '../../runtime/ArenaValueStore';

--- a/src/types/compiler.ts
+++ b/src/types/compiler.ts
@@ -1,0 +1,67 @@
+/**
+ * Compiler-safe shared types.
+ *
+ * This module intentionally excludes graph/Patch re-exports so backend/IR can
+ * depend on stable scalar type contracts without importing editor graph shapes.
+ */
+
+declare const BlockIdBrand: unique symbol;
+declare const PortIdBrand: unique symbol;
+
+export type BlockId = string & { readonly [BlockIdBrand]: never };
+export type PortId = string & { readonly [PortIdBrand]: never };
+
+export function blockId(s: string): BlockId {
+  return s as BlockId;
+}
+
+export function portId(s: string): PortId {
+  return s as PortId;
+}
+
+// [LAW:one-type-per-behavior] Canonical block-port reference shared across UI,
+// diagnostics, and derived role metadata.
+export interface PortEndpointRef {
+  readonly blockId: BlockId;
+  readonly portId: PortId;
+}
+
+/**
+ * Combine mode for input ports with multiple edges.
+ */
+export type CombineMode =
+  | 'last'
+  | 'first'
+  | 'sum'
+  | 'average'
+  | 'max'
+  | 'min'
+  | 'mul'
+  | 'layer'
+  | 'or'
+  | 'and'
+  | 'collect'
+  | 'array';
+
+export type CombineModeCategory = 'numeric' | 'any' | 'boolean';
+
+export const COMBINE_MODE_CATEGORY: Record<CombineMode, CombineModeCategory> = {
+  last: 'any',
+  first: 'any',
+  sum: 'numeric',
+  average: 'numeric',
+  max: 'numeric',
+  min: 'numeric',
+  mul: 'numeric',
+  layer: 'any',
+  or: 'boolean',
+  and: 'boolean',
+  collect: 'any',
+  array: 'any',
+};
+
+// [LAW:single-enforcer] Canonicalize legacy/user-facing combine aliases at one boundary.
+export function canonicalizeCombineMode(mode: CombineMode): CombineMode {
+  return mode === 'array' ? 'collect' : mode;
+}
+

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -115,84 +115,27 @@ export {
 // Block/Port IDs (string-based)
 // =============================================================================
 
-declare const BlockIdBrand: unique symbol;
-declare const PortIdBrand: unique symbol;
-
-export type BlockId = string & { readonly [BlockIdBrand]: never };
-export type PortId = string & { readonly [PortIdBrand]: never };
-
-export function blockId(s: string): BlockId {
-  return s as BlockId;
-}
-
-export function portId(s: string): PortId {
-  return s as PortId;
-}
-
-// [LAW:one-type-per-behavior] Canonical block-port reference shared across UI,
-// diagnostics, and derived role metadata.
-export interface PortEndpointRef {
-  readonly blockId: BlockId;
-  readonly portId: PortId;
-}
+export type {
+  BlockId,
+  PortId,
+  PortEndpointRef,
+  CombineMode,
+  CombineModeCategory,
+} from './compiler';
+export {
+  blockId,
+  portId,
+  COMBINE_MODE_CATEGORY,
+  canonicalizeCombineMode,
+} from './compiler';
 
 // =============================================================================
 // Combine Mode
 // =============================================================================
 
-/**
- * Combine mode for input ports with multiple edges.
- *
- * Modes are categorized by the types they work with:
- * - any: Works with any type
- * - numeric: Works with numeric types (float, int, vec2, vec3, color)
- * - boolean: Works with boolean type
- */
-export type CombineMode =
-  | 'last'      // any: Last value wins
-  | 'first'     // any: First value wins
-  | 'sum'       // numeric: Additive
-  | 'average'   // numeric: Arithmetic mean
-  | 'max'       // numeric: Maximum
-  | 'min'       // numeric: Minimum
-  | 'mul'       // numeric: Multiplicative
-  | 'layer'     // any: Layer composition
-  | 'or'        // boolean: Logical OR
-  | 'and'       // boolean: Logical AND
-  | 'collect'   // any: Preserve individual edge types (no unification)
-  | 'array';    // any: User-facing alias for collect semantics
-
-/**
- * Category for combine modes based on type compatibility.
- */
-export type CombineModeCategory = 'numeric' | 'any' | 'boolean';
-
-/**
- * Mapping of combine modes to their category.
- * Used for validating that a combine mode is compatible with a port's type.
- */
-export const COMBINE_MODE_CATEGORY: Record<CombineMode, CombineModeCategory> = {
-  last: 'any',
-  first: 'any',
-  sum: 'numeric',
-  average: 'numeric',
-  max: 'numeric',
-  min: 'numeric',
-  mul: 'numeric',
-  layer: 'any',
-  or: 'boolean',
-  and: 'boolean',
-  collect: 'any',
-  array: 'any',
-};
-
-// [LAW:single-enforcer] Canonicalize legacy/user-facing combine aliases at one boundary.
-export function canonicalizeCombineMode(mode: CombineMode): CombineMode {
-  return mode === 'array' ? 'collect' : mode;
-}
-
 // Import CanonicalType for local use in interface definitions
 import type { CanonicalType } from '../core/canonical-types';
+import type { BlockId, PortEndpointRef } from './compiler';
 
 // =============================================================================
 // Transform System Types


### PR DESCRIPTION
## Summary
- add compiler-safe shared type surface in `src/types/compiler.ts`
- migrate backend/IR imports from `src/types` barrel to compiler-safe types
- remove graph-era `Edge` dependency from backend combine utilities via backend-local seam type

## Verification
- pnpm -s typecheck
- pnpm -s vitest run src/compiler/backend/__tests__/combine-utils.test.ts src/compiler/backend/__tests__/binding-pass.test.ts src/compiler/backend/__tests__/backend-preconditions.test.ts src/compiler/ir/__tests__/value-expr-invariants.test.ts src/compiler/ir/__tests__/storage-class.test.ts src/compiler/ir/__tests__/bridges.test.ts

Bead: oscilla-animator-v2-q640
