### PR TITLE
P2-2: enforce Naga lowering artifact invariants

### DIFF
--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -43,6 +43,7 @@ import type { ArenaSlotDescriptor } from '../runtime/ArenaValueStore';
 import type { ValueExpr, ValueExprId } from './ir/value-expr';
 import type { Step, PureFn } from './ir/types';
 import { lowerScheduleToNagaModule } from './ir/naga-lowering';
+import { validateNagaLoweringProgram } from './ir/naga-lowering-validate';
 import { compilationInspector } from '../services/CompilationInspectorService';
 import { computeRenderReachableBlocks } from './reachability';
 import { resolveKernels } from './resolve-kernels';
@@ -513,6 +514,13 @@ function convertLinkedIRToProgram(
     valueExprs: valueExprNodes,
     exprToBlock: builder.getExprToBlock(),
   });
+  // [LAW:single-enforcer] Naga artifact structural invariants are enforced once
+  // at compile output construction before worker/runtime consumption.
+  const nagaIssues = validateNagaLoweringProgram(nagaLoweringProgram);
+  if (nagaIssues.length > 0) {
+    const messages = nagaIssues.map((issue) => `${issue.code}: ${issue.message}`).join('; ');
+    throw new Error(`Naga lowering validation failed: ${messages}`);
+  }
 
   // Build debug index
   const stepToBlock = new Map();

--- a/src/compiler/ir/__tests__/naga-lowering-validate.test.ts
+++ b/src/compiler/ir/__tests__/naga-lowering-validate.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import type { NagaLoweringProgramIR } from '../naga-lowering';
+import { validateNagaLoweringProgram } from '../naga-lowering-validate';
+
+function makeValidArtifact(): NagaLoweringProgramIR {
+  return {
+    module: {
+      types: [
+        { kind: 'scalar', scalar: 'f32', width: 4 },
+        { kind: 'scalar', scalar: 'u32', width: 4 },
+        { kind: 'vector', size: 3, scalar: 'u32', width: 4 },
+      ],
+      constants: [
+        { type: 1, value: 0 },
+      ],
+      global_variables: [],
+      functions: [
+        {
+          name: 'compute_main',
+          arguments: [{ name: 'global_id', type: 2, builtin: 'global_invocation_id' }],
+          expressions: [
+            { kind: 'argument', argument: 0 },
+            { kind: 'access_index', base: 0, index: 0 },
+          ],
+          body: [
+            { kind: 'store', buffer: 'arena_out', index: 1, value: 1, comment: 'smoke' },
+          ],
+        },
+      ],
+      entry_points: [
+        { stage: 'compute', function: 'compute_main', workgroupSize: [64, 1, 1] },
+      ],
+    },
+    sourceMap: {
+      Expr_0: { blockId: null, stepIndex: -1 },
+      Expr_1: { blockId: null, stepIndex: -1 },
+      Stmt_0: { blockId: null, stepIndex: 0 },
+    },
+  };
+}
+
+describe('validateNagaLoweringProgram', () => {
+  it('accepts a structurally valid lowering artifact', () => {
+    expect(validateNagaLoweringProgram(makeValidArtifact())).toEqual([]);
+  });
+
+  it('rejects artifacts with missing compute entry points', () => {
+    const artifact: NagaLoweringProgramIR = {
+      ...makeValidArtifact(),
+      module: {
+        ...makeValidArtifact().module,
+        entry_points: [],
+      },
+    };
+    const issues = validateNagaLoweringProgram(artifact);
+    expect(issues.some((issue) => issue.code === 'E_NAGA_ENTRYPOINT_MISSING')).toBe(true);
+  });
+
+  it('rejects missing expression source map entries', () => {
+    const valid = makeValidArtifact();
+    const artifact: NagaLoweringProgramIR = {
+      ...valid,
+      sourceMap: {
+        Expr_0: valid.sourceMap.Expr_0!,
+        Stmt_0: valid.sourceMap.Stmt_0!,
+      },
+    };
+    const issues = validateNagaLoweringProgram(artifact);
+    expect(issues.some((issue) => issue.code === 'E_NAGA_SOURCE_MAP_EXPR_MISSING')).toBe(true);
+  });
+});

