### PR TITLE
Audit 3/5: Remove hotpath executeFrame warmup path

### DIFF
--- a/src/services/__tests__/runtime-hotpath-install.test.ts
+++ b/src/services/__tests__/runtime-hotpath-install.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+import type { DrawPrepSinkIR } from '../../compiler/ir/program';
+import type { ValueExprId, ValueSlot } from '../../compiler/ir/Indices';
+import type { StepMaterialize, StepRender } from '../../compiler/ir/types';
+import type { ArenaSlotDescriptor } from '../../runtime/ArenaValueStore';
+import type { CompiledProgramIR } from '../../compiler/ir/program';
+import { canonicalType, HANDLE } from '../../core/canonical-types';
+import { createRuntimeState, DrawPrepSinkTableHeaderWord, SHAPE_BANK_HEADER_WORDS } from '../../runtime';
+import { buildProgramTopologyTableFromIds } from '../../compiler/ir/program-topology';
+import { registerDynamicTopology } from '../../shapes/registry';
+import { buildRuntimeHotpathInstallPlanes } from '../runtime-hotpath-install';
+
+const TEST_TOPOLOGY_ID = registerDynamicTopology(
+  {
+    params: [{ name: 'radius', type: 'float', default: 1 }],
+  },
+  'runtime-hotpath-install-test-topology',
+);
+
+function descriptor(offset: number, stride: number, laneCount: number): ArenaSlotDescriptor {
+  return {
+    offset,
+    stride,
+    laneCount,
+    length: stride * laneCount,
+    packing: 'soa',
+  };
+}
+
+function makeBaseProgram(): CompiledProgramIR {
+  const shapeSlot = 30 as ValueSlot;
+  const controlPointsSlot = 10 as ValueSlot;
+  const colorSlot = 20 as ValueSlot;
+  const scaleSlot = 31 as ValueSlot;
+  const instanceId = 'inst-main' as any;
+
+  const materializeStep: StepMaterialize = {
+    kind: 'materialize',
+    field: 0 as ValueExprId,
+    instanceId,
+    target: shapeSlot,
+  };
+  const renderStep: StepRender = {
+    kind: 'render',
+    instanceId,
+    controlPointsSlot,
+    colorSlot,
+    scale: { k: 'slot', slot: scaleSlot },
+    shape: { k: 'slot', slot: shapeSlot },
+  };
+  const drawPrepSinks: readonly DrawPrepSinkIR[] = [
+    {
+      sinkIndex: 0,
+      renderStepIndex: 1,
+      instanceId,
+      indirectRecordIndex: 0,
+      instanceCountMode: 'static',
+      staticInstanceCount: 1,
+      drawMode: 'indexed',
+      indirectRegion: 'indexed',
+      indirectStrideBytes: 20,
+      topologySource: 'shapeHeaderV1',
+      firstInstanceSource: 'runtimePacked',
+      indexedFirstIndex: 0,
+      indexedBaseVertex: 0,
+    },
+  ];
+
+  return {
+    irVersion: 1,
+    valueExprs: {
+      nodes: [
+        {
+          kind: 'shapeRef',
+          type: canonicalType(HANDLE),
+          topologyId: TEST_TOPOLOGY_ID,
+          paramArgs: [],
+        },
+      ],
+    },
+    constants: { json: [] },
+    schedule: {
+      timeModel: { periodAMs: 4000, periodBMs: 8000 },
+      instances: new Map([
+        [
+          instanceId,
+          {
+            id: instanceId,
+            domainType: 'domain-main' as any,
+            count: 1,
+            lifecycle: 'static',
+            maxCount: 1,
+            identityMode: 'none',
+          },
+        ],
+      ]),
+      steps: [materializeStep, renderStep],
+      stateMappings: [],
+      stateSlotCount: 0,
+      eventSlotCount: 0,
+      eventCount: 0,
+    } as any,
+    outputs: [],
+    slotMeta: [],
+    runtimeSlots: [],
+    runtimeAddressTable: {
+      slotLookup: new Map(),
+      fieldExprToSlot: new Map(),
+      scalarExprToArenaAddress: new Map(),
+      slotToArena: new Map<ValueSlot, ArenaSlotDescriptor>([
+        [shapeSlot, descriptor(0, 1, 1)],
+        [controlPointsSlot, descriptor(8, 2, 1)],
+        [colorSlot, descriptor(16, 4, 1)],
+        [scaleSlot, descriptor(24, 1, 1)],
+      ]),
+    },
+    debugIndex: {
+      stepToBlock: new Map(),
+      slotToBlock: new Map(),
+      exprToBlock: new Map(),
+      ports: [],
+      slotToPort: new Map(),
+      blockMap: new Map(),
+    },
+    fieldSlotRegistry: new Map(),
+    renderGlobals: [],
+    kernelRegistry: {} as any,
+    topologyTable: buildProgramTopologyTableFromIds([TEST_TOPOLOGY_ID]),
+    arenaLayout: [],
+    arenaPayloadFloats: 0,
+    arenaTotalFloats: 64,
+    drawPrepProgram: {
+      totalRecordCount: 1,
+      indexedRecordCount: 1,
+      indexedRegionBaseWords: 0,
+      indexedStrideWords: 5,
+      nonIndexedRecordCount: 0,
+      nonIndexedRegionBaseWords: 5,
+      nonIndexedStrideWords: 4,
+      sinks: drawPrepSinks,
+    },
+  } as unknown as CompiledProgramIR;
+}
+
+describe('buildRuntimeHotpathInstallPlanes', () => {
+  it('publishes non-empty sink-table and shape-bank payloads for a valid program', () => {
+    const program = makeBaseProgram();
+    const state = createRuntimeState(0, 0, 1, 64);
+
+    const planes = buildRuntimeHotpathInstallPlanes(program, state, 100);
+
+    expect(planes.sinkTableWords).not.toBeNull();
+    expect(planes.sinkTableWordCount).toBeGreaterThan(0);
+    expect(planes.shapeBankWordCount).toBeGreaterThanOrEqual(SHAPE_BANK_HEADER_WORDS);
+    expect(planes.shapeBankWords.length).toBe(planes.shapeBankWordCount);
+    expect(planes.sinkTableWords?.[DrawPrepSinkTableHeaderWord.TotalRecordCount]).toBe(1);
+  });
+
+  it('fails fast when runtimeAddressTable is missing', () => {
+    const program = makeBaseProgram();
+    const invalid = {
+      ...program,
+      runtimeAddressTable: undefined,
+    } as CompiledProgramIR;
+    const state = createRuntimeState(0, 0, 1, 64);
+
+    expect(() => buildRuntimeHotpathInstallPlanes(invalid, state, 100)).toThrow(
+      'Missing precomputed runtimeAddressTable',
+    );
+  });
+
+  it('fails fast when draw-prep dynamic sink count cannot be resolved', () => {
+    const program = makeBaseProgram();
+    const dynamicMissing = {
+      ...program,
+      drawPrepProgram: {
+        ...program.drawPrepProgram!,
+        sinks: [
+          {
+            ...program.drawPrepProgram!.sinks[0]!,
+            instanceId: 'inst-dynamic-missing' as any,
+            instanceCountMode: 'dynamic',
+            staticInstanceCount: undefined,
+          },
+        ],
+      },
+    } as CompiledProgramIR;
+    const state = createRuntimeState(0, 0, 1, 64);
+
+    expect(() => buildRuntimeHotpathInstallPlanes(dynamicMissing, state, 100)).toThrow(
+      'missing dynamic instance count',
+    );
+  });
+});

