### PR TITLE
P2-3: add Naga validation bridge to worker compile pipeline

### DIFF
--- a/src/compiler/__tests__/naga-compile.test.ts
+++ b/src/compiler/__tests__/naga-compile.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { buildPatch } from '../../graph';
+import { compile } from '../compile';
+import { compileProgramWithNaga } from '../naga-compile';
+
+function buildSimplePatch() {
+  return buildPatch((b) => {
+    const time = b.addBlock('InfiniteTimeRoot');
+    b.setPortDefault(time, 'periodAMs', 1000);
+    b.setPortDefault(time, 'periodBMs', 2000);
+
+    const osc = b.addBlock('Oscillator');
+    b.wire(time, 'phaseA', osc, 'phase');
+  });
+}
+
+describe('compileProgramWithNaga', () => {
+  it('compiles lowering artifact to WGSL', async () => {
+    const result = compile(buildSimplePatch());
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+
+    const compiled = await compileProgramWithNaga(result.program);
+    expect(compiled.kind).toBe('ok');
+    if (compiled.kind !== 'ok') return;
+
+    expect(compiled.wgsl).toContain('@compute @workgroup_size(');
+    expect(compiled.wgsl).toContain('fn compute_main');
+  });
+
+  it('fails when compiled program has no lowering artifact', async () => {
+    const result = compile(buildSimplePatch());
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+
+    const withoutLowering = {
+      ...result.program,
+      nagaLoweringProgram: undefined,
+    };
+    const compiled = await compileProgramWithNaga(withoutLowering as typeof result.program);
+    expect(compiled.kind).toBe('error');
+    if (compiled.kind !== 'error') return;
+    expect(compiled.errors.some((error) => error.code === 'IRValidationFailed')).toBe(true);
+  });
+
+  it('maps validation failures to source block IDs via sourceMap', async () => {
+    const result = compile(buildSimplePatch());
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+
+    const lowering = result.program.nagaLoweringProgram;
+    expect(lowering).toBeDefined();
+    if (!lowering) return;
+
+    const fn = lowering.module.functions[0];
+    const referencedExprIds = fn.body
+      .flatMap((stmt) => (stmt.kind === 'store' ? [stmt.index, stmt.value] : []))
+      .filter((exprId) => {
+        const source = lowering.sourceMap[`Expr_${exprId}`];
+        return source?.blockId !== null && source?.blockId !== undefined;
+      });
+    expect(referencedExprIds.length).toBeGreaterThan(0);
+    if (referencedExprIds.length === 0) return;
+
+    const targetExprId = referencedExprIds[0]!;
+    const targetBlockId = lowering.sourceMap[`Expr_${targetExprId}`]!.blockId;
+    expect(typeof targetBlockId).toBe('string');
+    if (typeof targetBlockId !== 'string') return;
+
+    const baseModule = structuredClone(lowering.module);
+    const firstFn = baseModule.functions[0]!;
+    const mutatedExpressions = [...firstFn.expressions];
+    mutatedExpressions[targetExprId] = {
+      kind: 'argument',
+      argument: 999,
+    };
+    const mutatedModule = {
+      ...baseModule,
+      functions: [
+        {
+          ...firstFn,
+          expressions: mutatedExpressions,
+        },
+        ...baseModule.functions.slice(1),
+      ],
+    };
+
+    const faultyProgram = {
+      ...result.program,
+      nagaLoweringProgram: {
+        module: mutatedModule,
+        sourceMap: lowering.sourceMap,
+      },
+    };
+
+    const compiled = await compileProgramWithNaga(faultyProgram as typeof result.program);
+    expect(compiled.kind).toBe('error');
+    if (compiled.kind !== 'error') return;
+    expect(
+      compiled.errors.some((error) => error.where?.blockId === targetBlockId),
+    ).toBe(true);
+  });
+});

