### PR TITLE
compiler: enforce P0-1 arena + SoA invariants

### DIFF
--- a/docs/WebGPU-Complete/P0-1__SoA_Mandate__Memory_Layout_Refactor.md
+++ b/docs/WebGPU-Complete/P0-1__SoA_Mandate__Memory_Layout_Refactor.md
@@ -49,7 +49,8 @@ The compiler must emit and keep consistent:
 2. `runtimeSlots`
 3. `runtimeAddressTable`
 4. `arenaLayout`
-5. `arenaTotalFloats`
+5. `arenaPayloadFloats`
+6. `arenaTotalFloats`
 
 ### 2.2 Descriptor Derivation Rules
 
@@ -62,7 +63,8 @@ The compiler must emit and keep consistent:
 
 1. Repeated compilation of identical input must produce deterministic arena offsets/descriptors.
 2. Descriptor ranges must be non-overlapping for active slots.
-3. `arenaTotalFloats` must equal the sum of descriptor lengths.
+3. `arenaPayloadFloats` must equal the sum of descriptor lengths.
+4. `arenaTotalFloats` must equal emitted arena-zone total (`arenaZones.totalFloats`) and must be `>= arenaPayloadFloats`.
 
 // [LAW:verifiable-goals] These rules are mechanically enforced by compiler/runtime layout tests.
 
@@ -71,7 +73,7 @@ The compiler must emit and keep consistent:
 ### 3.1 Addressing and Execution
 
 1. Runtime execution must use compiler-emitted address metadata (no legacy metadata derivation).
-2. Arena allocation must exactly match `arenaTotalFloats`.
+2. Arena allocation must exactly match `arenaTotalFloats` (zone total), while descriptor-sum validation uses `arenaPayloadFloats`.
 3. Slot reads/writes in hot paths must route through canonical descriptor-aware indexing.
 
 ### 3.2 No Legacy Numeric Paths

--- a/src/compiler/__tests__/arena-layout.test.ts
+++ b/src/compiler/__tests__/arena-layout.test.ts
@@ -544,18 +544,21 @@ describe('arenaLayout integration', () => {
       expect(regions[i].start).toBeGreaterThanOrEqual(regions[i - 1].end);
     }
 
-    // arenaTotalFloats includes zone padding (header + alignment), so it must
-    // be >= payload descriptor sum and match emitted zone metadata total.
+    // [LAW:one-source-of-truth] Descriptor payload sum and total arena budget
+    // are emitted as separate compiler metrics with explicit invariants.
     const totalFromLayout = program.arenaLayout
       .filter((d) => d.offset >= 0)
       .reduce((sum, d) => sum + d.length, 0);
-    expect(program.arenaTotalFloats).toBeGreaterThanOrEqual(totalFromLayout);
+    expect(program.arenaPayloadFloats).toBe(totalFromLayout);
     const arenaZones = program.arenaZones;
     expect(arenaZones).toBeDefined();
     if (!arenaZones) {
       throw new Error('Compiled program missing arenaZones metadata');
     }
+    expect(arenaZones.payloadFloats).toBe(totalFromLayout);
+    expect(program.arenaPayloadFloats).toBe(arenaZones.payloadFloats);
     expect(program.arenaTotalFloats).toBe(arenaZones.totalFloats);
+    expect(program.arenaTotalFloats).toBeGreaterThanOrEqual(program.arenaPayloadFloats);
 
     // arenaTotalFloats > 0 (a compiled program with blocks must have slots)
     expect(program.arenaTotalFloats).toBeGreaterThan(0);

--- a/src/compiler/__tests__/no-legacy-types.test.ts
+++ b/src/compiler/__tests__/no-legacy-types.test.ts
@@ -2,7 +2,6 @@ import { execFileSync } from 'node:child_process';
 import { describe, expect, it } from 'vitest';
 import { buildPatch } from '../../graph';
 import { compile } from '../compile';
-import { requireInst } from '../../core/canonical-types';
 
 function rg(pattern: string, scope: readonly string[], globs: readonly string[] = ['*.ts', '*.tsx']): string[] {
   try {
@@ -94,14 +93,9 @@ describe('no-legacy-types gate', () => {
       expect(slot.type.payload.kind).not.toBe('object');
     }
 
-    // [LAW:dataflow-not-control-flow] Channel separation is canonical: either
-    // slots are scalarized (stride=1) or explicitly SoA-packed.
-    const nonSoaMultiComponentSlots = program.runtimeSlots.filter(
-      (slot) =>
-        requireInst(slot.type.extent.cardinality, 'cardinality').kind === 'many' &&
-        slot.arena.stride > 1 &&
-        slot.arena.packing !== 'soa',
-    );
-    expect(nonSoaMultiComponentSlots).toEqual([]);
+    // [LAW:one-source-of-truth] P0-1 canonical packing is SoA for runtime slot
+    // descriptors; compiler slot planning must not emit AoS descriptors.
+    const nonSoaSlots = program.runtimeSlots.filter((slot) => slot.arena.packing !== 'soa');
+    expect(nonSoaSlots).toEqual([]);
   });
 });

