### PR TITLE
P4: enforce spy readback NaN trap and preserve non-finite samples

### DIFF
--- a/src/services/RuntimeService.ts
+++ b/src/services/RuntimeService.ts
@@ -117,7 +117,8 @@ export class RuntimeService {
   private spyReadbackHz = 5;
   private debugProbeTransport: DebugProbeTransport;
   private debugProbeUpgradeInFlight: Promise<void> | null = null;
-  private lastSpyReadbackAnomalyKey = '';
+  private spyReadbackAnomalyFrameId: number | null = null;
+  private readonly spyReadbackAnomalyKeysForFrame = new Set<string>();
 
   constructor(
     private readonly store: RootStore,
@@ -740,21 +741,30 @@ export class RuntimeService {
     if ((packet.packetFlags & DEBUG_PACKET_FLAG_NAN_DETECTED_ANY) === 0) {
       return;
     }
-    const anomalousSample = packet.samples.find((sample) =>
-      sample.values.some((value) => !Number.isFinite(value)));
-    if (!anomalousSample) {
-      return;
+
+    let anomalousSample: DebugProbePacketSample | undefined;
+    let anomalousValue: number | undefined;
+    for (const sample of packet.samples) {
+      const value = sample.values.find((candidate) => !Number.isFinite(candidate));
+      if (value !== undefined) {
+        anomalousSample = sample;
+        anomalousValue = value;
+        break;
+      }
     }
-    const anomalousValue = anomalousSample.values.find((value) => !Number.isFinite(value));
-    if (anomalousValue === undefined) {
+    if (!anomalousSample || anomalousValue === undefined) {
       return;
     }
 
-    const anomalyKey = `${packet.frameId}:${Number(anomalousSample.slotId)}:${anomalousSample.targetId}`;
-    if (this.lastSpyReadbackAnomalyKey === anomalyKey) {
+    if (this.spyReadbackAnomalyFrameId !== packet.frameId) {
+      this.spyReadbackAnomalyFrameId = packet.frameId;
+      this.spyReadbackAnomalyKeysForFrame.clear();
+    }
+    const anomalyKey = `${Number(anomalousSample.slotId)}:${anomalousSample.targetId}`;
+    if (this.spyReadbackAnomalyKeysForFrame.has(anomalyKey)) {
       return;
     }
-    this.lastSpyReadbackAnomalyKey = anomalyKey;
+    this.spyReadbackAnomalyKeysForFrame.add(anomalyKey);
 
     const valueLabel =
       Number.isNaN(anomalousValue)

--- a/src/services/__tests__/RuntimeService.spy-readback.test.ts
+++ b/src/services/__tests__/RuntimeService.spy-readback.test.ts
@@ -185,7 +185,7 @@ describe('RuntimeService spy readback packet selection', () => {
     ]);
   });
 
-  it('logs and pauses playback when spy readback detects NaN', () => {
+  it('logs and pauses playback when spy readback detects NaN with frame-scoped dedupe', () => {
     const diagnosticsLog = vi.fn();
     const pause = vi.fn();
     const playback = {
@@ -200,37 +200,45 @@ describe('RuntimeService spy readback packet selection', () => {
       playback,
     } as any);
     const applySpyReadback = vi.spyOn(debugService, 'applySpyReadback');
+    let pollCount = 0;
 
     try {
       (runtime as any).debugProbeTransport = {
         debugCommand: () => {},
-        debugPollPacket: () => ({
-          version: 1,
-          sequence: 1,
-          capturedAtMs: 200,
-          runtimeFrameId: 33,
-          sampleCount: 1,
-          packetFlags: 1 << 3,
-          samples: [{
-            targetId: 77,
-            slotId: valueSlot(8),
-            payloadKind: 'scalar',
-            stride: 1,
-            laneCount: 1,
-            sampleFlags: 1 << 3,
-            values: [Number.NaN],
-          }],
-        }),
+        debugPollPacket: () => {
+          pollCount += 1;
+          const targetId = pollCount === 2 ? 88 : 77;
+          return {
+            version: 1,
+            sequence: pollCount,
+            capturedAtMs: 200 + pollCount,
+            runtimeFrameId: 33,
+            sampleCount: 1,
+            packetFlags: 1 << 3,
+            samples: [{
+              targetId,
+              slotId: valueSlot(8),
+              payloadKind: 'scalar',
+              stride: 1,
+              laneCount: 1,
+              sampleFlags: 1 << 3,
+              values: [Number.NaN],
+            }],
+          };
+        },
       };
 
       (runtime as any).runSpyReadbackCycle();
       (runtime as any).runSpyReadbackCycle();
+      (runtime as any).runSpyReadbackCycle();
 
-      expect(diagnosticsLog).toHaveBeenCalledTimes(1);
+      expect(diagnosticsLog).toHaveBeenCalledTimes(2);
       expect(diagnosticsLog.mock.calls[0]?.[0]).toMatchObject({ level: 'error' });
       expect(String(diagnosticsLog.mock.calls[0]?.[0]?.message)).toContain('Spy readback detected NaN');
       expect(pause).toHaveBeenCalledTimes(1);
-      expect(applySpyReadback).toHaveBeenCalledWith(valueSlot(8), Number.NaN, 200, 33);
+      expect(applySpyReadback).toHaveBeenCalledWith(valueSlot(8), Number.NaN, 201, 33);
+      expect(applySpyReadback).toHaveBeenCalledWith(valueSlot(8), Number.NaN, 202, 33);
+      expect(applySpyReadback).toHaveBeenCalledWith(valueSlot(8), Number.NaN, 203, 33);
     } finally {
       applySpyReadback.mockRestore();
     }


### PR DESCRIPTION
Summary
- implement P4 readback anomaly handling in RuntimeService so non-finite probe values are no longer silently dropped
- preserve NaN/Inf scalar samples in spy readback packets so debug UI can render the actual faulting value
- add a deterministic NaN trap: runtime logs a structured error and pauses playback on first anomalous sample per frame/target
- dedupe anomaly logging per frame/slot/target to prevent repeated log spam from the same stalled state

Validation
- pnpm run typecheck
- pnpm exec vitest run src/services/__tests__/RuntimeService.spy-readback.test.ts src/services/__tests__/DebugService-spy-readback.test.ts
- pnpm exec vitest run src/runtime/__tests__/StepDebugSession.test.ts src/ui/debug-viz/ValueRenderer.test.ts src/services/__tests__/RuntimeService.spy-readback.test.ts