--- a/src/compiler/naga-bridge.ts
+++ b/src/compiler/naga-bridge.ts
@@ -1,0 +1,50 @@
+import type { NagaModuleIR } from './ir/naga-lowering';
+import initShim, { compile_ir, type ShimFormattedError } from './wasm/oscilla_naga_shim';
+
+export interface NagaCompilationResult {
+  readonly wgsl: string;
+}
+
+export class NagaValidationError extends Error {
+  readonly errors: readonly ShimFormattedError[];
+
+  constructor(errors: readonly ShimFormattedError[]) {
+    super(errors.map((error) => error.message).join('; ') || 'Naga validation failed');
+    this.name = 'NagaValidationError';
+    this.errors = errors;
+  }
+}
+
+export class NagaService {
+  private static bootPromise: Promise<void> | null = null;
+  private static ready = false;
+
+  static async boot(): Promise<void> {
+    if (this.ready) return;
+    if (!this.bootPromise) {
+      // [LAW:single-enforcer] Naga WASM/bootstrap lifecycle is owned by one
+      // service boundary to avoid duplicate initialization races.
+      this.bootPromise = initShim()
+        .then(() => {
+          this.ready = true;
+        })
+        .catch((error) => {
+          this.bootPromise = null;
+          throw error;
+        });
+    }
+    await this.bootPromise;
+  }
+
+  static compile(module: NagaModuleIR): NagaCompilationResult {
+    if (!this.ready) {
+      throw new Error('NagaService.compile called before boot');
+    }
+    const result = compile_ir(module);
+    if (!result.is_valid) {
+      throw new NagaValidationError(result.errors);
+    }
+    return { wgsl: result.wgsl };
+  }
+}
+

