### PR TITLE
[oscilla-animator-v2-zq12.1] P3-1 CPU->GPU input marshalling

### DIFF
--- a/src/render/webgpu/InputService.ts
+++ b/src/render/webgpu/InputService.ts
@@ -1,0 +1,59 @@
+import { WEBGPU_RENDER_CONTRACT } from './shaders';
+
+export interface InputSnapshot {
+  readonly timeSeconds: number;
+  readonly deltaTimeSeconds: number;
+  readonly frameCount: number;
+  readonly width: number;
+  readonly height: number;
+  readonly mouseX: number;
+  readonly mouseY: number;
+  readonly mouseButtons: number;
+  readonly audioLow: number;
+  readonly audioMid: number;
+  readonly audioHigh: number;
+  readonly gaugeActive: number;
+}
+
+function finiteOr(value: number, fallback: number): number {
+  return Number.isFinite(value) ? value : fallback;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+export class InputService {
+  private readonly bytes = new Uint8Array(WEBGPU_RENDER_CONTRACT.inputHeaderBytes);
+  private readonly view = new DataView(this.bytes.buffer);
+
+  marshal(input: InputSnapshot): Uint8Array {
+    this.bytes.fill(0);
+
+    const width = Math.max(0, finiteOr(input.width, 0));
+    const height = Math.max(0, finiteOr(input.height, 0));
+    const aspect = height > 0 ? width / height : 1;
+
+    const mouseX01 = clamp(finiteOr(input.mouseX, 0), 0, 1);
+    const mouseY01 = clamp(finiteOr(input.mouseY, 0), 0, 1);
+    const mouseX = (mouseX01 * 2 - 1) * aspect;
+    const mouseY = (1 - mouseY01) * 2 - 1;
+
+    // [LAW:single-enforcer] InputService is the only boundary that serializes
+    // CPU frame inputs into the canonical fixed-offset GPU header layout.
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderTimeOffsetBytes, finiteOr(input.timeSeconds, 0), true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderDeltaTimeOffsetBytes, finiteOr(input.deltaTimeSeconds, 0), true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderFrameCountOffsetBytes, finiteOr(input.frameCount, 0), true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderResolutionXOffsetBytes, width, true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderResolutionYOffsetBytes, height, true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderMouseXOffsetBytes, mouseX, true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderMouseYOffsetBytes, mouseY, true);
+    this.view.setUint32(WEBGPU_RENDER_CONTRACT.inputHeaderMouseButtonsOffsetBytes, input.mouseButtons >>> 0, true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderAudioLowOffsetBytes, finiteOr(input.audioLow, 0), true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderAudioMidOffsetBytes, finiteOr(input.audioMid, 0), true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderAudioHighOffsetBytes, finiteOr(input.audioHigh, 0), true);
+    this.view.setFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderGaugeActiveOffsetBytes, finiteOr(input.gaugeActive, 0), true);
+
+    return this.bytes;
+  }
+}

--- a/src/render/webgpu/WebGPURenderer.ts
+++ b/src/render/webgpu/WebGPURenderer.ts
@@ -1,6 +1,7 @@
 import type { DrawPathInstancesOp, PathGeometry, RenderFrameIR } from '../types';
 import { PathTessellator } from './PathTessellator';
 import { exportTopologyBankU32, getTopologyRegistryRevision } from '../../shapes/registry';