--- a/src/services/runtime-hotpath-install.ts
+++ b/src/services/runtime-hotpath-install.ts
@@ -1,0 +1,129 @@
+import type { CompiledProgramIR } from '../compiler/ir/program';
+import type { InstanceId, ValueSlot } from '../compiler/ir/Indices';
+import type { InstanceDecl, Step, StepMaterialize } from '../compiler/ir/types';
+import {
+  packDrawPrepSinkTableV1,
+  resetShapeBankFrameAllocator,
+  resolveTime,
+  type RuntimeState,
+} from '../runtime';
+import { arenaEncodeFromAoS, type ArenaSlotDescriptor } from '../runtime/ArenaValueStore';
+import { getExprAddressTable } from '../runtime/ExprAddressTable';
+import { resolveInstanceLaneCount } from '../runtime/InstanceCountResolver';
+import { createMaterializeScratch } from '../runtime/MaterializeScratch';
+import { materializeValueExpr } from '../runtime/ValueExprMaterializer';
+
+const MAX_UINT32 = 0xFFFF_FFFF;
+const INSTALL_MATERIALIZE_SCRATCH = createMaterializeScratch();
+
+function assertFiniteUint32(value: number, context: string): number {
+  if (
+    !Number.isFinite(value)
+    || !Number.isInteger(value)
+    || !Number.isSafeInteger(value)
+    || value < 0
+    || value > MAX_UINT32
+  ) {
+    throw new Error(`${context} must be a uint32 (got ${String(value)})`);
+  }
+  return value;
+}
+
+function materializeStepToArena(
+  program: CompiledProgramIR,
+  state: RuntimeState,
+  step: StepMaterialize,
+  instances: ReadonlyMap<InstanceId, InstanceDecl>,
+  slotToArena: ReadonlyMap<ValueSlot, ArenaSlotDescriptor>,
+  pureFnContext: { kernelRegistry: CompiledProgramIR['kernelRegistry'] },
+): void {
+  const arenaDesc = slotToArena.get(step.target);
+  if (!arenaDesc || arenaDesc.offset < 0 || arenaDesc.length <= 0) {
+    throw new Error(`runtime-hotpath: materialize slot ${String(step.target)} missing arena descriptor`);
+  }
+  if (state.arena.length < arenaDesc.offset + arenaDesc.length) {
+    throw new Error(
+      `runtime-hotpath: materialize slot ${String(step.target)} exceeds arena ` +
+      `(need=${arenaDesc.offset + arenaDesc.length}, have=${state.arena.length})`,
+    );
+  }
+  const instanceDecl = instances.get(step.instanceId);
+  const count = instanceDecl
+    ? resolveInstanceLaneCount(instanceDecl, program, state, pureFnContext)
+    : 0;
+  const buffer = materializeValueExpr(
+    step.field,
+    program.valueExprs,
+    step.instanceId,
+    count,
+    state,
+    program,
+    undefined,
+    INSTALL_MATERIALIZE_SCRATCH,
+    pureFnContext,
+  );
+  arenaEncodeFromAoS(state.arena, arenaDesc, buffer);
+}
+
+function materializeProgramForGpuInstall(
+  program: CompiledProgramIR,
+  state: RuntimeState,
+  nowMs: number,
+): void {
+  const instances = program.schedule.instances;
+  const addressTable = getExprAddressTable(program);
+  // [LAW:one-source-of-truth] Worker materialization uses compiler-owned
+  // ExprAddressTable metadata; no local descriptor synthesis.
+  state.cache.scalarExprToArenaAddress = addressTable.scalarExprToArenaAddress;
+  resetShapeBankFrameAllocator(state.shapeBank);
+  INSTALL_MATERIALIZE_SCRATCH.reset();
+  state.time = resolveTime(nowMs, program.schedule.timeModel, state.timeState);
+  // [LAW:single-enforcer] Dynamic instance counts are seeded through the shared
+  // InstanceCountResolver cache contract consumed by DrawPrepSinkTablePacker.
+  state.cache.instanceLaneCounts?.clear();
+  state.cache.instanceLaneCountFrameId = state.cache.frameId;
+  const pureFnContext = { kernelRegistry: program.kernelRegistry };
+  for (const instanceDecl of instances.values()) {
+    resolveInstanceLaneCount(instanceDecl, program, state, pureFnContext);
+  }
+  for (const step of program.schedule.steps as readonly Step[]) {
+    if (step.kind !== 'materialize') continue;
+    materializeStepToArena(program, state, step, instances, addressTable.slotToArena, pureFnContext);
+  }
+}
+
+export interface RuntimeHotpathInstallPlanes {
+  readonly sinkTableWords: Uint32Array | null;
+  readonly sinkTableWordCount: number;
+  readonly shapeBankWords: Uint32Array;
+  readonly shapeBankWordCount: number;
+}
+
+export function buildRuntimeHotpathInstallPlanes(
+  program: CompiledProgramIR,
+  state: RuntimeState,
+  nowMs: number,
+): RuntimeHotpathInstallPlanes {
+  materializeProgramForGpuInstall(program, state, nowMs);
+  // [LAW:one-source-of-truth] Sink-table metadata comes from one canonical
+  // packer contract for all program types (fluid and non-fluid).
+  const packed = packDrawPrepSinkTableV1(program, state);
+  const sinkTableWords = packed
+    ? new Uint32Array(packed.words.subarray(0, packed.wordCount))
+    : null;
+  const sinkTableWordCount = packed?.wordCount ?? 0;
+  const shapeBankWordCount = assertFiniteUint32(
+    state.shapeBank.volatilePtr,
+    'gpuDrivenShapeBank.wordCount',
+  );
+  const shapeBankWords = new Uint32Array(shapeBankWordCount);
+  if (shapeBankWordCount > 0) {
+    shapeBankWords.set(state.shapeBank.data.subarray(0, shapeBankWordCount), 0);
+  }
+  return {
+    sinkTableWords,
+    sinkTableWordCount,
+    shapeBankWords,
+    shapeBankWordCount,
+  };
+}

