### PR TITLE
[oscilla-animator-v2-zq12.2] P3-2 compute dispatch geometry

### DIFF
--- a/src/render/webgpu/WebGPURenderer.ts
+++ b/src/render/webgpu/WebGPURenderer.ts
@@ -10,6 +10,7 @@ import {
 } from './shaders';
 
 const GPU_BUFFER_USAGE = {
+  COPY_SRC: 0x0004,
   COPY_DST: 0x0008,
   INDEX: 0x0010,
   VERTEX: 0x0020,
@@ -28,6 +29,12 @@ const SIMULATION_STATE_BYTES = 16;
 function alignTo4(value: number): number {
   const remainder = value % 4;
   return remainder === 0 ? value : value + (4 - remainder);
+}
+
+function computeDispatchWorkgroups(capacity: number, workgroupSize: number): number {
+  // [LAW:single-enforcer] Dispatch geometry is computed once from canonical
+  // capacity/workgroup constants, not ad-hoc at each callsite.
+  return Math.max(1, Math.ceil(capacity / workgroupSize));
 }
 
 interface GPUMesh {
@@ -131,11 +138,11 @@ class WebGPUComputeRuntime {
     this.stateBuffers = [
       device.createBuffer({
         size: WEBGPU_RENDER_CONTRACT.inputHeaderBytes + SIMULATION_CAPACITY * SIMULATION_STATE_BYTES,
-        usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST,
+        usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST | GPU_BUFFER_USAGE.COPY_SRC,
       }),
       device.createBuffer({
         size: WEBGPU_RENDER_CONTRACT.inputHeaderBytes + SIMULATION_CAPACITY * SIMULATION_STATE_BYTES,
-        usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST,
+        usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST | GPU_BUFFER_USAGE.COPY_SRC,
       }),
     ] as const;
 
@@ -218,7 +225,7 @@ class WebGPUComputeRuntime {
     this.paramsStaging[0] = clampedCount;
     this.paramsStaging[1] = clampedDt;
     this.paramsStaging[2] = 0.999; // Mild damping keeps default simulation stable.
-    this.paramsStaging[3] = 0;
+    this.paramsStaging[3] = SIMULATION_CAPACITY;
     this.device.queue.writeBuffer(this.paramsBuffer, 0, this.paramsStaging);
 
     // [LAW:dataflow-not-control-flow] Compute pass always executes.
@@ -226,7 +233,7 @@ class WebGPUComputeRuntime {
     const pass = commandEncoder.beginComputePass();
     pass.setPipeline(this.pipeline);
     pass.setBindGroup(WEBGPU_RENDER_CONTRACT.computeBindGroup, this.bindGroups[this.activeStateIndex]);
-    const workgroups = Math.max(1, Math.ceil(clampedCount / SIMULATION_WORKGROUP_SIZE));
+    const workgroups = computeDispatchWorkgroups(SIMULATION_CAPACITY, SIMULATION_WORKGROUP_SIZE);
     pass.dispatchWorkgroups(workgroups);
     pass.end();
     this.activeStateIndex = this.activeStateIndex ^ 1;

--- a/src/render/webgpu/__tests__/WebGPURenderer.test.ts
+++ b/src/render/webgpu/__tests__/WebGPURenderer.test.ts
@@ -238,6 +238,17 @@ describe('WebGPURenderer', () => {
       WEBGPU_RENDER_CONTRACT.inputHeaderBytes + WEBGPU_RENDER_CONTRACT.simulationCapacity * 16
     );
     expect(bufferSizes).toContain(Uint32Array.BYTES_PER_ELEMENT);
+    const computeStateBuffers = env.device.createBuffer.mock.calls
+      .map(([descriptor]: [unknown]) => descriptor as { size: number; usage: number })
+      .filter((descriptor) =>
+        descriptor.size === WEBGPU_RENDER_CONTRACT.inputHeaderBytes + WEBGPU_RENDER_CONTRACT.simulationCapacity * 16
+      );
+    expect(computeStateBuffers).toHaveLength(2);
+    for (const descriptor of computeStateBuffers) {
+      expect((descriptor.usage & 0x0080) !== 0).toBe(true); // STORAGE
+      expect((descriptor.usage & 0x0008) !== 0).toBe(true); // COPY_DST
+      expect((descriptor.usage & 0x0004) !== 0).toBe(true); // COPY_SRC
+    }
 
     const bindGroupDescriptors = env.device.createBindGroup.mock.calls.map(
       ([descriptor]: [unknown]) => descriptor as { entries: Array<{ binding: number }> }
@@ -579,7 +590,7 @@ describe('WebGPURenderer', () => {
     expect(drawPrepBindGroups).toHaveLength(1);
   });
 
-  it('dispatches simulation workgroups from unique op instance count (not fill/stroke pass count)', async () => {
+  it('dispatches simulation workgroups from canonical capacity and passes activeCount in params', async () => {
     const env = createFakeWebGPUEnvironment();
     setNavigatorGpu(env.gpu);
     const renderer = await createWebGPURenderer(env.canvas);
@@ -599,7 +610,17 @@ describe('WebGPURenderer', () => {
     ]));
 
     // First compute dispatch is simulation pass (draw-prep dispatches are fixed-size 1).
-    expect(env.computePass.dispatchWorkgroups.mock.calls[0]?.[0]).toBe(2);
+    expect(env.computePass.dispatchWorkgroups.mock.calls[0]?.[0]).toBe(
+      WEBGPU_RENDER_CONTRACT.simulationCapacity / WEBGPU_RENDER_CONTRACT.computeWorkgroupSize
+    );
+    const computeParamsWrite = env.device.queue.writeBuffer.mock.calls.find((args: unknown[]) =>
+      args[2] instanceof Float32Array &&
+      (args[2] as Float32Array).length === WEBGPU_RENDER_CONTRACT.computeParamsFloats
+    );
+    expect(computeParamsWrite).toBeDefined();
+    const computeParams = computeParamsWrite?.[2] as Float32Array;
+    expect(computeParams[0]).toBe(instanceCount);
+    expect(computeParams[3]).toBe(WEBGPU_RENDER_CONTRACT.simulationCapacity);
   });
 
   it('fails fast when simulation instance count exceeds contract capacity', async () => {

--- a/src/render/webgpu/shaders.ts
+++ b/src/render/webgpu/shaders.ts
@@ -133,7 +133,7 @@ struct SimState {
 };
 
 struct SimParams {
-  // v0 = [activeCount, dtSeconds, damping, _]
+  // v0 = [activeCount, dtSeconds, damping, capacity]
   v0: vec4<f32>,
 };
 
@@ -143,6 +143,11 @@ struct SimParams {
 
 @compute @workgroup_size(${WEBGPU_RENDER_CONTRACT.computeWorkgroupSize})
 fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+  let capacity = u32(simParams.v0.w);
+  if (gid.x >= capacity) {
+    return;
+  }
+
   let activeCount = u32(simParams.v0.x);
   if (gid.x >= activeCount) {
     return;


### PR DESCRIPTION
## Summary
- Implements `oscilla-animator-v2-zq12.2` (`P3-2_GPU_Compute_Dispatch_Explained.md`).
- Updates compute dispatch geometry to use canonical simulation capacity workgroup sizing (`ceil(capacity / 64)`) every frame.
- Preserves active-lane behavior by passing active instance count through compute params while dispatching full-capacity workgroups.
- Adds explicit compute tail guard by capacity in WGSL and keeps active-count guard for inactive lanes.
- Updates compute state buffers to include `COPY_SRC` usage as required by the ping-pong arena write contract.

## Changed Files
- `src/render/webgpu/WebGPURenderer.ts`
- `src/render/webgpu/shaders.ts`
- `src/render/webgpu/__tests__/WebGPURenderer.test.ts`

## Validation
- `BEAD_ID=oscilla-animator-v2-zq12.2 scripts/enforce-webgpu-bead-readiness.sh`
- `pnpm -s test src/render/webgpu/__tests__/WebGPURenderer.test.ts`
- `pnpm -s typecheck`
- `pnpm -s test`