+import { InputService } from './InputService';
 import {
   DRAW_PREP_COMPUTE_WGSL,
   PATH_RENDER_WGSL,
@@ -22,6 +23,7 @@ const MIN_INSTANCE_CAPACITY = 1024;
 const SIMULATION_CAPACITY = WEBGPU_RENDER_CONTRACT.simulationCapacity;
 const SIMULATION_WORKGROUP_SIZE = WEBGPU_RENDER_CONTRACT.computeWorkgroupSize;
 const DRAW_PREP_WORKGROUP_SIZE = WEBGPU_RENDER_CONTRACT.drawPrepWorkgroupSize;
+const SIMULATION_STATE_BYTES = 16;
 
 function alignTo4(value: number): number {
   const remainder = value % 4;
@@ -43,6 +45,13 @@ interface RenderInput {
   readonly panX: number;
   readonly panY: number;
   readonly timeMs: number;
+  readonly inputMouseX?: number;
+  readonly inputMouseY?: number;
+  readonly inputMouseButtons?: number;
+  readonly inputAudioLow?: number;
+  readonly inputAudioMid?: number;
+  readonly inputAudioHigh?: number;
+  readonly inputGaugeActive?: number;
   readonly drawPrepShaderWgsl?: string;
 }
 
@@ -121,11 +130,11 @@ class WebGPUComputeRuntime {
 
     this.stateBuffers = [
       device.createBuffer({
-        size: SIMULATION_CAPACITY * 16,
+        size: WEBGPU_RENDER_CONTRACT.inputHeaderBytes + SIMULATION_CAPACITY * SIMULATION_STATE_BYTES,
         usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST,
       }),
       device.createBuffer({
-        size: SIMULATION_CAPACITY * 16,
+        size: WEBGPU_RENDER_CONTRACT.inputHeaderBytes + SIMULATION_CAPACITY * SIMULATION_STATE_BYTES,
         usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST,
       }),
     ] as const;
@@ -194,9 +203,17 @@ class WebGPUComputeRuntime {
     return new WebGPUComputeRuntime(device, pipeline);
   }
 
-  step(commandEncoder: any, activeCount: number, dtSeconds: number): void {
+  step(commandEncoder: any, activeCount: number, dtSeconds: number, inputHeader: Uint8Array): void {
     const clampedCount = Math.max(0, Math.min(SIMULATION_CAPACITY, activeCount));
     const clampedDt = Math.max(0, Math.min(0.1, dtSeconds));
+
+    this.device.queue.writeBuffer(
+      this.stateBuffers[this.activeStateIndex],
+      0,
+      inputHeader,
+      0,
+      WEBGPU_RENDER_CONTRACT.inputHeaderBytes,
+    );
 
     this.paramsStaging[0] = clampedCount;
     this.paramsStaging[1] = clampedDt;
@@ -362,6 +379,7 @@ class WebGPUDrawPrepRuntime {
  */
 export class WebGPURenderer {
   private readonly tessellator = new PathTessellator();
+  private readonly inputService = new InputService();
   private readonly meshCache = new Map<string, GPUMesh>();
   private readonly sceneUniforms = new Float32Array(WEBGPU_RENDER_CONTRACT.sceneUniformFloats);
   private readonly computeRuntime: WebGPUComputeRuntime;
@@ -385,6 +403,7 @@ export class WebGPURenderer {
   private instanceStaging = new Float32Array(0);
 
   private lastFrameTimeMs: number | null = null;
+  private frameCount = 0;
   private fatalError: Error | null = null;
   private lastConfiguredSize = { width: -1, height: -1 };
 
@@ -511,7 +530,22 @@ export class WebGPURenderer {
     const commandEncoder = this.device.createCommandEncoder();
     const simulationInstanceCount = this.countSimulationInstances(drawPlan);
     this.assertSimulationCapacity(simulationInstanceCount);
-    this.computeRuntime.step(commandEncoder, simulationInstanceCount, dtSeconds);
+    const frameInputHeader = this.inputService.marshal({
+      timeSeconds: input.timeMs / 1000,
+      deltaTimeSeconds: dtSeconds,
+      frameCount: this.frameCount,
+      width: input.width,
+      height: input.height,
+      mouseX: input.inputMouseX ?? 0,
+      mouseY: input.inputMouseY ?? 0,
+      mouseButtons: input.inputMouseButtons ?? 0,
+      audioLow: input.inputAudioLow ?? 0,
+      audioMid: input.inputAudioMid ?? 0,
+      audioHigh: input.inputAudioHigh ?? 0,
+      gaugeActive: input.inputGaugeActive ?? 0,
+    });
+    this.computeRuntime.step(commandEncoder, simulationInstanceCount, dtSeconds, frameInputHeader);
+    this.frameCount += 1;
     const totalInstances = this.countPlannedInstances(drawPlan);
     this.ensureInstanceCapacity(totalInstances);
     const packedInstances = this.packDrawPlanInstances(drawPlan);
@@ -597,6 +631,21 @@ export class WebGPURenderer {
     }
     if (!Number.isFinite(timeMs)) {
       throw new Error(`WebGPURenderer: timeMs must be finite, got ${timeMs}`);
+    }
+
+    const optionalFields = [
+      ['inputMouseX', input.inputMouseX],
+      ['inputMouseY', input.inputMouseY],
+      ['inputMouseButtons', input.inputMouseButtons],
+      ['inputAudioLow', input.inputAudioLow],
+      ['inputAudioMid', input.inputAudioMid],
+      ['inputAudioHigh', input.inputAudioHigh],
+      ['inputGaugeActive', input.inputGaugeActive],
+    ] as const;
+    for (const [name, value] of optionalFields) {
+      if (value !== undefined && !Number.isFinite(value)) {
+        throw new Error(`WebGPURenderer: ${name} must be finite when provided, got ${value}`);
+      }
     }
   }
 

--- a/src/render/webgpu/__tests__/WebGPURenderer.test.ts
+++ b/src/render/webgpu/__tests__/WebGPURenderer.test.ts
@@ -234,6 +234,9 @@ describe('WebGPURenderer', () => {
     expect(bufferSizes).toContain(
       WEBGPU_RENDER_CONTRACT.computeParamsFloats * Float32Array.BYTES_PER_ELEMENT
     );
+    expect(bufferSizes).toContain(
+      WEBGPU_RENDER_CONTRACT.inputHeaderBytes + WEBGPU_RENDER_CONTRACT.simulationCapacity * 16
+    );
     expect(bufferSizes).toContain(Uint32Array.BYTES_PER_ELEMENT);
 
     const bindGroupDescriptors = env.device.createBindGroup.mock.calls.map(
@@ -341,6 +344,51 @@ describe('WebGPURenderer', () => {
     expect(firstFrameBindGroup).toBe(computeBindGroupDescriptors[0]);
     expect(secondFrameBindGroup).toBe(computeBindGroupDescriptors[1]);
     expect(firstFrameBindGroup).not.toBe(secondFrameBindGroup);
+  });
+
+  it('marshals frame input values into the compute read-buffer header before dispatch', async () => {
+    const env = createFakeWebGPUEnvironment();
+    setNavigatorGpu(env.gpu);
+    const renderer = await createWebGPURenderer(env.canvas);
+
+    renderer.render(makeRenderInput([], {
+      timeMs: 1000,
+      inputMouseX: 0.75,
+      inputMouseY: 0.25,
+      inputMouseButtons: 5,
+      inputAudioLow: 0.2,
+      inputAudioMid: 0.4,
+      inputAudioHigh: 0.8,
+      inputGaugeActive: 1,
+    }));
+
+    const computeBindGroupDescriptors = env.device.createBindGroup.mock.calls
+      .map(([descriptor]: [unknown]) => descriptor as { entries: Array<{ resource: { buffer: unknown } }> })
+      .filter((descriptor) => descriptor.entries.length === 3);
+    const firstFrameReadBuffer = computeBindGroupDescriptors[0]?.entries[0]?.resource.buffer;
+    expect(firstFrameReadBuffer).toBeDefined();
+
+    const inputHeaderWrite = env.device.queue.writeBuffer.mock.calls.find((args: unknown[]) =>
+      args[0] === firstFrameReadBuffer &&
+      args[2] instanceof Uint8Array &&
+      args[4] === WEBGPU_RENDER_CONTRACT.inputHeaderBytes
+    );
+    expect(inputHeaderWrite).toBeDefined();
+
+    const inputHeaderBytes = inputHeaderWrite?.[2] as Uint8Array;
+    const view = new DataView(inputHeaderBytes.buffer, inputHeaderBytes.byteOffset, inputHeaderBytes.byteLength);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderTimeOffsetBytes, true)).toBeCloseTo(1);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderDeltaTimeOffsetBytes, true)).toBeCloseTo(0);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderFrameCountOffsetBytes, true)).toBeCloseTo(0);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderResolutionXOffsetBytes, true)).toBeCloseTo(128);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderResolutionYOffsetBytes, true)).toBeCloseTo(96);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderMouseXOffsetBytes, true)).toBeCloseTo(2 / 3);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderMouseYOffsetBytes, true)).toBeCloseTo(0.5);
+    expect(view.getUint32(WEBGPU_RENDER_CONTRACT.inputHeaderMouseButtonsOffsetBytes, true)).toBe(5);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderAudioLowOffsetBytes, true)).toBeCloseTo(0.2);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderAudioMidOffsetBytes, true)).toBeCloseTo(0.4);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderAudioHighOffsetBytes, true)).toBeCloseTo(0.8);
+    expect(view.getFloat32(WEBGPU_RENDER_CONTRACT.inputHeaderGaugeActiveOffsetBytes, true)).toBeCloseTo(1);
   });
 
   it('allocates distinct compute src/dst buffers to prevent aliasing hazards', async () => {

--- a/src/render/webgpu/shaders.ts
+++ b/src/render/webgpu/shaders.ts
@@ -24,6 +24,20 @@ export const WEBGPU_RENDER_CONTRACT = Object.freeze({
   computeDstStateBinding: 1,
   computeParamsBinding: 2,
   computeParamsFloats: 4,
+  inputHeaderBytes: 256,
+  inputHeaderTimeOffsetBytes: 0x00,
+  inputHeaderDeltaTimeOffsetBytes: 0x04,
+  inputHeaderFrameCountOffsetBytes: 0x08,
+  inputHeaderResolutionXOffsetBytes: 0x0c,
+  inputHeaderResolutionYOffsetBytes: 0x10,
+  inputHeaderMouseXOffsetBytes: 0x14,
+  inputHeaderMouseYOffsetBytes: 0x18,
+  inputHeaderMouseButtonsOffsetBytes: 0x1c,
+  inputHeaderAudioLowOffsetBytes: 0x20,
+  inputHeaderAudioMidOffsetBytes: 0x24,
+  inputHeaderAudioHighOffsetBytes: 0x28,
+  inputHeaderGaugeActiveOffsetBytes: 0x2c,
+  inputHeaderSimStateOffset: 16,
   computeWorkgroupSize: 64,
   simulationCapacity: 65_536,
   indirectArgsWords: 5,
@@ -137,10 +151,11 @@ fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let dt = simParams.v0.y;
   let damping = simParams.v0.z;
 
-  var state = srcState[gid.x];
+  let stateIndex = gid.x + ${WEBGPU_RENDER_CONTRACT.inputHeaderSimStateOffset}u;
+  var state = srcState[stateIndex];
   state.position = state.position + state.velocity * dt;
   state.velocity = state.velocity * damping;
-  dstState[gid.x] = state;
+  dstState[stateIndex] = state;
 }
 `;
 

--- a/src/services/AnimationLoop.ts
+++ b/src/services/AnimationLoop.ts
@@ -62,6 +62,37 @@ function assertWebGPULoopContract(deps: AnimationLoopDeps): void {
 const CONTINUITY_STORE_UPDATE_INTERVAL = 200; // 5Hz
 const EMPTY_RENDER_FRAME: RenderFrameIR = { version: 2, ops: [] };
 
+function readChannel(snapshot: { getFloat: (name: string) => number } | undefined, name: string): number {
+  return snapshot?.getFloat(name) ?? 0;
+}
+
+function resolveRendererInputChannels(currentState: RuntimeState): {
+  readonly inputMouseX: number;
+  readonly inputMouseY: number;
+  readonly inputMouseButtons: number;
+  readonly inputAudioLow: number;
+  readonly inputAudioMid: number;
+  readonly inputAudioHigh: number;
+  readonly inputGaugeActive: number;
+} {
+  const snapshot = currentState.externalChannels?.snapshot;
+  const leftButton = readChannel(snapshot, 'mouse.button.left.held') > 0 ? 1 : 0;
+  const rightButton = readChannel(snapshot, 'mouse.button.right.held') > 0 ? 1 : 0;
+  const middleButton = readChannel(snapshot, 'mouse.button.middle.held') > 0 ? 1 : 0;
+
+  // [LAW:one-source-of-truth] External channel snapshot is the canonical
+  // runtime input source; renderer payload values are derived from it only.
+  return {
+    inputMouseX: readChannel(snapshot, 'mouse.x'),
+    inputMouseY: readChannel(snapshot, 'mouse.y'),
+    inputMouseButtons: leftButton | (rightButton << 1) | (middleButton << 2),
+    inputAudioLow: readChannel(snapshot, 'audio.low'),
+    inputAudioMid: readChannel(snapshot, 'audio.mid'),
+    inputAudioHigh: readChannel(snapshot, 'audio.high'),
+    inputGaugeActive: readChannel(snapshot, 'gauge.active'),
+  };
+}
+
 function assertProgramPhaseBoundary(deps: AnimationLoopDeps): void {
   const program = deps.getCurrentProgram();
   if (!program) return;
@@ -204,6 +235,7 @@ export function executeAnimationFrame(
   // [LAW:one-source-of-truth] The active draw-prep shader comes from the
   // compiled program contract; renderer selection has one canonical source.
   const drawPrepShaderWgsl = currentProgram?.drawPrepProgram?.wgsl;
+  const inputChannels = resolveRendererInputChannels(currentState);
   renderer.render({
     frame: frameToRender,
     width: canvas.width,
@@ -212,6 +244,7 @@ export function executeAnimationFrame(
     panX: pan.x,
     panY: pan.y,
     timeMs: tMs,
+    ...inputChannels,
     drawPrepShaderWgsl,
   });
   state.renderTime = performance.now() - renderStart;

--- a/src/services/__tests__/AnimationLoop.test.ts
+++ b/src/services/__tests__/AnimationLoop.test.ts
@@ -226,6 +226,62 @@ describe('AnimationLoop', () => {
     expect(renderArg.drawPrepShaderWgsl).toBe(drawPrepShaderWgsl);
   });
 
+  it('derives renderer input channels from the canonical external snapshot', () => {
+    const arena = { reset: vi.fn(), getTotalBytes: () => 0 };
+    const renderer = { render: vi.fn() };
+    executeFrameMock.mockReturnValue({ version: 2, ops: [] } as any);
+
+    const channels = new Map<string, number>([
+      ['mouse.x', 0.7],
+      ['mouse.y', 0.2],
+      ['mouse.button.left.held', 1],
+      ['mouse.button.right.held', 1],
+      ['audio.low', 0.1],
+      ['audio.mid', 0.2],
+      ['audio.high', 0.3],
+      ['gauge.active', 1],
+    ]);
+
+    const deps = {
+      getCurrentProgram: () => ({}),
+      getCurrentState: () => ({
+        health: createHealthMetrics(),
+        externalChannels: {
+          snapshot: {
+            getFloat: (name: string) => channels.get(name) ?? 0,
+          },
+        },
+      }),
+      getCanvas: () => ({ width: 100, height: 80 }),
+      getRenderer: () => renderer,
+      getArena: () => arena,
+      store: {
+        stepDebug: null,
+        diagnostics: {
+          recordJank: vi.fn(),
+          updateFrameTiming: vi.fn(),
+          updateMemoryStats: vi.fn(),
+        },
+        continuity: { updateFromRuntime: vi.fn() },
+        viewport: { zoom: 1, pan: { x: 0, y: 0 }, setContentBounds: vi.fn() },
+        events: { emit: vi.fn() },
+        getPatchRevision: () => 1,
+      },
+    } as any;
+
+    const state = createAnimationLoopState();
+    executeAnimationFrame(16, deps, state);
+
+    const renderArg = renderer.render.mock.calls[0]?.[0];
+    expect(renderArg.inputMouseX).toBe(0.7);
+    expect(renderArg.inputMouseY).toBe(0.2);
+    expect(renderArg.inputMouseButtons).toBe(3);
+    expect(renderArg.inputAudioLow).toBe(0.1);
+    expect(renderArg.inputAudioMid).toBe(0.2);
+    expect(renderArg.inputAudioHigh).toBe(0.3);
+    expect(renderArg.inputGaugeActive).toBe(1);
+  });
+
   afterEach(() => {
     vi.unstubAllGlobals();
     (globalThis as any).requestAnimationFrame = originalRaf;


### PR DESCRIPTION
## Summary
- Implements `oscilla-animator-v2-zq12.1` (`P3-1_CPU_to_GPU_Input_Marshalling.md`).
- Adds a dedicated `InputService` that owns the canonical 256-byte frame-input header serialization using a preallocated `ArrayBuffer`/`DataView`.
- Uploads the serialized header to the active compute read buffer before dispatch each frame.
- Reserves the first 256 bytes of compute state buffers and shifts simulation indexing past the reserved header region.
- Wires renderer input fields from runtime `externalChannels.snapshot` in `AnimationLoop` so the renderer consumes structured canonical input data.

## Changed Files
- `src/render/webgpu/InputService.ts`
- `src/render/webgpu/shaders.ts`
- `src/render/webgpu/WebGPURenderer.ts`
- `src/services/AnimationLoop.ts`
- `src/render/webgpu/__tests__/WebGPURenderer.test.ts`
- `src/services/__tests__/AnimationLoop.test.ts`

## Validation
- `BEAD_ID=oscilla-animator-v2-zq12.1 scripts/enforce-webgpu-bead-readiness.sh`
- `pnpm -s typecheck`
- `pnpm -s test src/render/webgpu/__tests__/WebGPURenderer.test.ts src/services/__tests__/AnimationLoop.test.ts`
- `pnpm -s test`