--- a/src/services/runtime-hotpath.worker.ts
+++ b/src/services/runtime-hotpath.worker.ts
@@ -1,7 +1,6 @@
 /// <reference lib="webworker" />
 
 import type { CompiledProgramIR } from '../compiler/ir/program';
-import type { InstanceDecl, Step, StepMaterialize } from '../compiler/ir/types';
 import {
   DRAW_PREP_SINK_TABLE_HEADER_WORDS,
   DRAW_PREP_SINK_TABLE_RECORD_WORDS,
@@ -10,19 +9,11 @@ import {
   createRuntimeStateFromSession,
   createSessionState,
   migrateState,
-  packDrawPrepSinkTableV1,
   prepareStateWriteBank,
   reconcilePhaseOffsets,
-  resetShapeBankFrameAllocator,
-  resolveTime,
   type RuntimeState,
   type SessionState,
 } from '../runtime';
-import { arenaEncodeFromAoS, type ArenaSlotDescriptor } from '../runtime/ArenaValueStore';
-import { getExprAddressTable } from '../runtime/ExprAddressTable';
-import { resolveInstanceLaneCount } from '../runtime/InstanceCountResolver';
-import { createMaterializeScratch } from '../runtime/MaterializeScratch';
-import { materializeValueExpr } from '../runtime/ValueExprMaterializer';
 import { createDefaultRegistry } from '../runtime/kernels/default-registry';
 import {
   RUNTIME_INPUT_FLOAT_WORDS,
@@ -36,6 +27,7 @@ import type {
   RuntimeHotpathWorkerOutboundMessage,
   RuntimeHotpathSinkTableSample,
 } from './runtime-hotpath-worker-protocol';
+import { buildRuntimeHotpathInstallPlanes } from './runtime-hotpath-install';
 
 const DEFAULT_TICK_HZ = 60;
 const HEARTBEAT_INTERVAL_MS = 500;
@@ -85,7 +77,6 @@ let viewport: ViewportState = {
   panX: 0,
   panY: 0,
 };
-const WARMUP_MATERIALIZE_SCRATCH = createMaterializeScratch();
 
 function postMessageToMain(payload: RuntimeHotpathWorkerOutboundMessage): void {
   (self as DedicatedWorkerGlobalScope).postMessage(payload);
@@ -121,70 +112,6 @@ function reviveProgram(program: SerializableCompiledProgramIR): CompiledProgramI
   };
 }
 
-
-function materializeStepToArena(
-  program: CompiledProgramIR,
-  state: RuntimeState,
-  step: StepMaterialize,
-  instances: ReadonlyMap<unknown, InstanceDecl>,
-  slotToArena: ReadonlyMap<unknown, ArenaSlotDescriptor>,
-  pureFnContext: { kernelRegistry: CompiledProgramIR['kernelRegistry'] },
-): void {
-  const arenaDesc = slotToArena.get(step.target);
-  if (!arenaDesc || arenaDesc.offset < 0 || arenaDesc.length <= 0) {
-    throw new Error(`runtime-hotpath: materialize slot ${String(step.target)} missing arena descriptor`);
-  }
-  if (state.arena.length < arenaDesc.offset + arenaDesc.length) {
-    throw new Error(
-      `runtime-hotpath: materialize slot ${String(step.target)} exceeds arena ` +
-      `(need=${arenaDesc.offset + arenaDesc.length}, have=${state.arena.length})`,
-    );
-  }
-  const instanceDecl = instances.get(step.instanceId);
-  const count = instanceDecl
-    ? resolveInstanceLaneCount(instanceDecl, program, state, pureFnContext)
-    : 0;
-  const buffer = materializeValueExpr(
-    step.field,
-    program.valueExprs,
-    step.instanceId,
-    count,
-    state,
-    program,
-    undefined,
-    WARMUP_MATERIALIZE_SCRATCH,
-    pureFnContext,
-  );
-  arenaEncodeFromAoS(state.arena, arenaDesc, buffer);
-}
-
-function materializeProgramForGpuInstall(
-  program: CompiledProgramIR,
-  state: RuntimeState,
-  nowMs: number,
-): void {
-  const instances = program.schedule.instances as ReadonlyMap<unknown, InstanceDecl>;
-  const addressTable = getExprAddressTable(program);
-  // [LAW:one-source-of-truth] Worker materialization uses compiler-owned
-  // ExprAddressTable metadata; no local descriptor synthesis.
-  state.cache.scalarExprToArenaAddress = addressTable.scalarExprToArenaAddress;
-  resetShapeBankFrameAllocator(state.shapeBank);
-  WARMUP_MATERIALIZE_SCRATCH.reset();
-  state.time = resolveTime(nowMs, program.schedule.timeModel, state.timeState);
-  // [LAW:single-enforcer] Dynamic instance counts are seeded through the shared
-  // InstanceCountResolver cache contract consumed by DrawPrepSinkTablePacker.
-  state.cache.instanceLaneCounts?.clear();
-  state.cache.instanceLaneCountFrameId = state.cache.frameId;
-  const pureFnContext = { kernelRegistry: program.kernelRegistry };
-  for (const instanceDecl of instances.values()) {
-    resolveInstanceLaneCount(instanceDecl, program, state, pureFnContext);
-  }
-  for (const step of program.schedule.steps as readonly Step[]) {
-    if (step.kind !== 'materialize') continue;
-    materializeStepToArena(program, state, step, instances, addressTable.slotToArena, pureFnContext);
-  }
-}
-
 function buildSinkTableSample(
   words: Uint32Array | null,
   sinkTableWordCount: number,
@@ -211,19 +138,6 @@ function buildSinkTableSample(
       }
       : null,
   };
-}
-
-function buildGpuDrivenSinkTableWords(
-  program: CompiledProgramIR,
-  state: RuntimeState,
-): { words: Uint32Array; wordCount: number } | null {
-  // [LAW:one-source-of-truth] Sink-table metadata comes from one canonical
-  // packer contract for all program types (fluid and non-fluid).
-  const packed = packDrawPrepSinkTableV1(program, state);
-  if (!packed) return null;
-  const words = new Uint32Array(packed.wordCount);
-  words.set(packed.words.subarray(0, packed.wordCount), 0);
-  return { words, wordCount: packed.wordCount };
 }
 
 function installProgram(program: SerializableCompiledProgramIR): void {
@@ -282,30 +196,22 @@ function installProgram(program: SerializableCompiledProgramIR): void {
     );
   }
 
