### PR TITLE
Add guardrail against direct WGSL emitter reintroduction

### DIFF
--- a/src/__tests__/architecture-guardrails.test.ts
+++ b/src/__tests__/architecture-guardrails.test.ts
@@ -230,6 +230,18 @@ describe('Architecture Guardrails', () => {
         scope: ['src/compiler/compile.ts'],
         maxCount: 0,
       },
+      {
+        id: 'K-P0-6',
+        pattern: '\\bemitWgslModule\\s*\\(',
+        scope: ['src'],
+        maxCount: 0,
+      },
+      {
+        id: 'K-P0-7',
+        pattern: '\\bcreateDrawPrepWgslAst\\s*\\(',
+        scope: ['src'],
+        maxCount: 0,
+      },
     ];
 
     for (const gate of gates) {


### PR DESCRIPTION
## Summary\n- add architecture guardrails that forbid direct WGSL emitter entrypoints in \n- block reintroduction of  and  patterns\n\n## Context\n- PR #141 introduced direct WGSL string emission, which is forbidden by spec\n- this gate enforces the no-direct-WGSL policy at CI/test boundary