--- a/src/compiler/backend/__tests__/backend-preconditions.test.ts
+++ b/src/compiler/backend/__tests__/backend-preconditions.test.ts
@@ -56,6 +56,7 @@ function testProgramConverter(
     renderGlobals: [],
     kernelRegistry: createDefaultRegistry(),
     arenaLayout: [],
+    arenaPayloadFloats: 0,
     arenaTotalFloats: 0,
   };
 }

--- a/src/compiler/compile.ts
+++ b/src/compiler/compile.ts
@@ -520,6 +520,18 @@ function convertLinkedIRToProgram(
       arena,
     };
   });
+  const descriptorPayloadFloats = arenaLayout.reduce((sum, descriptor) => sum + descriptor.length, 0);
+  if (descriptorPayloadFloats !== arenaZonePlan.payloadFloats) {
+    // [LAW:single-enforcer] Compiler layout planning is the single boundary
+    // that guarantees descriptor-sum payload invariants.
+    throw new Error(
+      'convertLinkedIRToProgram: payload sum mismatch (layout=' +
+        descriptorPayloadFloats +
+        ', plan=' +
+        arenaZonePlan.payloadFloats +
+        ')',
+    );
+  }
 
   // Build output specs from canonical output contract only.
   const outputs: OutputSpecIR[] = [{ kind: 'renderFrame' }];
