### PR TITLE
WebGPU P4-1.2: tracked spy slot readback + mini-view freshness

### DIFF
--- a/src/services/DebugService.ts
+++ b/src/services/DebugService.ts
@@ -97,6 +97,11 @@ export interface DebugServiceIssue {
   readonly detail?: unknown;
 }
 
+export interface SpySlotReadbackMeta {
+  readonly capturedAtMs: number;
+  readonly frameId: number;
+}
+
 const MAX_DEBUG_ISSUES = 128;
 const ISSUE_THROTTLE_MS = 2000;
 
@@ -141,6 +146,14 @@ class DebugService {
 
   /** Reference counts for scalar history tracking keys (supports multiple observers). */
   private trackedHistoryRefs = new Map<string, number>();
+  /** Canonical key payload for trackedHistoryRefs entries (for remap-safe slot derivation). */
+  private trackedHistoryKeys = new Map<string, DebugTargetKey>();
+  /** Reference counts for tracked scalar slots used by spy readback selection. */
+  private trackedSpyScalarSlotRefs = new Map<ValueSlot, number>();
+  /** Active tracked scalar slots for spy probe reads. */
+  private trackedSpyScalarSlots = new Set<ValueSlot>();
+  /** Last async readback metadata by scalar slot. */
+  private spyReadbackMetaBySlot = new Map<ValueSlot, SpySlotReadbackMeta>();
 
   /** Global scalar history mode: pre-track mapped scalar history keys. */
   private autoTrackAllDebugData = false;
@@ -210,12 +223,14 @@ class DebugService {
     this.trackedFieldSlots.clear();
     this.trackedFieldSlotRefs.clear();
     this.fieldAccumulators.clear();
+    this.spyReadbackMetaBySlot.clear();
     this.runtimeStarted = false;
     // [LAW:one-source-of-truth] Arena belongs to ProgramState; clear stale ref on recompile.
     // setArenaRef() will restore it after this call in setupDebugProbe.
     this.arenaRef = null;
     this.historyService.onMappingChanged();
     this.syncGlobalDebugTracking();
+    this.rebuildTrackedSpyScalarSlots();
   }
 
   /**
@@ -226,6 +241,7 @@ class DebugService {
     this.portToSlotMap = map;
     this.historyService.onMappingChanged();
     this.syncGlobalDebugTracking();
+    this.rebuildTrackedSpyScalarSlots();
   }
 
   /**
@@ -351,7 +367,9 @@ class DebugService {
     const serialized = serializeKey(key);
     const refs = this.trackedHistoryRefs.get(serialized) ?? 0;
     this.trackedHistoryRefs.set(serialized, refs + 1);
+    this.trackedHistoryKeys.set(serialized, key);
     if (refs > 0) return;
+    this.trackSpyScalarSlotForKey(key);
     if (!this.globalHistoryKeys.has(serialized)) {
       this.historyService.track(key);
     }
@@ -365,6 +383,8 @@ class DebugService {
     const refs = this.trackedHistoryRefs.get(serialized) ?? 0;
     if (refs <= 1) {
       this.trackedHistoryRefs.delete(serialized);
+      this.trackedHistoryKeys.delete(serialized);
+      this.untrackSpyScalarSlotForKey(key);
       if (!this.globalHistoryKeys.has(serialized)) {
         this.historyService.untrack(key);
       }
@@ -386,6 +406,25 @@ class DebugService {
     this.scalarValues.set(slotId, value);
     this.scalarTapSlots.add(slotId);
     this.historyService.onSlotWrite(slotId, value);
+  }
+
+  /**
+   * Apply an async spy-readback scalar sample.
+   *
+   * [LAW:single-enforcer] DebugService is the only bridge that records async
+   * readback slot values and freshness metadata for UI consumption.
+   */
+  applySpyReadback(
+    slotId: ValueSlot,
+    value: number,
+    capturedAtMs: number,
+    frameId: number,
+  ): void {
+    this.runtimeStarted = true;
+    this.scalarValues.set(slotId, value);
+    this.scalarTapSlots.add(slotId);
+    this.historyService.onSlotWrite(slotId, value);
+    this.spyReadbackMetaBySlot.set(slotId, { capturedAtMs, frameId });
   }
 
   /**
@@ -563,6 +602,21 @@ class DebugService {
   }
 
   /**
+   * Return currently tracked scalar slots for low-rate spy readback.
+   */
+  getTrackedSpyScalarSlots(maxSlots: number = 16): readonly ValueSlot[] {
+    const limit = Math.max(1, Math.floor(maxSlots));
+    return Array.from(this.trackedSpyScalarSlots.values()).slice(0, limit);
+  }
+
+  /**
+   * Return latest async readback metadata for a scalar slot, if present.
+   */
+  getSlotSpyReadbackMeta(slotId: ValueSlot): SpySlotReadbackMeta | undefined {
+    return this.spyReadbackMetaBySlot.get(slotId);
+  }
+
+  /**
    * Clear all stored data.
    * Called when patch is unloaded or recompiled.
    */
@@ -576,7 +630,11 @@ class DebugService {
     this.trackedFieldSlots.clear();
     this.trackedFieldSlotRefs.clear();
     this.trackedHistoryRefs.clear();
+    this.trackedHistoryKeys.clear();
+    this.trackedSpyScalarSlotRefs.clear();
+    this.trackedSpyScalarSlots.clear();
     this.globalHistoryKeys.clear();
+    this.spyReadbackMetaBySlot.clear();
     this.fieldAccumulators.clear();
     this.unmappedEdges = [];
     this.runtimeStarted = false;
@@ -625,6 +683,7 @@ class DebugService {
         this.historyService.untrack(key);
       }
     }
+    this.rebuildTrackedSpyScalarSlots();
   }
 
   /**
@@ -633,7 +692,8 @@ class DebugService {
   private isScalarHistoryEligible(type: CanonicalType): boolean {
     const cardinality = requireInst(type.extent.cardinality, 'cardinality').kind;
     if (cardinality !== 'one') return false;
-    return getSampleEncoding(type.payload).sampleable;
+    const encoding = getSampleEncoding(type.payload);
+    return encoding.sampleable && encoding.stride === 1;
   }
 
   /**
@@ -646,6 +706,51 @@ class DebugService {
       blockId: portKey.slice(0, idx),
       portName: portKey.slice(idx + 1),
     };
+  }
+
+  private resolveDebugTargetMeta(key: DebugTargetKey): EdgeMetadata | undefined {
+    if (key.kind === 'edge') {
+      return this.edgeToSlotMap.get(key.edgeId);
+    }
+    return this.portToSlotMap.get(`${key.blockId}:${key.portName}`);
+  }
+
+  private trackSpyScalarSlotForKey(key: DebugTargetKey): void {
+    const meta = this.resolveDebugTargetMeta(key);
+    if (!meta || !this.isScalarHistoryEligible(meta.type)) {
+      return;
+    }
+    const refs = this.trackedSpyScalarSlotRefs.get(meta.slotId) ?? 0;
+    this.trackedSpyScalarSlotRefs.set(meta.slotId, refs + 1);
+    this.trackedSpyScalarSlots.add(meta.slotId);
+  }
+
+  private untrackSpyScalarSlotForKey(key: DebugTargetKey): void {
+    const meta = this.resolveDebugTargetMeta(key);
+    if (!meta || !this.isScalarHistoryEligible(meta.type)) {
+      return;
+    }
+    const refs = this.trackedSpyScalarSlotRefs.get(meta.slotId) ?? 0;
+    if (refs <= 1) {
+      this.trackedSpyScalarSlotRefs.delete(meta.slotId);
+      this.trackedSpyScalarSlots.delete(meta.slotId);
+      return;
+    }
+    this.trackedSpyScalarSlotRefs.set(meta.slotId, refs - 1);
+  }
+
+  private rebuildTrackedSpyScalarSlots(): void {
+    this.trackedSpyScalarSlotRefs.clear();
+    this.trackedSpyScalarSlots.clear();
+    for (const [serialized, key] of this.trackedHistoryKeys.entries()) {
+      const refs = this.trackedHistoryRefs.get(serialized) ?? 0;
+      if (refs <= 0) continue;
+      const meta = this.resolveDebugTargetMeta(key);
+      if (!meta || !this.isScalarHistoryEligible(meta.type)) continue;
+      const slotRefs = this.trackedSpyScalarSlotRefs.get(meta.slotId) ?? 0;
+      this.trackedSpyScalarSlotRefs.set(meta.slotId, slotRefs + refs);
+      this.trackedSpyScalarSlots.add(meta.slotId);
+    }
   }
 
   private recordIssue(issue: DebugServiceIssue): void {

--- a/src/services/RuntimeService.ts
+++ b/src/services/RuntimeService.ts
@@ -42,11 +42,11 @@ import {
 import { debugSettings } from '../settings/tokens/debug-settings';
 import { compilerFlagsSettings } from '../settings/tokens/compiler-flags-settings';
 import { appSettings } from '../settings/tokens/app-settings';
+import { arenaRead } from '../runtime/ArenaValueStore';
+import type { ValueSlot } from '../types';
 
 export interface RuntimeSpyReadbackEntry {
-  readonly exprId: number;
-  readonly slotId: number;
-  readonly component: number;
+  readonly slotId: ValueSlot;
   readonly value: number;
 }
 
@@ -95,7 +95,6 @@ export class RuntimeService {
   private spyReadbackTimer: ReturnType<typeof setTimeout> | null = null;
   private spyReadbackInFlight = false;
   private spyReadbackHz = 15;
-  private spyTrackedExprIds: number[] = [];
 
   constructor(
     private readonly store: RootStore,
@@ -125,17 +124,6 @@ export class RuntimeService {
   setSpyReadbackSink(onSpyReadback: ((packet: RuntimeSpyReadbackPacket) => void) | null): void {
     // [LAW:no-shared-mutable-globals] Spy readback delivery is explicit callback ownership.
     this.spyReadbackSink = onSpyReadback;
-    if (this.spyReadbackSink) {
-      this.startSpyReadbackLoop();
-    } else {
-      this.stopSpyReadbackLoop();
-    }
-  }
-
-  setSpyTrackedExprIds(exprIds: readonly number[]): void {
-    // [LAW:dataflow-not-control-flow] Probe selection is data-driven and can be
-    // updated without branching runtime frame execution.
-    this.spyTrackedExprIds = Array.from(exprIds);
   }
 
   private logWorkerFailure(err: unknown): void {
@@ -437,9 +425,7 @@ export class RuntimeService {
       this.animationState,
       this.handleAnimationLoopError,
     );
-    if (this.spyReadbackSink) {
-      this.startSpyReadbackLoop();
-    }
+    this.startSpyReadbackLoop();
 
     // Persist current patch immediately after initial compile
     // (covers the case where we loaded a default demo)
@@ -503,15 +489,13 @@ export class RuntimeService {
     if (this.spyReadbackInFlight) {
       return;
     }
-    if (!this.spyReadbackSink) {
-      return;
-    }
     this.spyReadbackInFlight = true;
     try {
       const packet = this.buildSpyReadbackPacket(performance.now());
       if (!packet || packet.entries.length === 0) {
         return;
       }
+      this.applySpyReadbackPacket(packet);
       // [LAW:dataflow-not-control-flow] Readback delivery is async fire-and-forget
       // and decoupled from the frame loop cadence.
       await Promise.resolve();
@@ -529,29 +513,27 @@ export class RuntimeService {
       return null;
     }
 
-    const scalarAddresses = table.scalarExprToArenaAddress;
-    if (scalarAddresses.size === 0) {
+    const trackedSlots = debugService.getTrackedSpyScalarSlots(16);
+    if (trackedSlots.length === 0) {
       return null;
     }
 
-    const selectedExprs =
-      this.spyTrackedExprIds.length > 0
-        ? this.spyTrackedExprIds
-        : Array.from(scalarAddresses.keys()).slice(0, 16);
-
     const entries: RuntimeSpyReadbackEntry[] = [];
-    for (const exprId of selectedExprs) {
-      const addr = scalarAddresses.get(exprId);
-      if (!addr) continue;
-      const arenaIndex = addr.arena.offset + addr.component;
-      const value = state.arena[arenaIndex];
+    for (const slotId of trackedSlots) {
+      const lookup = table.slotLookup.get(slotId);
+      if (!lookup || lookup.arena.laneCount !== 1 || lookup.arena.stride < 1) {
+        continue;
+      }
+      const value = arenaRead(state.arena, lookup.arena, 0, 0);
       if (!Number.isFinite(value)) continue;
       entries.push({
-        exprId,
-        slotId: addr.slot,
-        component: addr.component,
+        slotId,
         value,
       });
+    }
+
+    if (entries.length === 0) {
+      return null;
     }
 
     return {
@@ -559,5 +541,18 @@ export class RuntimeService {
       frameId: state.cache.frameId,
       entries,
     };
+  }
+
+  private applySpyReadbackPacket(packet: RuntimeSpyReadbackPacket): void {
+    // [LAW:single-enforcer] DebugService remains the single write boundary
+    // for async readback values consumed by UI/debug queries.
+    for (const entry of packet.entries) {
+      debugService.applySpyReadback(
+        entry.slotId,
+        entry.value,
+        packet.capturedAtMs,
+        packet.frameId,
+      );
+    }
   }
 }

--- a/src/services/__tests__/DebugService-spy-readback.test.ts
+++ b/src/services/__tests__/DebugService-spy-readback.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { debugService } from '../DebugService';
+import type { EdgeMetadata } from '../mapDebugEdges';
+import { FLOAT, VEC2, canonicalScalar } from '../../core/canonical-types';
+import { valueSlot } from '../../types';
+
+function edgeMeta(slot: number, type: ReturnType<typeof canonicalScalar>): EdgeMetadata {
+  return {
+    slotId: valueSlot(slot),
+    type,
+  };
+}
+
+describe('DebugService spy readback integration', () => {
+  beforeEach(() => {
+    debugService.clear();
+  });
+
+  afterEach(() => {
+    debugService.clear();
+  });
+
+  it('tracks scalar slots from tracked history keys with ref-count semantics', () => {
+    const key = { kind: 'edge' as const, edgeId: 'edge-1' };
+    const map = new Map<string, EdgeMetadata>([
+      ['edge-1', edgeMeta(5, canonicalScalar(FLOAT))],
+    ]);
+
+    debugService.setEdgeToSlotMap(map);
+    debugService.setPortToSlotMap(new Map());
+
+    expect(debugService.getTrackedSpyScalarSlots()).toEqual([]);
+
+    debugService.trackHistoryKey(key);
+    expect(debugService.getTrackedSpyScalarSlots()).toEqual([valueSlot(5)]);
+
+    debugService.trackHistoryKey(key);
+    expect(debugService.getTrackedSpyScalarSlots()).toEqual([valueSlot(5)]);
+
+    debugService.untrackHistoryKey(key);
+    expect(debugService.getTrackedSpyScalarSlots()).toEqual([valueSlot(5)]);
+
+    debugService.untrackHistoryKey(key);
+    expect(debugService.getTrackedSpyScalarSlots()).toEqual([]);
+  });
+
+  it('rejects non-scalar (stride>1) payloads from spy-slot tracking', () => {
+    const key = { kind: 'edge' as const, edgeId: 'edge-vec2' };
+    const map = new Map<string, EdgeMetadata>([
+      ['edge-vec2', edgeMeta(11, canonicalScalar(VEC2))],
+    ]);
+
+    debugService.setEdgeToSlotMap(map);
+    debugService.setPortToSlotMap(new Map());
+
+    debugService.trackHistoryKey(key);
+    expect(debugService.getTrackedSpyScalarSlots()).toEqual([]);
+  });
+
+  it('applies async spy readback value + metadata and avoids duplicate history writes on query', () => {
+    const key = { kind: 'edge' as const, edgeId: 'edge-readback' };
+    const slot = valueSlot(17);
+    const map = new Map<string, EdgeMetadata>([
+      ['edge-readback', edgeMeta(17, canonicalScalar(FLOAT))],
+    ]);
+
+    debugService.setEdgeToSlotMap(map);
+    debugService.setPortToSlotMap(new Map());
+    debugService.setArenaRef(
+      new Float32Array([42]),
+      new Map([[slot, { offset: 0, stride: 1, laneCount: 1, length: 1 }]]),
+    );
+    debugService.trackHistoryKey(key);
+
+    debugService.applySpyReadback(slot, 42, 1200, 9);
+
+    const value = debugService.tryGetEdgeValue('edge-readback');
+    expect(value).toMatchObject({ kind: 'scalar', value: 42, slotId: slot });
+
+    const meta = debugService.getSlotSpyReadbackMeta(slot);
+    expect(meta).toEqual({ capturedAtMs: 1200, frameId: 9 });
+
+    const history = debugService.historyService.getHistory(key);
+    expect(history).toBeTruthy();
+    expect(history!.writeIndex).toBe(1);
+    expect(history!.buffer[0]).toBe(42);
+  });
+});

--- a/src/services/__tests__/RuntimeService.spy-readback.test.ts
+++ b/src/services/__tests__/RuntimeService.spy-readback.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { RuntimeService } from '../RuntimeService';
+import { debugService } from '../DebugService';
+import type { EdgeMetadata } from '../mapDebugEdges';
+import { FLOAT, canonicalScalar } from '../../core/canonical-types';
+import { valueSlot } from '../../types';
+
+function edgeMeta(slot: number): EdgeMetadata {
+  return {
+    slotId: valueSlot(slot),
+    type: canonicalScalar(FLOAT),
+  };
+}
+
+describe('RuntimeService spy readback packet selection', () => {
+  beforeEach(() => {
+    debugService.clear();
+  });
+
+  afterEach(() => {
+    debugService.clear();
+  });
+
+  it('builds packets from tracked scalar slots only (no fallback derivation)', () => {
+    const runtime = new RuntimeService({} as any);
+    const trackedSlot = valueSlot(3);
+
+    debugService.setEdgeToSlotMap(new Map([
+      ['edge-tracked', edgeMeta(3)],
+    ]));
+    debugService.setPortToSlotMap(new Map());
+    debugService.trackHistoryKey({ kind: 'edge', edgeId: 'edge-tracked' });
+
+    (runtime as any).compileState.currentProgram = {
+      runtimeAddressTable: {
+        slotLookup: new Map([
+          [valueSlot(3), {
+            storage: 'f32',
+            offset: 3,
+            stride: 1,
+            slot: valueSlot(3),
+            type: canonicalScalar(FLOAT),
+            arena: { offset: 3, stride: 1, laneCount: 1, length: 1 },
+          }],
+          [valueSlot(4), {
+            storage: 'f32',
+            offset: 4,
+            stride: 1,
+            slot: valueSlot(4),
+            type: canonicalScalar(FLOAT),
+            arena: { offset: 4, stride: 1, laneCount: 1, length: 1 },
+          }],
+        ]),
+      },
+    };
+    (runtime as any).compileState.currentState = {
+      arena: new Float32Array([0, 0, 0, 31, 77]),
+      cache: { frameId: 22 },
+    };
+
+    const packet = (runtime as any).buildSpyReadbackPacket(500);
+    expect(packet).toBeTruthy();
+    if (!packet) {
+      throw new Error('Expected spy readback packet');
+    }
+    expect(packet.frameId).toBe(22);
+    expect(packet.entries).toEqual([
+      { slotId: trackedSlot, value: 31 },
+    ]);
+  });
+
+  it('returns null when there are no tracked debug slots', () => {
+    const runtime = new RuntimeService({} as any);
+
+    (runtime as any).compileState.currentProgram = {
+      runtimeAddressTable: {
+        slotLookup: new Map([
+          [valueSlot(1), {
+            storage: 'f32',
+            offset: 1,
+            stride: 1,
+            slot: valueSlot(1),
+            type: canonicalScalar(FLOAT),
+            arena: { offset: 1, stride: 1, laneCount: 1, length: 1 },
+          }],
+        ]),
+      },
+    };
+    (runtime as any).compileState.currentState = {
+      arena: new Float32Array([0, 99]),
+      cache: { frameId: 3 },
+    };
+
+    const packet = (runtime as any).buildSpyReadbackPacket(100);
+    expect(packet).toBeNull();
+  });
+});

--- a/src/ui/debug-viz/DebugMiniView.tsx
+++ b/src/ui/debug-viz/DebugMiniView.tsx
@@ -12,7 +12,13 @@ import React, { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStores } from '../../stores';
 import { useDebugMiniView, type MiniViewData } from './useDebugMiniView';
-import { getValueRenderer } from './ValueRenderer';
+import {
+  getValueRenderer,
+  getSpyReadbackAgeMs,
+  getSpyReadbackFreshness,
+  withSpyReadbackMeta,
+  type SpyReadbackMeta,
+} from './ValueRenderer';
 import { Sparkline } from './charts/Sparkline';
 import { DistributionBar } from './charts/DistributionBar';
 import { WarmupIndicator } from './charts/WarmupIndicator';
@@ -151,10 +157,11 @@ export function formatTypeLine(type: CanonicalType): string {
   return `${payloadUnit} · ${card} · cont`;
 }
 
-export function OneValueSection({ value, meta, history }: {
+export function OneValueSection({ value, meta, history, spyReadbackMeta }: {
   value: EdgeValueResult | null;
   meta: EdgeMetadata;
   history: { buffer: Float32Array; writeIndex: number; capacity: number; stride: 0 | 1 | 2 | 3 | 4; filled: boolean } | null;
+  spyReadbackMeta: SpyReadbackMeta | null;
 }): React.ReactElement {
   const children: React.ReactElement[] = [];
 
@@ -199,9 +206,31 @@ export function OneValueSection({ value, meta, history }: {
       stride: 1,
     };
     const renderer = getValueRenderer(meta.type);
-    children.push(
-      React.createElement('div', { key: 'value' }, renderer.renderFull(sample))
+    const renderedValue = withSpyReadbackMeta(
+      renderer.renderFull(sample),
+      spyReadbackMeta ?? undefined,
     );
+    children.push(
+      React.createElement('div', { key: 'value' }, renderedValue)
+    );
+    if (spyReadbackMeta) {
+      const freshness = getSpyReadbackFreshness(spyReadbackMeta);
+      const ageMs = Math.round(getSpyReadbackAgeMs(spyReadbackMeta));
+      children.push(
+        React.createElement(
+          'div',
+          {
+            key: 'spy-readback-meta',
+            style: {
+              marginTop: '2px',
+              fontSize: '10px',
+              color: freshness === 'fresh' ? '#4ecdc4' : '#ffb86c',
+            },
+          },
+          `readback: ${freshness} (${ageMs}ms)`,
+        )
+      );
+    }
   } else {
     children.push(
       React.createElement('div', { key: 'value', style: { color: '#555' } }, 'awaiting value...')
@@ -456,6 +485,7 @@ export function DebugEdgeValueDisplay({ data }: { data: MiniViewData }): React.R
           value: data.value,
           meta: data.meta,
           history: data.history,
+          spyReadbackMeta: data.spyReadbackMeta,
         })
       : React.createElement(FieldValueSection, {
           value: data.value,

--- a/src/ui/debug-viz/useDebugMiniView.ts
+++ b/src/ui/debug-viz/useDebugMiniView.ts
@@ -13,6 +13,7 @@ import type { EdgeMetadata } from '../../services/mapDebugEdges';
 import { requireInst } from '../../core/canonical-types';
 import type { DebugTargetKey, HistoryView, BufferHistoryView, FieldHistoryView } from './types';
 import type { TrackedEntry } from './HistoryService';
+import type { SpyReadbackMeta } from './ValueRenderer';
 
 /** Poll interval for value updates (ms). */
 const POLL_INTERVAL_MS = 250;
