### PR TITLE
compiler: preserve warnings on defensive worker failure path

### DIFF
--- a/src/services/compile.worker.ts
+++ b/src/services/compile.worker.ts
@@ -24,6 +24,9 @@ async function toBackendResult(
           {
             code: 'IRValidationFailed',
             message: 'Compiled program is missing generatedComputeProgram',
+            details: {
+              preNagaWarnings: result.warnings,
+            },
           },
         ],
       };


### PR DESCRIPTION
## Summary
- preserve `result.warnings` context on the defensive `generatedComputeProgram`-missing worker error path
- align warning propagation behavior with the Naga validation-failure path for consistent diagnostics

## Validation
- pnpm -s vitest run src/services/__tests__/CompileWorkerClient.test.ts src/services/__tests__/compile-worker-clone-safety.test.ts
- pnpm -s typecheck