@@ -683,6 +695,7 @@ function convertLinkedIRToProgram(
     arenaLayout,
     arenaZones: arenaZonePlan.toIR(),
     arenaRuntimeLayout: arenaZonePlan.runtimeLayout,
+    arenaPayloadFloats: arenaZonePlan.payloadFloats,
     arenaTotalFloats: arenaZonePlan.totalFloats,
     drawPrepProgram,
     nagaLoweringProgram,

--- a/src/compiler/ir/program.ts
+++ b/src/compiler/ir/program.ts
@@ -196,9 +196,17 @@ export interface CompiledProgramIR {
   readonly arenaRuntimeLayout?: ArenaRuntimeLayoutIR;
 
   /**
+   * Sum of canonical slot descriptor lengths across `arenaLayout`.
+   *
+   * [LAW:one-source-of-truth] Payload capacity is emitted once by compiler
+   * zone planning and used for descriptor-sum invariant checks.
+   */
+  readonly arenaPayloadFloats: number;
+
+  /**
    * Total number of floats in the arena buffer, as computed by the arena zone
    * plan (`totalFloats`). Includes header reservation and scalar->field
-   * alignment padding, not just slot descriptor lengths.
+   * alignment padding and state/gauge zones.
    */
   readonly arenaTotalFloats: number;
 
@@ -459,6 +467,11 @@ export interface ArenaZoneRangeIR {
 export interface ArenaZonesIR {
   readonly alignment: ArenaZoneAlignmentPolicyIR;
   readonly zones: readonly ArenaZoneRangeIR[];
+  /**
+   * Sum of canonical slot descriptor lengths (scalar + field payloads).
+   * Excludes header/alignment/state/gauge zone overhead.
+   */
+  readonly payloadFloats: number;
   readonly totalFloats: number;
 }
 

--- a/src/compiler/ir/storage-class.ts
+++ b/src/compiler/ir/storage-class.ts
@@ -129,6 +129,7 @@ export const DEFAULT_ARENA_ALIGNMENT_POLICY: ArenaZoneAlignmentPolicyIR = {
 };
 
 export interface ArenaZonePlan {
+  readonly payloadFloats: number;
   readonly totalFloats: number;
   readonly zones: readonly ArenaZoneRangeIR[];
   readonly alignment: ArenaZoneAlignmentPolicyIR;
@@ -227,6 +228,7 @@ export function deriveArenaZonePlan(
   const descriptors = new Map<ValueSlot, ArenaSlotDescriptor>();
   const zones: ArenaZoneRangeIR[] = [];
   const gaugeTargetLayouts: ArenaGaugeTargetLayoutIR[] = [];
+  let payloadFloats = 0;
 
   const normalizedStateBankLength = normalizeAlignmentCount(options.stateBankLength ?? 0, 0, 0);
   const normalizedStateEntryCount = normalizeAlignmentCount(options.stateEntryCount ?? 0, 0, 0);
@@ -247,6 +249,7 @@ export function deriveArenaZonePlan(
       slot.packingPreference,
     );
     descriptors.set(slot.slot, descriptor);
+    payloadFloats += descriptor.length;
     cursor += descriptor.length;
   }
   const scalarDataEnd = cursor;
@@ -275,6 +278,7 @@ export function deriveArenaZonePlan(
       slot.packingPreference,
     );
     descriptors.set(slot.slot, descriptor);
+    payloadFloats += descriptor.length;
     cursor += descriptor.length;
   }
   const fieldEnd = cursor;
@@ -331,10 +335,12 @@ export function deriveArenaZonePlan(
   const toIR = (): ArenaZonesIR => ({
     alignment: normalizedAlignment,
     zones,
+    payloadFloats,
     totalFloats: gaugeEnd,
   });
 
   return {
+    payloadFloats,
     totalFloats: gaugeEnd,
     zones,
     alignment: normalizedAlignment,

--- a/src/runtime/__tests__/CameraResolver.test.ts
+++ b/src/runtime/__tests__/CameraResolver.test.ts
@@ -44,6 +44,7 @@ function mockProgram(
     renderGlobals,
     kernelRegistry: { resolve: () => undefined, entries: () => [] } as any,
     arenaLayout: [],
+    arenaPayloadFloats: 0,
     arenaTotalFloats: 0,
   };
 }

--- a/src/runtime/__tests__/ExprAddressTable.test.ts
+++ b/src/runtime/__tests__/ExprAddressTable.test.ts
@@ -131,6 +131,7 @@ function mockProgram(opts: {
     renderGlobals: [],
     kernelRegistry: { resolve: () => undefined, entries: () => [] } as any,
     arenaLayout,
+    arenaPayloadFloats: arenaLayout.reduce((sum, d) => sum + Math.max(0, d.length), 0),
     arenaTotalFloats: 0,
   } as CompiledProgramIR;
 }

--- a/src/runtime/__tests__/ScheduleExecutor-phase-boundary.test.ts
+++ b/src/runtime/__tests__/ScheduleExecutor-phase-boundary.test.ts
@@ -72,6 +72,7 @@ function makeProgramWithPhaseBoundaryViolation(): CompiledProgramIR {
     renderGlobals: [],
     kernelRegistry: { resolve: () => undefined, entries: () => [] } as any,
     arenaLayout: [{ offset: 0, stride: 4, laneCount: 1, length: 4 }],
+    arenaPayloadFloats: 4,
     arenaTotalFloats: 4,
   } as CompiledProgramIR;
 }
@@ -142,6 +143,7 @@ function makeProgramWithCardinalityWriteMismatch(): CompiledProgramIR {
     renderGlobals: [],
     kernelRegistry: { resolve: () => undefined, entries: () => [] } as any,
     arenaLayout: [{ offset: 0, stride: 1, laneCount: 2, length: 2 }],
+    arenaPayloadFloats: 2,
     arenaTotalFloats: 2,
   } as CompiledProgramIR;
 }

--- a/src/runtime/__tests__/lane-identity.test.ts
+++ b/src/runtime/__tests__/lane-identity.test.ts
@@ -69,6 +69,7 @@ function makeMinimalProgram(opts: {
     renderGlobals: [],
     kernelRegistry: {} as any,
     arenaLayout: [],
+    arenaPayloadFloats: 0,
     arenaTotalFloats: 0,
   } as CompiledProgramIR;
 }


### PR DESCRIPTION
## Summary
- formalize arena invariants with two explicit metrics:
  - `arenaPayloadFloats` = sum of descriptor lengths
  - `arenaTotalFloats` = full zone total (`arenaZones.totalFloats`)
- add compile-time invariant check to prevent descriptor-sum drift from zone-plan payload
- tighten SoA contract tests to require SoA packing on runtime slot descriptors
- update P0-1 spec text to match enforced compiler/runtime contract

## Verification
- `pnpm -s typecheck`
- `pnpm -s vitest run src/compiler/__tests__/arena-layout.test.ts src/compiler/__tests__/no-legacy-types.test.ts src/runtime/__tests__/ExprAddressTable.test.ts src/runtime/__tests__/ScheduleExecutor-phase-boundary.test.ts`
- `pnpm -s vitest run src/__tests__/architecture-guardrails.test.ts`
