### PR TITLE
[oscilla-animator-v2-zq12.4] P3-4 render pass deep dive

### DIFF
--- a/src/render/webgpu/WebGPURenderer.ts
+++ b/src/render/webgpu/WebGPURenderer.ts
@@ -18,6 +18,10 @@ const GPU_BUFFER_USAGE = {
   INDIRECT: 0x0100,
 } as const;
 
+const GPU_TEXTURE_USAGE = {
+  RENDER_ATTACHMENT: 0x0010,
+} as const;
+
 const INSTANCE_FLOATS = WEBGPU_RENDER_CONTRACT.instanceFloats;
 const MIN_INSTANCE_CAPACITY = 1024;
 const SIMULATION_CAPACITY = WEBGPU_RENDER_CONTRACT.simulationCapacity;
@@ -406,6 +410,8 @@ export class WebGPURenderer {
   private frameCount = 0;
   private fatalError: Error | null = null;
   private lastConfiguredSize = { width: -1, height: -1 };
+  private msaaColorTexture: any | null = null;
+  private msaaColorView: any | null = null;
 
   private constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -571,13 +577,16 @@ export class WebGPURenderer {
       );
     }
 
+    const currentTextureView = this.context.getCurrentTexture().createView();
+    const colorAttachmentView = this.msaaColorView ?? currentTextureView;
     const pass = commandEncoder.beginRenderPass({
       colorAttachments: [
         {
-          view: this.context.getCurrentTexture().createView(),
+          view: colorAttachmentView,
+          resolveTarget: this.msaaColorView ? currentTextureView : undefined,
           loadOp: 'clear',
-          storeOp: 'store',
-          clearValue: { r: 0, g: 0, b: 0, a: 1 },
+          storeOp: this.msaaColorView ? 'discard' : 'store',
+          clearValue: { r: 0, g: 0, b: 0, a: 0 },
         },
       ],
     });
@@ -600,6 +609,7 @@ export class WebGPURenderer {
   dispose(): void {
     this.computeRuntime.dispose();
     this.drawPrepRuntime.dispose();
+    this.destroyMsaaColorTarget();
     this.sceneUniformBuffer.destroy();
     this.indirectArgsBuffer.destroy();
     this.topologyBankBuffer.destroy();
@@ -674,8 +684,29 @@ export class WebGPURenderer {
       format: this.canvasFormat,
       alphaMode: 'premultiplied',
     });
+    this.recreateMsaaColorTarget(width, height);
     this.lastConfiguredSize.width = width;
     this.lastConfiguredSize.height = height;
+  }
+
+  private recreateMsaaColorTarget(width: number, height: number): void {
+    this.destroyMsaaColorTarget();
+    this.msaaColorTexture = this.device.createTexture({
+      size: {
+        width: Math.max(1, Math.floor(width)),
+        height: Math.max(1, Math.floor(height)),
+      },
+      sampleCount: WEBGPU_RENDER_CONTRACT.renderMsaaSampleCount,
+      format: this.canvasFormat,
+      usage: GPU_TEXTURE_USAGE.RENDER_ATTACHMENT,
+    });
+    this.msaaColorView = this.msaaColorTexture.createView();
+  }
+
+  private destroyMsaaColorTarget(): void {
+    this.msaaColorTexture?.destroy();
+    this.msaaColorTexture = null;
+    this.msaaColorView = null;
   }
 
   private syncTopologyBank(): void {
@@ -1073,7 +1104,7 @@ export class WebGPURenderer {
             format: canvasFormat,
             blend: {
               color: {
-                srcFactor: 'src-alpha',
+                srcFactor: 'one',
                 dstFactor: 'one-minus-src-alpha',
                 operation: 'add',
               },
@@ -1092,7 +1123,7 @@ export class WebGPURenderer {
         cullMode: 'none',
       },
       multisample: {
-        count: 1,
+        count: WEBGPU_RENDER_CONTRACT.renderMsaaSampleCount,
       },
     });
   }

--- a/src/render/webgpu/__tests__/WebGPURenderer.test.ts
+++ b/src/render/webgpu/__tests__/WebGPURenderer.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createWebGPURenderer } from '../WebGPURenderer';
-import { WEBGPU_RENDER_CONTRACT } from '../shaders';
+import { PATH_RENDER_WGSL, WEBGPU_RENDER_CONTRACT } from '../shaders';
 import { getTopologyRegistryRevision, registerDynamicTopology } from '../../../shapes/registry';
 import { PathVerb } from '../../../shapes/types';
 import type { DrawPathInstancesOp } from '../../types';
