### PR TITLE
Recover dropped collect-array/edge-alias commits (conflicts resolved)

### DIFF
--- a/src/compiler/backend/lower-blocks.ts
+++ b/src/compiler/backend/lower-blocks.ts
@@ -64,11 +64,16 @@ function requireBlockEffects(
   );
 }
 
+interface LoweringError extends Error {
+  code?: CompileError['code'];
+}
+
+function isLoweringError(error: unknown): error is LoweringError {
+  return error instanceof Error && 'code' in error;
+}
+
 function classifyLoweringErrorCode(error: unknown): CompileError['code'] {
-  if (!(error instanceof Error)) return 'NotImplemented';
-  if (error.message.includes('ExprSyntaxError')) return 'ExprSyntaxError';
-  if (error.message.includes('ExprTypeError')) return 'ExprTypeError';
-  if (error.message.includes('ExprCompileError')) return 'ExprCompileError';
+  if (isLoweringError(error) && error.code !== undefined) return error.code;
   return 'NotImplemented';
 }
 

--- a/src/compiler/frontend/composite-expansion.ts
+++ b/src/compiler/frontend/composite-expansion.ts
@@ -19,7 +19,7 @@
 import type { BlockId, BlockRole } from '../../types';
 import { derivedRole } from '../../types';
 import type { Block, Edge, InputPort, OutputPort, Patch } from '../../graph/Patch';
-import { normalizeCanonicalName } from '../../core/canonical-name';
+import { deriveEdgeAlias } from '../../graph/edge-alias';
 import {
   getCompositeDefinition,
   isCompositeType,
@@ -146,23 +146,6 @@ function boundaryInEdgeId(path: ExpansionPath, port: string, origEdgeId: string)
 
 function boundaryOutEdgeId(path: ExpansionPath, port: string, origEdgeId: string): string {
   return `cx:${pathKey(path)}:out:${port}:re:${origEdgeId}`;
-}
-
-function deriveEdgeAlias(
-  from: Edge['from'],
-  blocks: ReadonlyMap<BlockId, Block>,
-): string {
-  // [LAW:single-enforcer] Composite expansion derives aliases exactly once
-  // when creating rewritten/internal edges.
-  if (from.kind !== 'port') {
-    throw new Error(`Cannot derive edge alias from endpoint kind '${from.kind}'`);
-  }
-  const source = blocks.get(from.blockId as BlockId);
-  if (!source) {
-    throw new Error(`Cannot derive edge alias: source block '${from.blockId}' not found`);
-  }
-  const canonical = source.displayName ? normalizeCanonicalName(source.displayName) : source.id;
-  return `${canonical}.${from.slotId}`;
 }
 
 // =============================================================================

--- a/src/compiler/frontend/normalize-adapters.ts
+++ b/src/compiler/frontend/normalize-adapters.ts
@@ -40,8 +40,8 @@
 
 import type { BlockId, BlockRole } from '../../types';
 import type { InferenceCanonicalType } from '../../core/inference-types';
-import { normalizeCanonicalName } from '../../core/canonical-name';
 import type { Block, Edge, Patch, LensAttachment } from '../../graph/Patch';
+import { deriveEdgeAlias } from '../../graph/edge-alias';
 import { derivedLensBlockId } from '../../graph/lens-block-id';
 import { getBlockDefinition, requireBlockDef } from '../../blocks/registry';
 import { findAdapter } from '../../blocks/adapter-spec';
@@ -99,22 +99,6 @@ function getPortType(
   const ports = direction === 'input' ? blockDef.inputs : blockDef.outputs;
   const port = ports[portId];
   return port?.type ?? null;
-}
-
-function deriveEdgeAlias(
-  from: Edge['from'],
-  blocks: ReadonlyMap<BlockId, Block>,
-): string {
-  // [LAW:single-enforcer] Adapter/lens expansion assigns canonical aliases at edge creation.
-  if (from.kind !== 'port') {
-    throw new Error(`Cannot derive edge alias from endpoint kind '${from.kind}'`);
-  }
-  const source = blocks.get(from.blockId as BlockId);
-  if (!source) {
-    throw new Error(`Cannot derive edge alias: source block '${from.blockId}' not found`);
-  }
-  const canonical = source.displayName ? normalizeCanonicalName(source.displayName) : source.id;
-  return `${canonical}.${from.slotId}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- replay dropped commits:
  - cdc529b10 (collect-array + canonical edge alias behavior)
  - 67b078ade (time-source alias fix)
- resolve rebase conflicts against current master architecture
- preserve only compatible net changes in current codebase:
  - src/compiler/backend/lower-blocks.ts
  - src/compiler/frontend/composite-expansion.ts
  - src/compiler/frontend/normalize-adapters.ts

## Conflict Resolution
- dropped pre-refactor graph-contract edits that no longer apply cleanly to current NormalizedPatch model
- reconciled to current master contracts while preserving collect-array/alias behavior intent

## Validation
- pnpm typecheck
- pnpm test src/compiler/frontend/__tests__/adapter-policy.test.ts src/compiler/frontend/__tests__/create-derived-obligations.test.ts src/compiler/frontend/__tests__/default-source-policy.test.ts src/compiler/frontend/__tests__/composite-expansion.test.ts src/compiler/frontend/__tests__/cardinality-adapter.test.ts src/compiler/__tests__/reachability.test.ts
