### PR TITLE
[oscilla-animator-v2-zq12.3] P3-3 draw-prep autonomous logistics

### DIFF
--- a/src/compiler/__tests__/steel-thread-dual-topology.test.ts
+++ b/src/compiler/__tests__/steel-thread-dual-topology.test.ts
@@ -89,11 +89,9 @@ describe('Steel Thread - Dual Topology with Scale', () => {
     expect(result.program.drawPrepProgram?.sinks.length).toBe(2);
     expect(result.program.drawPrepProgram?.sinks.map((sink) => sink.sinkIndex)).toEqual([0, 1]);
     expect(result.program.drawPrepProgram?.sinks.map((sink) => sink.indirectRecordIndex)).toEqual([0, 1]);
-    expect(result.program.drawPrepProgram?.wgsl).toContain('DRAW_SINK_0_RECORD');
-    expect(result.program.drawPrepProgram?.wgsl).toContain('DRAW_SINK_1_RECORD');
-    expect(result.program.drawPrepProgram?.wgsl).toContain('INSTANCE_COUNT: u32 = 2u');
-    expect(result.program.drawPrepProgram?.wgsl).toContain('INSTANCE_COUNT: u32 = 3u');
-    expect(result.program.drawPrepProgram?.wgsl).toContain('fn resolveInstanceCount');
+    expect(result.program.drawPrepProgram?.wgsl).toContain('@compute @workgroup_size(64)');
+    expect(result.program.drawPrepProgram?.wgsl).toContain('@group(0) @binding(1) var<storage, read> drawPrepRecords: array<u32>;');
+    expect(result.program.drawPrepProgram?.wgsl).toContain('let recordCount = drawPrepParams.v0.x;');
 
     const topologyIds = renderSteps.flatMap((step) => {
       if (step.shape.k === 'oneHandle') {

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -691,67 +691,35 @@ function buildDrawPrepProgram(scheduleIR: ScheduleIR): DrawPrepProgramIR {
   const wgslLines: string[] = [
     '// Auto-generated draw-prep WGSL (v3 stage-3).',
     'struct DrawPrepParams {',
-    '  // v0 = [indexCount, instanceCount, firstIndex, baseVertexBits]',
+    '  // v0 = [recordCount, maxRecords, _, _]',
     '  v0: vec4<u32>,',
-    '  // v1 = [firstInstance, recordIndex, maxRecords, _]',
-    '  v1: vec4<u32>,',
     '};',
     '',
     '@group(0) @binding(0) var<storage, read_write> indirectArgs: array<u32>;',
-    '@group(0) @binding(1) var<uniform> drawPrepParams: DrawPrepParams;',
+    '@group(0) @binding(1) var<storage, read> drawPrepRecords: array<u32>;',
+    '@group(0) @binding(2) var<uniform> drawPrepParams: DrawPrepParams;',
     '',
-    'const INDIRECT_ARGS_WORDS: u32 = 5u;',
+    'const DRAW_PREP_RECORD_WORDS: u32 = 5u;',
     '',
   ];
-  // [LAW:one-source-of-truth] Draw-prep sink constants are emitted from one
-  // canonical compiler sink table used by runtime and shader generation.
-  for (const sink of sinks) {
-    const instanceCountLiteral =
-      sink.instanceCountMode === 'static'
-        ? `${sink.staticInstanceCount ?? 0}u`
-        : '/* dynamic instance count */ 0u';
-    const isStaticLiteral = sink.instanceCountMode === 'static' ? '1u' : '0u';
-    wgslLines.push(`const DRAW_SINK_${sink.sinkIndex}_RECORD: u32 = ${sink.indirectRecordIndex}u;`);
-    wgslLines.push(`const DRAW_SINK_${sink.sinkIndex}_IS_STATIC: u32 = ${isStaticLiteral};`);
-    wgslLines.push(`const DRAW_SINK_${sink.sinkIndex}_INSTANCE_COUNT: u32 = ${instanceCountLiteral};`);
-  }
+  // [LAW:one-source-of-truth] Draw-prep writes consume one canonical manifest
+  // record schema so compiler/runtime share a single indirect-args contract.
   wgslLines.push(
-    '',
-    'fn resolveInstanceCount(recordIndex: u32, fallbackCount: u32) -> u32 {',
-    '  var count = fallbackCount;',
-    '  switch (recordIndex) {',
-  );
-  for (const sink of sinks) {
-    wgslLines.push(
-      `    case DRAW_SINK_${sink.sinkIndex}_RECORD: {`,
-      `      count = select(count, DRAW_SINK_${sink.sinkIndex}_INSTANCE_COUNT, DRAW_SINK_${sink.sinkIndex}_IS_STATIC == 1u);`,
-      '    }',
-    );
-  }
-  wgslLines.push(
-    '    default: {}',
-    '  }',
-    '  return count;',
-    '}',
-    '',
-    '@compute @workgroup_size(1)',
+    '@compute @workgroup_size(64)',
     'fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {',
-    '  if (gid.x > 0u) {',
+    '  let recordIndex = gid.x;',
+    '  let recordCount = drawPrepParams.v0.x;',
+    '  let maxRecords = drawPrepParams.v0.y;',
+    '  if (recordIndex >= recordCount || recordIndex >= maxRecords) {',
     '    return;',
     '  }',
     '',
-    '  let recordIndex = drawPrepParams.v1.y;',
-    '  let maxRecords = drawPrepParams.v1.z;',
-    '  if (recordIndex >= maxRecords) {',
-    '    return;',
-    '  }',
-    '',
-    '  let base = recordIndex * INDIRECT_ARGS_WORDS;',
-    '  indirectArgs[base + 0u] = drawPrepParams.v0.x; // indexCount',
-    '  indirectArgs[base + 1u] = resolveInstanceCount(recordIndex, drawPrepParams.v0.y); // instanceCount',
-    '  indirectArgs[base + 2u] = drawPrepParams.v0.z; // firstIndex',
-    '  indirectArgs[base + 3u] = drawPrepParams.v0.w; // baseVertex bits',
-    '  indirectArgs[base + 4u] = drawPrepParams.v1.x; // firstInstance',
+    '  let base = recordIndex * DRAW_PREP_RECORD_WORDS;',
+    '  indirectArgs[base + 0u] = drawPrepRecords[base + 0u]; // indexCount',
+    '  indirectArgs[base + 1u] = drawPrepRecords[base + 1u]; // instanceCount',
+    '  indirectArgs[base + 2u] = drawPrepRecords[base + 2u]; // firstIndex',
+    '  indirectArgs[base + 3u] = drawPrepRecords[base + 3u]; // baseVertex bits',
+    '  indirectArgs[base + 4u] = drawPrepRecords[base + 4u]; // firstInstance',
     '}',
   );
   return { sinks, wgsl: wgslLines.join('\n') };

--- a/src/render/webgpu/WebGPURenderer.ts
+++ b/src/render/webgpu/WebGPURenderer.ts
@@ -243,9 +243,12 @@ class WebGPUDrawPrepRuntime {
   private pipeline: any;
   private activeShaderCode: string;
   private readonly paramsBuffer: any;
+  private recordsBuffer: any;
+  private recordsCapacityWords = WEBGPU_RENDER_CONTRACT.drawPrepRecordWords;
   private readonly paramsStaging = new Uint32Array(WEBGPU_RENDER_CONTRACT.drawPrepParamsU32);
   private activeBindGroup: any | null = null;
   private activeIndirectBuffer: any | null = null;
+  private activeRecordsBuffer: any | null = null;
   // [LAW:single-enforcer] Hot-swap pending pipeline follows P2-1 async protocol.
   private pendingPipeline: any | null = null;
   private shaderGeneration = 0;
@@ -256,6 +259,10 @@ class WebGPUDrawPrepRuntime {
     this.paramsBuffer = device.createBuffer({
       size: WEBGPU_RENDER_CONTRACT.drawPrepParamsU32 * Uint32Array.BYTES_PER_ELEMENT,
       usage: GPU_BUFFER_USAGE.UNIFORM | GPU_BUFFER_USAGE.COPY_DST,
+    });
+    this.recordsBuffer = device.createBuffer({
+      size: WEBGPU_RENDER_CONTRACT.drawPrepRecordWords * Uint32Array.BYTES_PER_ELEMENT,
+      usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST,
     });
   }
 
@@ -285,6 +292,7 @@ class WebGPUDrawPrepRuntime {
       // Invalidate cached bind group since pipeline layout may have changed.
       this.activeBindGroup = null;
       this.activeIndirectBuffer = null;
+      this.activeRecordsBuffer = null;
     }
   }
 
@@ -319,7 +327,11 @@ class WebGPUDrawPrepRuntime {
   }
 
   private getOrCreateBindGroup(indirectBuffer: any): any {
-    if (this.activeBindGroup && this.activeIndirectBuffer === indirectBuffer) {
+    if (
+      this.activeBindGroup &&
+      this.activeIndirectBuffer === indirectBuffer &&
+      this.activeRecordsBuffer === this.recordsBuffer
+    ) {
       return this.activeBindGroup;
     }
 
@@ -331,6 +343,10 @@ class WebGPUDrawPrepRuntime {
           resource: { buffer: indirectBuffer },
         },
         {
+          binding: WEBGPU_RENDER_CONTRACT.drawPrepRecordBinding,
+          resource: { buffer: this.recordsBuffer },
+        },
+        {
           binding: WEBGPU_RENDER_CONTRACT.drawPrepParamsBinding,
           resource: { buffer: this.paramsBuffer },
         },
@@ -338,26 +354,56 @@ class WebGPUDrawPrepRuntime {
     });
     this.activeBindGroup = bindGroup;
     this.activeIndirectBuffer = indirectBuffer;
+    this.activeRecordsBuffer = this.recordsBuffer;
     return bindGroup;
+  }
+
+  private ensureRecordsCapacity(requiredWords: number): void {
+    if (requiredWords <= this.recordsCapacityWords) {
+      return;
+    }
+
+    let nextCapacityWords = this.recordsCapacityWords;
+    while (nextCapacityWords < requiredWords) {
+      nextCapacityWords *= 2;
+    }
+
+    const nextBuffer = this.device.createBuffer({
+      size: nextCapacityWords * Uint32Array.BYTES_PER_ELEMENT,
+      usage: GPU_BUFFER_USAGE.STORAGE | GPU_BUFFER_USAGE.COPY_DST,
+    });
+    this.recordsBuffer.destroy();
+    this.recordsBuffer = nextBuffer;
+    this.recordsCapacityWords = nextCapacityWords;
+    this.activeBindGroup = null;
+    this.activeRecordsBuffer = null;
   }
 
   step(
     commandEncoder: any,
     indirectBuffer: any,
-    recordIndex: number,
-    maxRecords: number,
-    indexCount: number,
-    instanceCount: number,
-    firstInstance: number,
+    drawPrepRecords: Uint32Array,
+    recordCount: number,
   ): void {
-    this.paramsStaging[0] = indexCount >>> 0;
-    this.paramsStaging[1] = instanceCount >>> 0;
-    this.paramsStaging[2] = 0; // firstIndex
-    this.paramsStaging[3] = 0; // baseVertex
-    this.paramsStaging[4] = firstInstance >>> 0;
-    this.paramsStaging[5] = recordIndex >>> 0;
-    this.paramsStaging[6] = maxRecords >>> 0;
-    this.paramsStaging[7] = 0;
+    const clampedRecordCount = Math.max(0, recordCount >>> 0);
+    const requiredWords = Math.max(
+      WEBGPU_RENDER_CONTRACT.drawPrepRecordWords,
+      clampedRecordCount * WEBGPU_RENDER_CONTRACT.drawPrepRecordWords
+    );
+    this.ensureRecordsCapacity(requiredWords);
+
+    if (clampedRecordCount > 0) {
+      this.device.queue.writeBuffer(
+        this.recordsBuffer,
+        0,
+        drawPrepRecords.subarray(0, clampedRecordCount * WEBGPU_RENDER_CONTRACT.drawPrepRecordWords)
+      );
+    }
+
+    this.paramsStaging[0] = clampedRecordCount;
+    this.paramsStaging[1] = this.recordsCapacityWords / WEBGPU_RENDER_CONTRACT.drawPrepRecordWords;
+    this.paramsStaging[2] = 0;
+    this.paramsStaging[3] = 0;
     this.device.queue.writeBuffer(this.paramsBuffer, 0, this.paramsStaging);
 
     const bindGroup = this.getOrCreateBindGroup(indirectBuffer);
@@ -365,12 +411,14 @@ class WebGPUDrawPrepRuntime {
     const pass = commandEncoder.beginComputePass();
     pass.setPipeline(this.pipeline);
     pass.setBindGroup(WEBGPU_RENDER_CONTRACT.drawPrepBindGroup, bindGroup);
-    pass.dispatchWorkgroups(DRAW_PREP_WORKGROUP_SIZE);
+    const workgroups = Math.max(1, Math.ceil(clampedRecordCount / DRAW_PREP_WORKGROUP_SIZE));
+    pass.dispatchWorkgroups(workgroups);
     pass.end();
   }
 
   dispose(): void {
     this.paramsBuffer.destroy();
+    this.recordsBuffer.destroy();
   }
 }
 
@@ -392,6 +440,7 @@ export class WebGPURenderer {
   private topologyBankBindGroup: any;
   private indirectArgsBuffer: any;
   private indirectArgsCapacityRecords = 1;
+  private drawPrepRecordStaging = new Uint32Array(WEBGPU_RENDER_CONTRACT.drawPrepRecordWords);
   private topologyBankBuffer: any;
   private topologyBankCapacityWords = 1;
   private topologyBankRevision = -1;
@@ -559,17 +608,11 @@ export class WebGPURenderer {
       );
     }
     this.ensureIndirectArgsCapacity(drawPlan.length);
-    for (const prepared of drawPlan) {
-      this.drawPrepRuntime.step(
-        commandEncoder,
-        this.indirectArgsBuffer,
-        prepared.indirectRecordIndex,
-        this.indirectArgsCapacityRecords,
-        prepared.mesh.indexCount,
-        prepared.instanceCount,
-        prepared.firstInstance,
-      );
-    }
+    this.ensureDrawPrepRecordCapacity(drawPlan.length);
+    this.packDrawPrepRecords(drawPlan);
+    // [LAW:dataflow-not-control-flow] Draw-prep dispatch runs once per frame;
+    // per-record variability is encoded in the manifest buffer, not control flow.
+    this.drawPrepRuntime.step(commandEncoder, this.indirectArgsBuffer, this.drawPrepRecordStaging, drawPlan.length);
 
     const pass = commandEncoder.beginRenderPass({
       colorAttachments: [
@@ -782,6 +825,32 @@ export class WebGPURenderer {
       this.indirectArgsBuffer,
       prepared.indirectRecordIndex * WEBGPU_RENDER_CONTRACT.indirectArgsBytes,
     );
+  }
+
+  private ensureDrawPrepRecordCapacity(requiredRecords: number): void {
+    const recordWords = WEBGPU_RENDER_CONTRACT.drawPrepRecordWords;
+    const currentCapacityRecords = this.drawPrepRecordStaging.length / recordWords;
+    if (requiredRecords <= currentCapacityRecords) {
+      return;
+    }
+
+    let nextCapacityRecords = Math.max(1, currentCapacityRecords);
+    while (nextCapacityRecords < requiredRecords) {
+      nextCapacityRecords *= 2;
+    }
+    this.drawPrepRecordStaging = new Uint32Array(nextCapacityRecords * recordWords);
+  }
+
+  private packDrawPrepRecords(drawPlan: readonly PreparedDrawPathOp[]): void {
+    const recordWords = WEBGPU_RENDER_CONTRACT.drawPrepRecordWords;
+    for (const prepared of drawPlan) {
+      const base = prepared.indirectRecordIndex * recordWords;
+      this.drawPrepRecordStaging[base] = prepared.mesh.indexCount >>> 0;
+      this.drawPrepRecordStaging[base + 1] = prepared.instanceCount >>> 0;
+      this.drawPrepRecordStaging[base + 2] = 0; // firstIndex
+      this.drawPrepRecordStaging[base + 3] = 0; // baseVertex bits
+      this.drawPrepRecordStaging[base + 4] = prepared.firstInstance >>> 0;
+    }
   }
 
   private countPlannedInstances(drawPlan: readonly PreparedDrawPathOp[]): number {

--- a/src/render/webgpu/__tests__/WebGPURenderer.test.ts
+++ b/src/render/webgpu/__tests__/WebGPURenderer.test.ts
@@ -103,12 +103,13 @@ function createFakeWebGPUEnvironment() {
 function collectDrawPrepBindGroupCalls(createBindGroupMock: { mock: { calls: unknown[][] } }): unknown[][] {
   return createBindGroupMock.mock.calls.filter((call: unknown[]) => {
     const descriptor = call[0] as { entries?: Array<{ binding: number }> };
-    if (!descriptor.entries || descriptor.entries.length !== 2) {
+    if (!descriptor.entries || descriptor.entries.length !== 3) {
       return false;
     }
     return (
       descriptor.entries[0]?.binding === WEBGPU_RENDER_CONTRACT.drawPrepIndirectBinding &&
-      descriptor.entries[1]?.binding === WEBGPU_RENDER_CONTRACT.drawPrepParamsBinding
+      descriptor.entries[1]?.binding === WEBGPU_RENDER_CONTRACT.drawPrepRecordBinding &&
+      descriptor.entries[2]?.binding === WEBGPU_RENDER_CONTRACT.drawPrepParamsBinding
     );
   });
 }
@@ -335,12 +336,21 @@ describe('WebGPURenderer', () => {
     renderer.render(makeRenderInput([], { timeMs: 16 }));
 
     const computeBindGroupDescriptors = env.device.createBindGroup.mock.calls
-      .map(([descriptor]: [unknown]) => descriptor as { entries: Array<{ binding: number }> })
-      .filter((descriptor) => descriptor.entries.length === 3);
+      .map(([descriptor]: [unknown]) => descriptor as {
+        entries: Array<{ binding: number; resource: { buffer: { descriptor?: { size?: number } } } }>;
+      })
+      .filter((descriptor) =>
+        descriptor.entries.length === 3 &&
+        descriptor.entries[0]?.resource?.buffer?.descriptor?.size ===
+          WEBGPU_RENDER_CONTRACT.inputHeaderBytes + WEBGPU_RENDER_CONTRACT.simulationCapacity * 16
+      );
     expect(computeBindGroupDescriptors.length).toBe(2);
 
-    const firstFrameBindGroup = env.computePass.setBindGroup.mock.calls[0]?.[1];
-    const secondFrameBindGroup = env.computePass.setBindGroup.mock.calls[1]?.[1];
+    const simulationBindGroups = env.computePass.setBindGroup.mock.calls
+      .map((args: unknown[]) => args[1])
+      .filter((bindGroup: unknown) => computeBindGroupDescriptors.includes(bindGroup as never));
+    const firstFrameBindGroup = simulationBindGroups[0];
+    const secondFrameBindGroup = simulationBindGroups[1];
     expect(firstFrameBindGroup).toBe(computeBindGroupDescriptors[0]);
     expect(secondFrameBindGroup).toBe(computeBindGroupDescriptors[1]);
     expect(firstFrameBindGroup).not.toBe(secondFrameBindGroup);
@@ -363,8 +373,14 @@ describe('WebGPURenderer', () => {
     }));
 
     const computeBindGroupDescriptors = env.device.createBindGroup.mock.calls
-      .map(([descriptor]: [unknown]) => descriptor as { entries: Array<{ resource: { buffer: unknown } }> })
-      .filter((descriptor) => descriptor.entries.length === 3);
+      .map(([descriptor]: [unknown]) => descriptor as {
+        entries: Array<{ resource: { buffer: { descriptor?: { size?: number } } } }>;
+      })
+      .filter((descriptor) =>
+        descriptor.entries.length === 3 &&
+        descriptor.entries[0]?.resource?.buffer?.descriptor?.size ===
+          WEBGPU_RENDER_CONTRACT.inputHeaderBytes + WEBGPU_RENDER_CONTRACT.simulationCapacity * 16
+      );
     const firstFrameReadBuffer = computeBindGroupDescriptors[0]?.entries[0]?.resource.buffer;
     expect(firstFrameReadBuffer).toBeDefined();
 
@@ -397,8 +413,14 @@ describe('WebGPURenderer', () => {
     await createWebGPURenderer(env.canvas);
 
     const computeBindGroupDescriptors = env.device.createBindGroup.mock.calls
-      .map(([descriptor]: [unknown]) => descriptor as { entries: Array<{ resource: { buffer: unknown } }> })
-      .filter((descriptor) => descriptor.entries.length === 3);
+      .map(([descriptor]: [unknown]) => descriptor as {
+        entries: Array<{ resource: { buffer: { descriptor?: { size?: number } } } }>;
+      })
+      .filter((descriptor) =>
+        descriptor.entries.length === 3 &&
+        descriptor.entries[0]?.resource?.buffer?.descriptor?.size ===
+          WEBGPU_RENDER_CONTRACT.inputHeaderBytes + WEBGPU_RENDER_CONTRACT.simulationCapacity * 16
+      );
     expect(computeBindGroupDescriptors.length).toBe(2);
 
     for (const descriptor of computeBindGroupDescriptors) {
@@ -416,8 +438,10 @@ describe('WebGPURenderer', () => {
 
     expect(env.renderPass.drawIndexedIndirect).toHaveBeenCalledTimes(1);
     const cpuIndirectArgsWrite = env.device.queue.writeBuffer.mock.calls.find((args: unknown[]) => {
+      const targetBuffer = args[0] as { descriptor?: { usage?: number } };
       const data = args[2];
-      return data instanceof Uint32Array && data.length === 5;
+      const writesIndirectBuffer = ((targetBuffer?.descriptor?.usage ?? 0) & 0x0100) !== 0;
+      return writesIndirectBuffer && data instanceof Uint32Array;
     });
     expect(cpuIndirectArgsWrite).toBeUndefined();
     expect(env.device.createCommandEncoder).toHaveBeenCalledTimes(1);
@@ -598,8 +622,22 @@ describe('WebGPURenderer', () => {
       }),
     ]));
 
-    // First compute dispatch is simulation pass (draw-prep dispatches are fixed-size 1).
+    // First compute dispatch is simulation pass (draw-prep dispatch follows as second dispatch).
     expect(env.computePass.dispatchWorkgroups.mock.calls[0]?.[0]).toBe(2);
+  });
+
+  it('dispatches draw-prep once per frame with ceil(renderRecordCount/64) workgroups', async () => {
+    const env = createFakeWebGPUEnvironment();
+    setNavigatorGpu(env.gpu);
+    const renderer = await createWebGPURenderer(env.canvas);
+    const topologyId = makeSimpleTopology('webgpu-draw-prep-workgroups-topology');
+    const opCount = 65;
+    const ops = Array.from({ length: opCount }, () => makeDrawOp(topologyId));
+
+    renderer.render(makeRenderInput(ops));
+
+    expect(env.computePass.dispatchWorkgroups).toHaveBeenCalledTimes(2);
+    expect(env.computePass.dispatchWorkgroups.mock.calls[1]?.[0]).toBe(2);
   });
 
   it('fails fast when simulation instance count exceeds contract capacity', async () => {
@@ -675,9 +713,17 @@ describe('WebGPURenderer', () => {
     makeSimpleTopology('webgpu-revision-gate-a');
     const renderer = await createWebGPURenderer(env.canvas);
 
+    const topologyBuffers = env.device.createBindGroup.mock.calls
+      .map(([descriptor]: [unknown]) => descriptor as { entries?: Array<{ binding: number; resource: { buffer: unknown } }> })
+      .filter((descriptor) => descriptor.entries?.length === 1)
+      .filter((descriptor) => descriptor.entries?.[0]?.binding === WEBGPU_RENDER_CONTRACT.topologyBankBinding)
+      .map((descriptor) => descriptor.entries?.[0]?.resource.buffer);
+
     env.device.queue.writeBuffer.mockClear();
     renderer.render(makeRenderInput([], { timeMs: 0 }));
-    const unchangedRevisionWrites = env.device.queue.writeBuffer.mock.calls.filter((args: unknown[]) => args[2] instanceof Uint32Array);
+    const unchangedRevisionWrites = env.device.queue.writeBuffer.mock.calls.filter((args: unknown[]) =>
+      topologyBuffers.includes(args[0]) && args[2] instanceof Uint32Array
+    );
     expect(unchangedRevisionWrites).toHaveLength(0);
 
     const revisionBefore = getTopologyRegistryRevision();
@@ -693,7 +739,14 @@ describe('WebGPURenderer', () => {
 
     env.device.queue.writeBuffer.mockClear();
     renderer.render(makeRenderInput([], { timeMs: 16 }));
-    const changedRevisionWrites = env.device.queue.writeBuffer.mock.calls.filter((args: unknown[]) => args[2] instanceof Uint32Array);
+    const topologyBuffersAfter = env.device.createBindGroup.mock.calls
+      .map(([descriptor]: [unknown]) => descriptor as { entries?: Array<{ binding: number; resource: { buffer: unknown } }> })
+      .filter((descriptor) => descriptor.entries?.length === 1)
+      .filter((descriptor) => descriptor.entries?.[0]?.binding === WEBGPU_RENDER_CONTRACT.topologyBankBinding)
+      .map((descriptor) => descriptor.entries?.[0]?.resource.buffer);
+    const changedRevisionWrites = env.device.queue.writeBuffer.mock.calls.filter((args: unknown[]) =>
+      topologyBuffersAfter.includes(args[0]) && args[2] instanceof Uint32Array
+    );
     expect(changedRevisionWrites.length).toBeGreaterThan(0);
   });
 
@@ -752,19 +805,20 @@ describe('WebGPURenderer', () => {
     const customDrawPrepWgsl = [
       'struct DrawPrepParams {',
       '  v0: vec4<u32>;',
-      '  v1: vec4<u32>;',
       '};',
       '@group(0) @binding(0) var<storage, read_write> indirectArgs: array<u32>;',
-      '@group(0) @binding(1) var<uniform> drawPrepParams: DrawPrepParams;',
-      '@compute @workgroup_size(1)',
+      '@group(0) @binding(1) var<storage, read> drawPrepRecords: array<u32>;',
+      '@group(0) @binding(2) var<uniform> drawPrepParams: DrawPrepParams;',
+      '@compute @workgroup_size(64)',
       'fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {',
-      '  if (gid.x > 0u) { return; }',
-      '  let base = drawPrepParams.v1.y * 5u;',
-      '  indirectArgs[base + 0u] = drawPrepParams.v0.x;',
-      '  indirectArgs[base + 1u] = drawPrepParams.v0.y;',
-      '  indirectArgs[base + 2u] = drawPrepParams.v0.z;',
-      '  indirectArgs[base + 3u] = drawPrepParams.v0.w;',
-      '  indirectArgs[base + 4u] = drawPrepParams.v1.x;',
+      '  let recordIndex = gid.x;',
+      '  if (recordIndex >= drawPrepParams.v0.x) { return; }',
+      '  let base = recordIndex * 5u;',
+      '  indirectArgs[base + 0u] = drawPrepRecords[base + 0u];',
+      '  indirectArgs[base + 1u] = drawPrepRecords[base + 1u];',
+      '  indirectArgs[base + 2u] = drawPrepRecords[base + 2u];',
+      '  indirectArgs[base + 3u] = drawPrepRecords[base + 3u];',
+      '  indirectArgs[base + 4u] = drawPrepRecords[base + 4u];',
       '}',
     ].join('\n');
 

--- a/src/render/webgpu/shaders.ts
+++ b/src/render/webgpu/shaders.ts
@@ -44,9 +44,11 @@ export const WEBGPU_RENDER_CONTRACT = Object.freeze({
   indirectArgsBytes: 5 * Uint32Array.BYTES_PER_ELEMENT,
   drawPrepBindGroup: 0,
   drawPrepIndirectBinding: 0,
-  drawPrepParamsBinding: 1,
-  drawPrepParamsU32: 8,
-  drawPrepWorkgroupSize: 1,
+  drawPrepRecordBinding: 1,
+  drawPrepParamsBinding: 2,
+  drawPrepRecordWords: 5,
+  drawPrepParamsU32: 4,
+  drawPrepWorkgroupSize: 64,
 } as const);
 
 export const PATH_RENDER_WGSL = /* wgsl */ `
@@ -161,32 +163,28 @@ fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
 export const DRAW_PREP_COMPUTE_WGSL = /* wgsl */ `
 struct DrawPrepParams {
-  // v0 = [indexCount, instanceCount, firstIndex, baseVertexBits]
+  // v0 = [recordCount, maxRecords, _, _]
   v0: vec4<u32>,
-  // v1 = [firstInstance, recordIndex, maxRecords, _]
-  v1: vec4<u32>,
 };
 
 @group(0) @binding(0) var<storage, read_write> indirectArgs: array<u32>;
-@group(0) @binding(1) var<uniform> drawPrepParams: DrawPrepParams;
+@group(0) @binding(1) var<storage, read> drawPrepRecords: array<u32>;
+@group(0) @binding(2) var<uniform> drawPrepParams: DrawPrepParams;
 
 @compute @workgroup_size(${WEBGPU_RENDER_CONTRACT.drawPrepWorkgroupSize})
 fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
-  if (gid.x > 0u) {
+  let recordIndex = gid.x;
+  let recordCount = drawPrepParams.v0.x;
+  let maxRecords = drawPrepParams.v0.y;
+  if (recordIndex >= recordCount || recordIndex >= maxRecords) {
     return;
   }
 
-  let recordIndex = drawPrepParams.v1.y;
-  let maxRecords = drawPrepParams.v1.z;
-  if (recordIndex >= maxRecords) {
-    return;
-  }
-
-  let base = recordIndex * ${WEBGPU_RENDER_CONTRACT.indirectArgsWords}u;
-  indirectArgs[base + 0u] = drawPrepParams.v0.x; // indexCount
-  indirectArgs[base + 1u] = drawPrepParams.v0.y; // instanceCount
-  indirectArgs[base + 2u] = drawPrepParams.v0.z; // firstIndex
-  indirectArgs[base + 3u] = drawPrepParams.v0.w; // baseVertex bits
-  indirectArgs[base + 4u] = drawPrepParams.v1.x; // firstInstance
+  let base = recordIndex * ${WEBGPU_RENDER_CONTRACT.drawPrepRecordWords}u;
+  indirectArgs[base + 0u] = drawPrepRecords[base + 0u]; // indexCount
+  indirectArgs[base + 1u] = drawPrepRecords[base + 1u]; // instanceCount
+  indirectArgs[base + 2u] = drawPrepRecords[base + 2u]; // firstIndex
+  indirectArgs[base + 3u] = drawPrepRecords[base + 3u]; // baseVertex bits
+  indirectArgs[base + 4u] = drawPrepRecords[base + 4u]; // firstInstance
 }
 `;


### PR DESCRIPTION
## Summary
- Implements `oscilla-animator-v2-zq12.3` (`P3-3_GPU_Draw_Prep__Autonomous_Rendering_Logistics.md`).
- Refactors draw-prep runtime to run one compute dispatch per frame using a manifest of draw records (`indexCount`, `instanceCount`, `firstIndex`, `baseVertex`, `firstInstance`).
- Changes draw-prep WGSL contract to consume a storage record buffer and dispatch by `gid.x` with `ceil(recordCount / 64)` geometry.
- Aligns compiler-generated draw-prep WGSL with the runtime contract (`bindings 0/1/2`, workgroup size 64, manifest copy path).
- Keeps draw-prep hot-swap behavior and bind-group reuse with record-buffer invalidation on capacity growth.

## Changed Files
- `src/render/webgpu/WebGPURenderer.ts`
- `src/render/webgpu/shaders.ts`
- `src/compiler/compile.ts`
- `src/render/webgpu/__tests__/WebGPURenderer.test.ts`
- `src/compiler/__tests__/steel-thread-dual-topology.test.ts`

## Validation
- `BEAD_ID=oscilla-animator-v2-zq12.3 scripts/enforce-webgpu-bead-readiness.sh`
- `pnpm -s test src/render/webgpu/__tests__/WebGPURenderer.test.ts src/compiler/__tests__/steel-thread.test.ts src/compiler/__tests__/steel-thread-dual-topology.test.ts`
- `pnpm -s typecheck`
- `pnpm -s test`