--- a/src/compiler/ir/naga-lowering-validate.ts
+++ b/src/compiler/ir/naga-lowering-validate.ts
@@ -1,0 +1,83 @@
+import type {
+  NagaFunctionIR,
+  NagaLoweringProgramIR,
+  NagaStatementIR,
+} from './naga-lowering';
+
+export interface NagaLoweringValidationIssue {
+  readonly code:
+    | 'E_NAGA_ENTRYPOINT_MISSING'
+    | 'E_NAGA_ENTRYPOINT_TARGET_MISSING'
+    | 'E_NAGA_FUNCTION_MISSING'
+    | 'E_NAGA_SOURCE_MAP_EXPR_MISSING'
+    | 'E_NAGA_SOURCE_MAP_STMT_MISSING';
+  readonly message: string;
+}
+
+function validateFunctionSourceMap(
+  fn: NagaFunctionIR,
+  sourceMap: Readonly<Record<string, unknown>>,
+): NagaLoweringValidationIssue[] {
+  const issues: NagaLoweringValidationIssue[] = [];
+
+  for (let exprIndex = 0; exprIndex < fn.expressions.length; exprIndex++) {
+    const key = `Expr_${exprIndex}`;
+    if (!(key in sourceMap)) {
+      issues.push({
+        code: 'E_NAGA_SOURCE_MAP_EXPR_MISSING',
+        message: `Naga lowering sourceMap is missing ${key}`,
+      });
+    }
+  }
+
+  for (let stmtIndex = 0; stmtIndex < fn.body.length; stmtIndex++) {
+    const statement = fn.body[stmtIndex] as NagaStatementIR;
+    if (statement.kind === 'comment') continue;
+    const key = `Stmt_${stmtIndex}`;
+    if (!(key in sourceMap)) {
+      issues.push({
+        code: 'E_NAGA_SOURCE_MAP_STMT_MISSING',
+        message: `Naga lowering sourceMap is missing ${key}`,
+      });
+    }
+  }
+
+  return issues;
+}
+
+export function validateNagaLoweringProgram(
+  artifact: NagaLoweringProgramIR,
+): readonly NagaLoweringValidationIssue[] {
+  const issues: NagaLoweringValidationIssue[] = [];
+  const entryPoints = artifact.module.entry_points;
+
+  if (entryPoints.length === 0) {
+    issues.push({
+      code: 'E_NAGA_ENTRYPOINT_MISSING',
+      message: 'Naga lowering artifact must include at least one compute entry point',
+    });
+    return issues;
+  }
+
+  const computeEntry = entryPoints.find((entry) => entry.stage === 'compute');
+  if (!computeEntry) {
+    issues.push({
+      code: 'E_NAGA_ENTRYPOINT_TARGET_MISSING',
+      message: 'Naga lowering artifact has no compute-stage entry point',
+    });
+    return issues;
+  }
+
+  const fn = artifact.module.functions.find((candidate) => candidate.name === computeEntry.function);
+  if (!fn) {
+    issues.push({
+      code: 'E_NAGA_FUNCTION_MISSING',
+      message: `Naga lowering artifact entry point targets missing function "${computeEntry.function}"`,
+    });
+    return issues;
+  }
+
+  issues.push(...validateFunctionSourceMap(fn, artifact.sourceMap));
+  return issues;
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated validator for compiler-emitted `nagaLoweringProgram` artifacts
- enforce entrypoint/function/source-map invariants during compile output construction
- add focused unit coverage for validator failure cases and success path

## Why
P2-2 requires ScheduleIR -> Naga module lowering to be a concrete, verifiable contract. This change moves those checks into one compile-time enforcement boundary instead of relying on implicit assumptions downstream.

## Validation
- `pnpm -s vitest run src/compiler/ir/__tests__/naga-lowering-validate.test.ts src/compiler/__tests__/naga-lowering.test.ts`
- `pnpm -s typecheck`