+  let installPlanes: ReturnType<typeof buildRuntimeHotpathInstallPlanes>;
   try {
-    materializeProgramForGpuInstall(revived, nextState, performance.now());
+    // [LAW:single-enforcer] Install-time runtime materialization + sink-table
+    // packing are enforced through one service module boundary.
+    installPlanes = buildRuntimeHotpathInstallPlanes(revived, nextState, performance.now());
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`[runtime-hotpath] install materialization failed: ${message}`);
-  }
-  const warmShapeBankWordCount = assertFiniteUint32(
-    nextState.shapeBank.volatilePtr,
-    'gpuDrivenShapeBank.wordCount',
-  );
-  const warmShapeBankWords = new Uint32Array(warmShapeBankWordCount);
-  if (warmShapeBankWordCount > 0) {
-    warmShapeBankWords.set(
-      nextState.shapeBank.data.subarray(0, warmShapeBankWordCount),
-      0,
-    );
   }
 
   gpuDrivenExecutionEnabled = false;
   gpuDrivenSinkTableWords = null;
   gpuDrivenSinkTableWordCount = 0;
   lastSinkTableSample = null;
-  gpuDrivenShapeBankWords = warmShapeBankWords;
-  gpuDrivenShapeBankWordCount = warmShapeBankWordCount;
+  gpuDrivenShapeBankWords = installPlanes.shapeBankWords;
+  gpuDrivenShapeBankWordCount = installPlanes.shapeBankWordCount;
   publishedSinkWordCount = 0;
   publishedShapeWordCount = 0;
   gpuDrivenPlanesDirty = true;