@@ -61,6 +61,11 @@ function createFakeWebGPUEnvironment() {
       destroy: vi.fn(),
       getMappedRange: vi.fn(() => new ArrayBuffer(descriptor.size)),
       unmap: vi.fn(),
+    })),
+    createTexture: vi.fn((descriptor: unknown) => ({
+      descriptor,
+      createView: vi.fn(() => ({ label: 'msaa-view' })),
+      destroy: vi.fn(),
     })),
     createBindGroup: vi.fn((descriptor: unknown) => descriptor),
     createCommandEncoder: vi.fn(() => commandEncoder),
@@ -803,6 +808,63 @@ describe('WebGPURenderer', () => {
 
     expect(env.device.createRenderPipelineAsync).toHaveBeenCalled();
     expect(env.device.createRenderPipeline).not.toHaveBeenCalled();
+  });
+
+  it('configures premultiplied alpha blending and 4x MSAA on the render pipeline', async () => {
+    const env = createFakeWebGPUEnvironment();
+    setNavigatorGpu(env.gpu);
+    await createWebGPURenderer(env.canvas);
+
+    expect(env.device.createRenderPipelineAsync).toHaveBeenCalled();
+    const firstRenderPipelineCall = (env.device.createRenderPipelineAsync as any).mock.calls[0];
+    const descriptor = firstRenderPipelineCall[0] as {
+      fragment: {
+        targets: Array<{
+          blend: {
+            color: { srcFactor: string; dstFactor: string; operation: string };
+            alpha: { srcFactor: string; dstFactor: string; operation: string };
+          };
+        }>;
+      };
+      multisample: { count: number };
+    };
+    expect(descriptor.fragment.targets[0]?.blend).toEqual({
+      color: {
+        srcFactor: 'one',
+        dstFactor: 'one-minus-src-alpha',
+        operation: 'add',
+      },
+      alpha: {
+        srcFactor: 'one',
+        dstFactor: 'one-minus-src-alpha',
+        operation: 'add',
+      },
+    });
+    expect(descriptor.multisample.count).toBe(WEBGPU_RENDER_CONTRACT.renderMsaaSampleCount);
+  });
+
+  it('uses premultiplied alpha output in the fragment shader', () => {
+    expect(PATH_RENDER_WGSL).toContain('vec4<f32>(input.color.rgb * input.color.a, input.color.a)');
+  });
+
+  it('renders through MSAA resolve attachment with discard store semantics', async () => {
+    const env = createFakeWebGPUEnvironment();
+    setNavigatorGpu(env.gpu);
+    const renderer = await createWebGPURenderer(env.canvas);
+
+    renderer.render(makeRenderInput([]));
+
+    const passDescriptor = env.device.createCommandEncoder.mock.results[0]?.value.beginRenderPass.mock.calls[0]?.[0] as {
+      colorAttachments: Array<{
+        resolveTarget?: unknown;
+        storeOp?: string;
+        clearValue?: { a?: number };
+      }>;
+    };
+    const colorAttachment = passDescriptor.colorAttachments[0];
+    expect(colorAttachment.resolveTarget).toBeDefined();
+    expect(colorAttachment.storeOp).toBe('discard');
+    expect(colorAttachment.clearValue?.a).toBe(0);
   });
 
   it('commits async draw-prep pipeline on next frame after shader update (hot-swap protocol)', async () => {

--- a/src/render/webgpu/shaders.ts
+++ b/src/render/webgpu/shaders.ts
@@ -47,6 +47,7 @@ export const WEBGPU_RENDER_CONTRACT = Object.freeze({
   drawPrepParamsBinding: 1,
   drawPrepParamsU32: 8,
   drawPrepWorkgroupSize: 1,
+  renderMsaaSampleCount: 4,
 } as const);
 
 export const PATH_RENDER_WGSL = /* wgsl */ `
@@ -122,7 +123,9 @@ fn vs_main(input: VertexInput, @builtin(instance_index) instanceIndex: u32) -> V
 
 @fragment
 fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
-  return input.color;
+  // [LAW:single-enforcer] Fragment stage outputs premultiplied alpha so browser
+  // compositing and pipeline blending share one canonical alpha contract.
+  return vec4<f32>(input.color.rgb * input.color.a, input.color.a);
 }
 `;
 


### PR DESCRIPTION
## Summary
- enforce premultiplied-alpha output in WebGPU fragment shader
- align blend state to premultiplied compositing (`src=one`, `dst=one-minus-src-alpha`)
- allocate/recreate a dedicated 4x MSAA color target and resolve to the current canvas texture each frame
- enforce render-pass resolve semantics (`storeOp: discard`) and keep clear alpha at 0 for compositing correctness
- expand renderer tests for blend, multisample, shader output, and render-pass resolve contract

## Validation
- pnpm -s typecheck
- pnpm -s test src/render/webgpu/__tests__/WebGPURenderer.test.ts

## Notes
- Supersedes #93, which could not be updated directly under prior branch rule settings.
