### PR TITLE
P1: finalize invariant gates for arena ping-pong and shape bank

### DIFF
--- a/src/__tests__/forbidden-patterns.test.ts
+++ b/src/__tests__/forbidden-patterns.test.ts
@@ -64,4 +64,38 @@ describe('forbidden patterns (v3 hard rules)', () => {
     // runtime mode flags; variability is expressed in data, not mode branches.
     expect(matches).toEqual([]);
   });
+
+  it('forbids GPU full-buffer copy commands in the WebGPU hot path', () => {
+    const matches = rg('copyBufferToBuffer\\s*\\(', ['src/render/webgpu/WebGPURenderer.ts']);
+
+    // [LAW:dataflow-not-control-flow] Frame execution keeps one deterministic
+    // compute->draw flow without whole-buffer copy detours.
+    expect(matches).toEqual([]);
+  });
+
+  it('forbids runtime arena reassignment in frame executors', () => {
+    const matches = rg('state\\.arena\\s*=', [
+      'src/runtime/ScheduleExecutor.ts',
+      'src/runtime/executeFrameStepped.ts',
+    ]);
+
+    // [LAW:one-source-of-truth] Runtime arena storage is single-owned and must
+    // not be replaced inside frame execution loops.
+    expect(matches).toEqual([]);
+  });
+
+  it('forbids shape-bank mutation helpers in renderer/assembler hot paths', () => {
+    const matches = rg('writeShapeBank(Header|HandleMetadata)\\s*\\(', [
+      'src/runtime/RenderAssembler.ts',
+      'src/render/webgpu/WebGPURenderer.ts',
+    ]);
+    expect(matches).toEqual([]);
+  });
+
+  it('forbids CPU-side direct indirect-args writes in WebGPU renderer', () => {
+    const matches = rg('writeBuffer\\s*\\(\\s*this\\.indirectArgsBuffer', [
+      'src/render/webgpu/WebGPURenderer.ts',
+    ]);
+    expect(matches).toEqual([]);
+  });
 });

--- a/src/compiler/__tests__/arena-layout.test.ts
+++ b/src/compiler/__tests__/arena-layout.test.ts
@@ -456,6 +456,50 @@ describe('arenaLayout integration', () => {
     }
   });
 