@@ -314,20 +220,14 @@ function installProgram(program: SerializableCompiledProgramIR): void {
   // artifact cannot satisfy this contract, fail installation instead of
   // reintroducing runtime mode branching.
   // [LAW:no-mode-explosion] Canonical runtime execution keeps one mode.
-  try {
-    const gpuDriven = buildGpuDrivenSinkTableWords(
-      revived,
-      nextState,
+  if (installPlanes.sinkTableWords) {
+    gpuDrivenExecutionEnabled = true;
+    gpuDrivenSinkTableWords = installPlanes.sinkTableWords;
+    gpuDrivenSinkTableWordCount = installPlanes.sinkTableWordCount;
+    lastSinkTableSample = buildSinkTableSample(
+      installPlanes.sinkTableWords,
+      installPlanes.sinkTableWordCount,
     );
-    if (gpuDriven) {
-      gpuDrivenExecutionEnabled = true;
-      gpuDrivenSinkTableWords = gpuDriven.words;
-      gpuDrivenSinkTableWordCount = gpuDriven.wordCount;
-      lastSinkTableSample = buildSinkTableSample(gpuDriven.words, gpuDriven.wordCount);
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    throw new Error(`[runtime-hotpath] GPU sink-table build failed: ${message}`);
   }
   if ((revived.drawPrepProgram?.sinks.length ?? 0) > 0 && !gpuDrivenExecutionEnabled) {
     // [LAW:one-source-of-truth] Draw-prep sink metadata must come from one


### PR DESCRIPTION
## Summary
- remove install-time `executeFrame(...)` warmup from `runtime-hotpath.worker`
- replace warmup fallback helpers with deterministic install-time materialization of `materialize` schedule steps
- seed dynamic instance counts through `InstanceCountResolver` cache and build sink table via canonical `packDrawPrepSinkTableV1`
- keep one GPU-owned publication path with no CPU warmup fallback

## Verification
- `npm run -s typecheck`