--- a/src/compiler/naga-compile.ts
+++ b/src/compiler/naga-compile.ts
@@ -1,0 +1,77 @@
+import type { CompileError } from './types';
+import { NagaService, NagaValidationError } from './naga-bridge';
+import type { CompiledProgramIR } from './ir/program';
+
+interface NagaSourceRef {
+  readonly blockId: string | null;
+}
+
+export type NagaCompilationOutcome =
+  | { readonly kind: 'ok'; readonly wgsl: string }
+  | { readonly kind: 'error'; readonly errors: readonly CompileError[] };
+
+function parseExpressionId(value: string): number | null {
+  const match = /Expression\s*\[(\d+)\]/i.exec(value);
+  if (!match) return null;
+  return Number.parseInt(match[1], 10);
+}
+
+function toCompileErrors(
+  error: NagaValidationError,
+  sourceMap: Readonly<Record<string, NagaSourceRef>>,
+): readonly CompileError[] {
+  return error.errors.map((entry) => {
+    const exprId = parseExpressionId(entry.location);
+    const sourceRef = exprId === null ? undefined : sourceMap[`Expr_${exprId}`];
+    const where = sourceRef?.blockId ? { blockId: sourceRef.blockId } : undefined;
+    return {
+      code: 'IRValidationFailed',
+      message: `${entry.message} (${entry.location})`,
+      where,
+      details: { path: entry.path },
+    } as const;
+  });
+}
+
+export async function compileProgramWithNaga(
+  program: CompiledProgramIR,
+): Promise<NagaCompilationOutcome> {
+  const lowering = program.nagaLoweringProgram;
+  if (!lowering) {
+    return {
+      kind: 'error',
+      errors: [
+        {
+          code: 'IRValidationFailed',
+          message: 'Missing nagaLoweringProgram on compiled IR',
+        },
+      ],
+    };
+  }
+
+  try {
+    await NagaService.boot();
+    const compiled = NagaService.compile(lowering.module);
+    return {
+      kind: 'ok',
+      wgsl: compiled.wgsl,
+    };
+  } catch (error) {
+    if (error instanceof NagaValidationError) {
+      return {
+        kind: 'error',
+        errors: toCompileErrors(error, lowering.sourceMap),
+      };
+    }
+    return {
+      kind: 'error',
+      errors: [
+        {
+          code: 'IRValidationFailed',
+          message: `Naga compilation bridge failure: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      ],
+    };
+  }
+}
+

--- a/src/compiler/wasm/oscilla_naga_shim.ts
+++ b/src/compiler/wasm/oscilla_naga_shim.ts
@@ -1,0 +1,262 @@
+import type {
+  NagaExpressionIR,
+  NagaFunctionIR,
+  NagaModuleIR,
+  NagaScalarKindIR,
+  NagaTypeIR,
+} from '../ir/naga-lowering';
+
+export interface ShimFormattedError {
+  readonly message: string;
+  readonly location: string;
+  readonly path: string;
+}
+
+export interface ShimCompilationResult {
+  readonly wgsl: string;
+  readonly is_valid: boolean;
+  readonly errors: readonly ShimFormattedError[];
+}
+
+let initialized = false;
+
+export default async function init(): Promise<void> {
+  initialized = true;
+}
+
+function formatScalarLiteral(value: number, scalar: NagaScalarKindIR): string {
+  if (scalar === 'u32') {
+    const integer = Math.trunc(value);
+    return `${integer}u`;
+  }
+  if (Number.isInteger(value)) {
+    return `${value}.0`;
+  }
+  return `${value}`;
+}
+
+function emitTypeRef(typeIndex: number, types: readonly NagaTypeIR[]): string {
+  const type = types[typeIndex];
+  if (!type) {
+    return 'f32';
+  }
+  switch (type.kind) {
+    case 'scalar':
+      return type.scalar;
+    case 'vector':
+      return `vec${type.size}<${type.scalar}>`;
+    case 'array':
+      return `array<${emitTypeRef(type.base, types)}>`;
+    case 'struct':
+      return type.name;
+    default: {
+      const _exhaustive: never = type;
+      return _exhaustive;
+    }
+  }
+}
+
+function emitStructs(types: readonly NagaTypeIR[]): string[] {
+  const lines: string[] = [];
+  for (const type of types) {
+    if (type.kind !== 'struct') continue;
+    lines.push(`struct ${type.name} {`);
+    for (const field of type.fields) {
+      lines.push(`  ${field.name}: ${emitTypeRef(field.type, types)},`);
+    }
+    lines.push('};', '');
+  }
+  return lines;
+}
+
+function makeError(message: string, location: string, path: string): ShimCompilationResult {
+  return {
+    wgsl: '',
+    is_valid: false,
+    errors: [{ message, location, path }],
+  };
+}
+
+function emitExpression(args: {
+  readonly fn: NagaFunctionIR;
+  readonly module: NagaModuleIR;
+  readonly exprId: number;
+  readonly cache: Map<number, string>;
+  readonly stack: Set<number>;
+}): ShimCompilationResult | string {
+  const { fn, module, exprId, cache, stack } = args;
+  const cached = cache.get(exprId);
+  if (cached !== undefined) {
+    return cached;
+  }
+  if (stack.has(exprId)) {
+    return makeError(`Expression cycle detected`, `Expression [${exprId}]`, `Function [${fn.name}]`);
+  }
+  const expr = fn.expressions[exprId] as NagaExpressionIR | undefined;
+  if (!expr) {
+    return makeError(`Expression handle not found`, `Expression [${exprId}]`, `Function [${fn.name}]`);
+  }
+
+  stack.add(exprId);
+  const done = (value: string): string => {
+    cache.set(exprId, value);
+    stack.delete(exprId);
+    return value;
+  };
+
+  const recurse = (nextExprId: number): ShimCompilationResult | string =>
+    emitExpression({ fn, module, exprId: nextExprId, cache, stack });
+
+  switch (expr.kind) {
+    case 'argument': {
+      const arg = fn.arguments[expr.argument];
+      if (!arg) {
+        stack.delete(exprId);
+        return makeError(
+          `Argument handle not found`,
+          `Expression [${exprId}]`,
+          `Function [${fn.name}] -> Argument [${expr.argument}]`,
+        );
+      }
+      return done(arg.name);
+    }
+    case 'constant': {
+      const constant = module.constants[expr.constant];
+      if (!constant) {
+        stack.delete(exprId);
+        return makeError(
+          `Constant handle not found`,
+          `Expression [${exprId}]`,
+          `Function [${fn.name}] -> Constant [${expr.constant}]`,
+        );
+      }
+      const type = module.types[constant.type];
+      if (!type || type.kind !== 'scalar') {
+        stack.delete(exprId);
+        return makeError(
+          `Constant scalar type is missing`,
+          `Expression [${exprId}]`,
+          `Function [${fn.name}] -> Constant [${expr.constant}]`,
+        );
+      }
+      return done(formatScalarLiteral(constant.value, type.scalar));
+    }
+    case 'access_index': {
+      const base = recurse(expr.base);
+      if (typeof base !== 'string') return base;
+      const components = ['x', 'y', 'z', 'w'];
+      const component = components[expr.index];
+      if (!component) {
+        stack.delete(exprId);
+        return makeError(
+          `access_index out of range`,
+          `Expression [${exprId}]`,
+          `Function [${fn.name}]`,
+        );
+      }
+      return done(`${base}.${component}`);
+    }
+    case 'binary': {
+      const left = recurse(expr.left);
+      if (typeof left !== 'string') return left;
+      const right = recurse(expr.right);
+      if (typeof right !== 'string') return right;
+      const op = expr.op === 'add' ? '+' : '*';
+      return done(`(${left} ${op} ${right})`);
+    }
+    case 'buffer_load': {
+      const index = recurse(expr.index);
+      if (typeof index !== 'string') return index;
+      return done(`${expr.buffer}[${index}]`);
+    }
+    case 'as': {
+      const value = recurse(expr.expr);
+      if (typeof value !== 'string') return value;
+      const to = expr.to === 'u32' ? 'u32' : 'f32';
+      return done(`bitcast<${to}>(${value})`);
+    }
+    default: {
+      const _exhaustive: never = expr;
+      stack.delete(exprId);
+      return _exhaustive;
+    }
+  }
+}
+
+function emitFunctionBody(fn: NagaFunctionIR, module: NagaModuleIR): ShimCompilationResult | string[] {
+  const lines: string[] = [];
+  const cache = new Map<number, string>();
+  const stack = new Set<number>();
+  for (let stmtIndex = 0; stmtIndex < fn.body.length; stmtIndex++) {
+    const stmt = fn.body[stmtIndex];
+    if (stmt.kind === 'comment') {
+      lines.push(`  // ${stmt.text}`);
+      continue;
+    }
+    const indexExpr = emitExpression({ fn, module, exprId: stmt.index, cache, stack });
+    if (typeof indexExpr !== 'string') return indexExpr;
+    const valueExpr = emitExpression({ fn, module, exprId: stmt.value, cache, stack });
+    if (typeof valueExpr !== 'string') return valueExpr;
+    lines.push(`  ${stmt.buffer}[${indexExpr}] = ${valueExpr}; // ${stmt.comment}`);
+  }
+  return lines;
+}
+
+export function compile_ir(module: NagaModuleIR): ShimCompilationResult {
+  if (!initialized) {
+    return makeError('Shim not initialized', 'Module', 'init');
+  }
+  const computeEntry = module.entry_points.find((entry) => entry.stage === 'compute');
+  if (!computeEntry) {
+    return makeError('Missing compute entry point', 'EntryPoint', 'Module');
+  }
+  const fn = module.functions.find((candidate) => candidate.name === computeEntry.function);
+  if (!fn) {
+    return makeError(
+      `Entry point function "${computeEntry.function}" not found`,
+      'EntryPoint',
+      'Module',
+    );
+  }
+
+  const lines: string[] = [
+    '// Generated by oscilla_naga_shim.ts (P2-3 bridge stub)',
+    ...emitStructs(module.types),
+  ];
+
+  for (const global of module.global_variables) {
+    const typeRef = emitTypeRef(global.type, module.types);
+    if (global.storageClass === 'uniform') {
+      lines.push(`@group(${global.binding.group}) @binding(${global.binding.binding}) var<uniform> ${global.name}: ${typeRef};`);
+      continue;
+    }
+    lines.push(
+      `@group(${global.binding.group}) @binding(${global.binding.binding}) var<storage, ${global.access}> ${global.name}: ${typeRef};`,
+    );
+  }
+  lines.push('');
+
+  const argParts: string[] = fn.arguments.map((arg) => {
+    const typeRef = emitTypeRef(arg.type, module.types);
+    const builtinPrefix = arg.builtin ? `@builtin(${arg.builtin}) ` : '';
+    return `${builtinPrefix}${arg.name}: ${typeRef}`;
+  });
+  const body = emitFunctionBody(fn, module);
+  if (!Array.isArray(body)) {
+    return body;
+  }
+
+  lines.push(
+    `@compute @workgroup_size(${computeEntry.workgroupSize[0]}, ${computeEntry.workgroupSize[1]}, ${computeEntry.workgroupSize[2]})`,
+    `fn ${fn.name}(${argParts.join(', ')}) {`,
+    ...body,
+    '}',
+  );
+
+  return {
+    wgsl: lines.join('\n'),
+    is_valid: true,
+    errors: [],
+  };
+}
+

--- a/src/services/compile.worker.ts
+++ b/src/services/compile.worker.ts
@@ -2,6 +2,7 @@
 
 import { compileFromFrontend } from '../compiler';
 import { compileFrontend } from '../compiler/frontend';
+import { compileProgramWithNaga } from '../compiler/naga-compile';
 import { EventHub } from '../events/EventHub';
 import { deserializePatch } from './PatchPersistence';
 import { exportSerializableTopologies } from '../shapes/registry';
@@ -12,11 +13,41 @@ import type {
 } from './compile-worker-protocol';
 import { collectProgramTopologyIds, stripKernelRegistry } from './compile-worker-serialization';
 
-function toBackendResult(
+async function toBackendResult(
   result: ReturnType<typeof compileFromFrontend>,
-): CompileWorkerBackendResult {
+): Promise<CompileWorkerBackendResult> {
   if (result.kind === 'ok') {
-    const program = stripKernelRegistry(result.program);
+    const nagaOutcome = await compileProgramWithNaga(result.program);
+    if (nagaOutcome.kind === 'error') {
+      return {
+        kind: 'error',
+        errors: nagaOutcome.errors,
+      };
+    }
+
+    if (!result.program.generatedComputeProgram) {
+      return {
+        kind: 'error',
+        errors: [
+          {
+            code: 'IRValidationFailed',
+            message: 'Compiled program is missing generatedComputeProgram',
+          },
+        ],
+      };
+    }
+
+    const programWithValidatedWgsl = {
+      ...result.program,
+      generatedComputeProgram: {
+        ...result.program.generatedComputeProgram,
+        // [LAW:one-source-of-truth] Worker WGSL payload comes from one validated
+        // Naga emission path, not parallel string emitters.
+        wgsl: nagaOutcome.wgsl,
+      },
+    };
+
+    const program = stripKernelRegistry(programWithValidatedWgsl);
     const topologyIds = collectProgramTopologyIds(program);
     return {
       kind: 'ok',
@@ -31,58 +62,61 @@ function toBackendResult(
   };
 }
 
+async function handleCompileMessage(message: CompileWorkerRequest): Promise<CompileWorkerResponse> {
+  const startMs = performance.now();
+  const { serializedPatch, frontendOptions, patchRevision, requestId } = message;
+
+  const decoded = deserializePatch(serializedPatch);
+  if (!decoded) {
+    return {
+      kind: 'workerError',
+      requestId,
+      patchRevision,
+      durationMs: Math.max(0, performance.now() - startMs),
+      message: 'Compile worker received invalid serialized patch payload',
+    };
+  }
+
+  const patch = decoded.patch;
+  const frontendResult = compileFrontend(patch, frontendOptions);
+  const backendResult = frontendResult.backendReady
+    ? await toBackendResult(
+        compileFromFrontend(frontendResult, {
+          // [LAW:single-enforcer] Compiler event emission remains owned by CompileOrchestrator.
+          // Worker compile uses an isolated no-listener hub for backend compile context.
+          events: new EventHub(),
+        }),
+      )
+    : null;
+
+  return {
+    kind: 'compiled',
+    requestId,
+    patchRevision,
+    durationMs: Math.max(0, performance.now() - startMs),
+    frontendResult,
+    backendResult,
+  };
+}
+
 self.onmessage = (event: MessageEvent<CompileWorkerRequest>) => {
   const message = event.data;
   if (!message || message.kind !== 'compile') {
     return;
   }
 
-  const startMs = performance.now();
-  const { serializedPatch, frontendOptions, patchRevision, requestId } = message;
-
-  try {
-    const decoded = deserializePatch(serializedPatch);
-    if (!decoded) {
+  void handleCompileMessage(message)
+    .then((response) => {
+      self.postMessage(response);
+    })
+    .catch((err) => {
       const response: CompileWorkerResponse = {
         kind: 'workerError',
-        requestId,
-        patchRevision,
-        durationMs: Math.max(0, performance.now() - startMs),
-        message: 'Compile worker received invalid serialized patch payload',
+        requestId: message.requestId,
+        patchRevision: message.patchRevision,
+        durationMs: 0,
+        message: err instanceof Error ? err.message : String(err),
       };
       self.postMessage(response);
-      return;
-    }
-
-    const patch = decoded.patch;
-    const frontendResult = compileFrontend(patch, frontendOptions);
-    const backendResult = frontendResult.backendReady
-      ? toBackendResult(
-          compileFromFrontend(frontendResult, {
-            // [LAW:single-enforcer] Compiler event emission remains owned by CompileOrchestrator.
-            // Worker compile uses an isolated no-listener hub for backend compile context.
-            events: new EventHub(),
-          }),
-        )
-      : null;
-
-    const response: CompileWorkerResponse = {
-      kind: 'compiled',
-      requestId,
-      patchRevision,
-      durationMs: Math.max(0, performance.now() - startMs),
-      frontendResult,
-      backendResult,
-    };
-    self.postMessage(response);
-  } catch (err) {
-    const response: CompileWorkerResponse = {
-      kind: 'workerError',
-      requestId,
-      patchRevision,
-      durationMs: Math.max(0, performance.now() - startMs),
-      message: err instanceof Error ? err.message : String(err),
-    };
-    self.postMessage(response);
-  }
+    });
 };


### PR DESCRIPTION
## Summary
- add a worker-consumed Naga bridge service (`NagaService`) with explicit boot and validation error surface
- add compile-time Naga compilation orchestration (`compileProgramWithNaga`) that maps validation errors back to compiler block IDs via lowering source-map
- add shim module integration (`compile_ir`) and route worker WGSL payload through that single boundary
- remove worker-side parallel WGSL source path by replacing `generatedComputeProgram.wgsl` with Naga-emitted WGSL only
- add focused tests for success path, missing artifact failure, and source-map error mapping

## Why
P2-3 requires a dedicated validation/emission layer between TS lowering output and runtime WGSL payloads. This change makes worker compilation consume `nagaLoweringProgram.module` as the canonical source, and fail as compile errors when validation fails.

## Validation
- `pnpm -s vitest run src/compiler/__tests__/naga-compile.test.ts src/services/__tests__/CompileWorkerClient.test.ts src/services/__tests__/compile-worker-clone-safety.test.ts`
- `pnpm -s typecheck`