+  it('emits contiguous zone boundaries with declared per-zone alignment', () => {
+    const patch = buildPatch((b) => {
+      b.addBlock('InfiniteTimeRoot');
+
+      const ellipse = b.addBlock('Ellipse');
+      const array = b.addBlock('Array');
+      b.setPortDefault(array, 'count', 7);
+      b.wire(ellipse, 'shape', array, 'element');
+
+      const layout = b.addBlock('GridLayoutUV');
+      b.setPortDefault(layout, 'rows', 1);
+      b.setPortDefault(layout, 'cols', 7);
+      b.wire(array, 'elements', layout, 'elements');
+
+      const colorSignal = b.addBlock('Const');
+      b.setConfig(colorSignal, 'value', { r: 0.8, g: 0.2, b: 0.1, a: 1 });
+      const colorField = b.addBlock('Broadcast');
+      b.wire(colorSignal, 'out', colorField, 'one');
+
+      const render = b.addBlock('RenderInstances2D');
+      b.wire(layout, 'controlPoints', render, 'controlPoints');
+      b.wire(colorField, 'field', render, 'color');
+    });
+
+    const result = compile(patch);
+    if (result.kind === 'error') {
+      throw new Error(`Compile failed: ${result.errors.map((e) => e.message).join(', ')}`);
+    }
+    const zones = result.program.arenaZones?.zones ?? [];
+    expect(zones.length).toBeGreaterThan(0);
+
+    let expectedStart = 0;
+    for (const zone of zones) {
+      expect(zone.start).toBe(expectedStart);
+      expect(zone.end).toBe(zone.start + zone.length);
+      if (zone.alignmentFloats > 0) {
+        expect(zone.start % zone.alignmentFloats).toBe(0);
+      }
+      expectedStart = zone.end;
+    }
+    expect(result.program.arenaZones?.totalFloats).toBe(expectedStart);
+    expect(result.program.arenaTotalFloats).toBe(expectedStart);
+  });
+
   it('runtime state arena length matches compiled arenaTotalFloats', () => {
     const patch = buildPatch((b) => {
       const time = b.addBlock('InfiniteTimeRoot');

--- a/src/render/webgpu/__tests__/WebGPURenderer.test.ts
+++ b/src/render/webgpu/__tests__/WebGPURenderer.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createWebGPURenderer } from '../WebGPURenderer';
 import { WEBGPU_RENDER_CONTRACT } from '../shaders';
-import { registerDynamicTopology } from '../../../shapes/registry';
+import { getTopologyRegistryRevision, registerDynamicTopology } from '../../../shapes/registry';
 import { PathVerb } from '../../../shapes/types';
 import type { DrawPathInstancesOp } from '../../types';
 
@@ -32,6 +32,7 @@ function createFakeWebGPUEnvironment() {
   const commandEncoder = {
     beginComputePass: vi.fn(() => computePass),
     beginRenderPass: vi.fn(() => renderPass),
+    copyBufferToBuffer: vi.fn(),
     finish: vi.fn(() => ({ label: 'cmd' })),
   };
 
@@ -375,6 +376,18 @@ describe('WebGPURenderer', () => {
     expect(env.device.createCommandEncoder.mock.results[0]?.value.beginComputePass).toHaveBeenCalledTimes(2);
   });
 
+  it('does not issue GPU copyBufferToBuffer calls during frame rendering', async () => {
+    const env = createFakeWebGPUEnvironment();
+    setNavigatorGpu(env.gpu);
+    const renderer = await createWebGPURenderer(env.canvas);
+    const topologyId = makeSimpleTopology('webgpu-no-buffer-copy-topology');
+
+    renderer.render(makeRenderInput([makeDrawOp(topologyId)]));
+
+    const encoder = env.device.createCommandEncoder.mock.results[0]?.value as { copyBufferToBuffer: ReturnType<typeof vi.fn> };
+    expect(encoder.copyBufferToBuffer).not.toHaveBeenCalled();
+  });
+
   it('renders cubic path geometry without rejecting supported curve verbs', async () => {
     const env = createFakeWebGPUEnvironment();
     setNavigatorGpu(env.gpu);
@@ -606,6 +619,34 @@ describe('WebGPURenderer', () => {
     renderer.render(makeRenderInput([op], { timeMs: 16 }));
     const secondFrameDrawPrepBindGroups = collectDrawPrepBindGroupCalls(env.device.createBindGroup);
     expect(secondFrameDrawPrepBindGroups).toHaveLength(0);
+  });
+
+  it('uploads topology bank only when topology registry revision changes', async () => {
+    const env = createFakeWebGPUEnvironment();
+    setNavigatorGpu(env.gpu);
+    makeSimpleTopology('webgpu-revision-gate-a');
+    const renderer = await createWebGPURenderer(env.canvas);
+
+    env.device.queue.writeBuffer.mockClear();
+    renderer.render(makeRenderInput([], { timeMs: 0 }));
+    const unchangedRevisionWrites = env.device.queue.writeBuffer.mock.calls.filter((args: unknown[]) => args[2] instanceof Uint32Array);
+    expect(unchangedRevisionWrites).toHaveLength(0);
+
+    const revisionBefore = getTopologyRegistryRevision();
+    registerDynamicTopology({
+      params: [],
+      verbs: [PathVerb.MOVE, PathVerb.LINE],
+      pointsPerVerb: [1, 136],
+      totalControlPoints: 137,
+      closed: false,
+    }, 'webgpu-revision-gate-b');
+    const revisionAfter = getTopologyRegistryRevision();
+    expect(revisionAfter).toBeGreaterThan(revisionBefore);
+
+    env.device.queue.writeBuffer.mockClear();
+    renderer.render(makeRenderInput([], { timeMs: 16 }));
+    const changedRevisionWrites = env.device.queue.writeBuffer.mock.calls.filter((args: unknown[]) => args[2] instanceof Uint32Array);
+    expect(changedRevisionWrites.length).toBeGreaterThan(0);
   });
 
   it('supports per-instance stroke widths for stroke rendering', async () => {

--- a/src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts
+++ b/src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts
@@ -220,6 +220,118 @@ describe('RenderAssembler - Per-Instance Shapes', () => {
         /Shape handle buffer length mismatch/
       );
     });
+
+    it('rejects shape handles that do not span a full shape-bank header', () => {
+      const state = createMockState();
+      const positionBuffer = new Float32Array([0.1, 0.2, 0.0]);
+      const colorBuffer = new Uint8ClampedArray([255, 0, 0, 255]);
+      const shapeHandles = new Float32Array([
+        state.shapeBank!.data.length - SHAPE_BANK_HEADER_WORDS + 1,
+      ]);
+
+      setTestSlotBuffer(state, 1 as ValueSlot, positionBuffer);
+      setTestSlotBuffer(state, 2 as ValueSlot, colorBuffer);
+      setTestSlotBuffer(state, 3 as ValueSlot, shapeHandles);
+
+      const scalarExprToArenaOffset = new Map<number, number>([[0, 10]]);
+      state.arena[10] = 1.0;
+      const slotToArena = buildSlotToArenaWithShapeSlots(state, [
+        { slot: 1 as ValueSlot, stride: 3 },
+        { slot: 2 as ValueSlot, stride: 4 },
+      ]);
+
+      const step: StepRender = {
+        kind: 'render',
+        instanceId: instanceId('invalid-shape-header-span'),
+        controlPointsSlot: 1 as ValueSlot,
+        colorSlot: 2 as ValueSlot,
+        scale: { k: 'one', id: 0 as ValueExprId },
+        shape: { k: 'slot', slot: 3 as ValueSlot },
+      };
+
+      const context: AssemblerContext = {
+        scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
+        instances: new Map([['invalid-shape-header-span', createMockInstance(1)]]),
+        state,
+        resolvedCamera: DEFAULT_CAMERA,
+        arena: getTestArena(),
+        slotToArena,
+      };
+
+      expect(() => assembleDrawPathInstancesOp(step, context)).toThrow(/shape handle out of range/i);
+    });
+  });
+
+  describe('Shape Bank Read Contract', () => {
+    it('treats shape bank as read-only during per-instance assembly', () => {
+      const state = createMockState();
+      const instanceCount = 2;
+      const positionBuffer = new Float32Array(instanceCount * 3);
+      const colorBuffer = new Uint8ClampedArray(instanceCount * 4);
+      const shapeBuffer = new Uint32Array(instanceCount * SHAPE2D_WORDS);
+      const controlPointsBuffer = new Float32Array([
+        0, 1, 1, 0, 0, -1, -1, 0,
+      ]);
+
+      for (let i = 0; i < instanceCount; i++) {
+        writeShape2D(shapeBuffer, i, {
+          topologyId: CIRCLE_ID,
+          pointsFieldSlot: 4,
+          pointsCount: 4,
+          styleRef: 0,
+          flags: 1,
+        });
+        positionBuffer[i * 3] = i * 0.1;
+        positionBuffer[i * 3 + 1] = 0.5;
+        positionBuffer[i * 3 + 2] = 0.0;
+        colorBuffer[i * 4] = 255;
+        colorBuffer[i * 4 + 3] = 255;
+      }
+
+      setTestSlotBuffer(state, 1 as ValueSlot, positionBuffer);
+      setTestSlotBuffer(state, 2 as ValueSlot, colorBuffer);
+      installShapeHandlesFromPacked(state, 3 as ValueSlot, shapeBuffer);
+      setTestSlotBuffer(state, 4 as ValueSlot, controlPointsBuffer);
+
+      const scalarExprToArenaOffset = new Map<number, number>([[0, 10]]);
+      state.arena[10] = 1.0;
+      const slotToArena = buildSlotToArenaWithShapeSlots(state, [
+        { slot: 1 as ValueSlot, stride: 3 },
+        { slot: 2 as ValueSlot, stride: 4 },
+        { slot: 4 as ValueSlot, stride: 2 },
+      ]);
+
+      const step: StepRender = {
+        kind: 'render',
+        instanceId: instanceId('shape-bank-read-only'),
+        controlPointsSlot: 1 as ValueSlot,
+        colorSlot: 2 as ValueSlot,
+        scale: { k: 'one', id: 0 as ValueExprId },
+        shape: { k: 'slot', slot: 3 as ValueSlot },
+      };
+
+      const shapeBank = state.shapeBank!;
+      const volatileBefore = shapeBank.volatilePtr;
+      const dataSnapshot = shapeBank.data.slice();
+      const topologySnapshot = shapeBank.topologyIdByHandle.slice();
+      const controlPointSnapshot = shapeBank.controlPointSlotByHandle.slice();
+
+      const context: AssemblerContext = {
+        scalarExprToArenaAddress: buildScalarExprToArenaAddressFromOffsets(scalarExprToArenaOffset),
+        instances: new Map([['shape-bank-read-only', createMockInstance(instanceCount)]]),
+        state,
+        resolvedCamera: DEFAULT_CAMERA,
+        arena: getTestArena(),
+        slotToArena,
+      };
+
+      const result = assembleDrawPathInstancesOp(step, context);
+      expect(result.length).toBeGreaterThan(0);
+      expect(shapeBank.volatilePtr).toBe(volatileBefore);
+      expect(Array.from(shapeBank.data)).toEqual(Array.from(dataSnapshot));
+      expect(Array.from(shapeBank.topologyIdByHandle)).toEqual(Array.from(topologySnapshot));
+      expect(Array.from(shapeBank.controlPointSlotByHandle)).toEqual(Array.from(controlPointSnapshot));
+    });
   });
 
   describe('Topology Grouping', () => {

--- a/src/runtime/__tests__/executeFrameStepped.test.ts
+++ b/src/runtime/__tests__/executeFrameStepped.test.ts
@@ -257,6 +257,37 @@ describe('executeFrameStepped', () => {
     expect(foundWrittenSlots).toBe(true);
   });
 
+  it('swaps state read/write banks per frame without reallocating arena storage', () => {
+    const program = phasorProgram;
+    const schedule = program.schedule as ScheduleIR;
+    expect((schedule.stateSlotCount ?? 0)).toBeGreaterThan(0);
+
+    const state = createStateForProgram(program);
+    const arena = getTestArena();
+    const initialArenaBuffer = state.arena.buffer;
+    const initialRead = state.state;
+    const initialWrite = state.stateWrite;
+    expect(initialWrite).toBeDefined();
+    expect(initialRead).not.toBe(initialWrite);
+
+    let frame = executeFrameStepped(program, state, arena, 16.67);
+    while (!frame.next().done) {
+      // Exhaust generator
+    }
+    expect(state.arena.buffer).toBe(initialArenaBuffer);
+    expect(state.state).toBe(initialWrite);
+    expect(state.stateWrite).toBe(initialRead);
+
+    arena.reset();
+    frame = executeFrameStepped(program, state, arena, 33.34);
+    while (!frame.next().done) {
+      // Exhaust generator
+    }
+    expect(state.arena.buffer).toBe(initialArenaBuffer);
+    expect(state.state).toBe(initialRead);
+    expect(state.stateWrite).toBe(initialWrite);
+  });
+
   it('keeps phasor state bounded during long-horizon stepped execution', () => {
     const program = phasorProgram;
     const schedule = program.schedule as ScheduleIR;

--- a/src/shapes/__tests__/registry.test.ts
+++ b/src/shapes/__tests__/registry.test.ts
@@ -4,6 +4,7 @@ import {
   exportSerializableTopologies,
   exportTopologyBankU32,
   TopologyBankFlag,
+  TopologyBankWord,
   TOPOLOGY_BANK_WORDS,
   getTopologyRegistryRevision,
   installSerializableTopologies,
@@ -76,5 +77,31 @@ describe('shapes/registry topology bank export', () => {
     expect(bank.data[3]).toBe(TopologyBankFlag.IsPath | TopologyBankFlag.Closed);
     expect(bank.indexById.get(id)).toBe(0);
     expect(bank.revision).toBe(getTopologyRegistryRevision());
+  });
+
+  it('keeps revision stable across export-only reads', () => {
+    const id = registerDynamicTopology(makePathTopology(10, true), 'shape-topology-bank-revision-read');
+    const revisionBefore = getTopologyRegistryRevision();
+    const first = exportTopologyBankU32([id]);
+    const second = exportTopologyBankU32([id]);
+
+    expect(first.revision).toBe(revisionBefore);
+    expect(second.revision).toBe(revisionBefore);
+    expect(getTopologyRegistryRevision()).toBe(revisionBefore);
+    expect(Array.from(second.data)).toEqual(Array.from(first.data));
+  });
+
+  it('bumps revision exactly on new topology registration and reflects it in bank export', () => {
+    const revisionBefore = getTopologyRegistryRevision();
+    // Use a structurally unique topology so registration cannot intern to an existing ID.
+    const uniquePoints = revisionBefore + 1000;
+    const id = registerDynamicTopology(makePathTopology(uniquePoints, false), 'shape-topology-bank-revision-bump');
+    const revisionAfter = getTopologyRegistryRevision();
+    const bank = exportTopologyBankU32([id]);
+
+    expect(revisionAfter).toBe(revisionBefore + 1);
+    expect(bank.revision).toBe(revisionAfter);
+    expect(bank.data[TopologyBankWord.Id]).toBe(id);
+    expect(bank.data[TopologyBankWord.TotalControlPoints]).toBe(uniquePoints);
   });
 });


### PR DESCRIPTION
## Summary
- completes remaining P1 guardrail tickets: `oscilla-animator-v2-dke8.1.6` and `oscilla-animator-v2-dke8.2.6`
- adds deterministic invariant gates for:
  - no GPU full-buffer copy path and no CPU direct indirect-args writes
  - arena zone contiguity/alignment and frame-to-frame state-bank ping-pong swaps
  - shape-bank read-only runtime contract and handle/header-span validation
  - topology-bank revision semantics (no export-only revision churn; renderer uploads only on revision changes)

## Validation
- `pnpm -s vitest run src/__tests__/forbidden-patterns.test.ts src/compiler/__tests__/arena-layout.test.ts src/runtime/__tests__/executeFrameStepped.test.ts src/render/webgpu/__tests__/WebGPURenderer.test.ts src/shapes/__tests__/registry.test.ts src/runtime/__tests__/RenderAssembler-per-instance-shapes.test.ts`
- `pnpm -s typecheck`
- `BEAD_ID=oscilla-animator-v2-dke8.1.6 scripts/enforce-webgpu-bead-readiness.sh`
- `BEAD_ID=oscilla-animator-v2-dke8.2.6 scripts/enforce-webgpu-bead-readiness.sh`