@@ -37,6 +38,8 @@ export interface MiniViewData {
   fieldInstanceHistory: HistoryView | null;
   /** Buffer history for raster heatmap (null if not a field or not tracked) */
   fieldBufferHistory: BufferHistoryView | null;
+  /** Latest async readback freshness metadata for scalar slots */
+  spyReadbackMeta: SpyReadbackMeta | null;
 }
 
 type MiniViewTarget =
@@ -75,6 +78,7 @@ function useDebugTargetMiniView(
 ): MiniViewData | null {
   const [value, setValue] = useState<EdgeValueResult | null>(null);
   const [tick, setTick] = useState(0);
+  const [nowMs, setNowMs] = useState(() => performance.now());
 
   const edgeId = target?.kind === 'edge' ? target.edgeId : null;
   const blockId = target?.kind === 'port' ? target.blockId : null;
@@ -121,6 +125,7 @@ function useDebugTargetMiniView(
         ? debugService.tryGetEdgeValue(edgeId)
         : debugService.tryGetPortValue(blockId!, portName!);
       setValue(result ?? null);
+      setNowMs(performance.now());
       setTick(t => t + 1); // Force Sparkline re-render
     };
 
@@ -143,6 +148,12 @@ function useDebugTargetMiniView(
   const fieldBufferHistory = cardinality === 'many'
     ? debugService.getFieldBufferHistory(meta.slotId) ?? null
     : null;
+  const slotSpyReadback = cardinality === 'one'
+    ? debugService.getSlotSpyReadbackMeta(meta.slotId)
+    : undefined;
+  const spyReadbackMeta = slotSpyReadback
+    ? { capturedAtMs: slotSpyReadback.capturedAtMs, nowMs }
+    : null;
 
   return {
     key,
@@ -153,6 +164,7 @@ function useDebugTargetMiniView(
     fieldHistory,
     fieldInstanceHistory,
     fieldBufferHistory,
+    spyReadbackMeta,
   };
 }
 


### PR DESCRIPTION
## Summary
- wire RuntimeService spy readback packet generation to `DebugService` tracked scalar slots only
- remove fallback derivation for untracked spy probes (`no tracked slots => no packet`)
- apply async readback samples into `DebugService` as the single value/freshness write boundary
- extend mini-view data/rendering to display readback freshness state and age
- add focused tests for DebugService spy-readback behavior and RuntimeService slot selection

## Bead
- oscilla-animator-v2-tjdc.2

## Verification
- `pnpm -s test -- src/services/__tests__/DebugService-spy-readback.test.ts src/services/__tests__/RuntimeService.spy-readback.test.ts src/ui/debug-viz/ValueRenderer.test.ts`
- `pnpm -s typecheck`
- `BEAD_ID=oscilla-animator-v2-tjdc.2 scripts/enforce-webgpu-bead-readiness.sh`
