### PR TITLE
Add demo HCL parser round-trip structural tests (kb26.7)

### DIFF
--- a/src/patch-dsl/__tests__/demo-roundtrip.test.ts
+++ b/src/patch-dsl/__tests__/demo-roundtrip.test.ts
@@ -33,6 +33,8 @@ function blockSnapshot(block: Block): Record<string, unknown> {
     domainId: block.domainId,
     role: normalizeValue(block.role),
     params: normalizeValue(block.params),
+    inputPorts: normalizeValue(block.inputPorts),
+    outputPorts: normalizeValue(block.outputPorts),
   };
 }
 


### PR DESCRIPTION
## Summary
- add `src/patch-dsl/__tests__/demo-roundtrip.test.ts`
- iterate every demo in `src/demo/hcl` and assert structural equality for parse -> serialize -> parse
- compare canonical snapshots (block count, edge count, block types, named connections, block params/metadata, edge metadata) independent of generated IDs

## Testing
- pnpm -s vitest run src/patch-dsl/__tests__/demo-roundtrip.test.ts
- pnpm -s vitest run src/patch-dsl/__tests__
