### PR TITLE
Strictify diagnostics action boundary ID validation

### DIFF
--- a/src/diagnostics/__tests__/actionExecutor.test.ts
+++ b/src/diagnostics/__tests__/actionExecutor.test.ts
@@ -13,7 +13,7 @@ import type {
   MuteDiagnosticAction,
   OpenDocsAction,
 } from '../types';
-import type { BlockId } from '../../types';
+import { blockId } from '../../types';
 import { createTestBlockMap, resetBlockFactory } from '../../test-utils/block-factory';
 
 type DepsGetter = () => ActionExecutorDeps;
@@ -24,36 +24,57 @@ type MutableDeps = ActionExecutorDeps & {
 };
 
 function createMockDeps(): ActionExecutorDeps {
-  return {
-    patchStore: {
-      addBlock: vi.fn(() => 'block-123'),
-      addEdge: vi.fn(() => 'edge-new'),
-      removeBlock: vi.fn(),
-      removeEdge: vi.fn(),
-      patch: {
-        blocks: createTestBlockMap([
-          {
-            id: 'block-123' as BlockId,
-            type: 'Gain',
-            inputPorts: new Map([['in', { id: 'in', combineMode: 'last' }]]),
-            outputPorts: new Map([['out', { id: 'out' }]]),
-          },
-          {
-            id: 'block-tr' as BlockId,
-            type: 'InfiniteTimeRoot',
-            inputPorts: new Map(),
-            outputPorts: new Map([['t', { id: 't' }]]),
-          },
-        ]),
-        edges: [
-          {
-            id: 'edge-1',
-            from: { kind: 'port', blockId: 'block-a', slotId: 'out' },
-            to: { kind: 'port', blockId: 'block-b', slotId: 'in' },
-          },
-        ],
+  const patch = {
+    blocks: createTestBlockMap([
+      {
+        id: blockId('block-123'),
+        type: 'Gain',
+        inputPorts: new Map([['in', { id: 'in', combineMode: 'last' }]]),
+        outputPorts: new Map([['out', { id: 'out' }]]),
       },
-    },
+      {
+        id: blockId('block-tr'),
+        type: 'InfiniteTimeRoot',
+        inputPorts: new Map(),
+        outputPorts: new Map([['t', { id: 't' }]]),
+      },
+    ]),
+    edges: [
+      {
+        id: 'edge-1',
+        from: { kind: 'port', blockId: 'block-a', slotId: 'out' },
+        to: { kind: 'port', blockId: 'block-b', slotId: 'in' },
+      },
+    ],
+  };
+
+  const patchStore = {
+    addBlock: vi.fn(() => 'block-123'),
+    addEdge: vi.fn(() => 'edge-new'),
+    removeEdge: vi.fn(),
+    patch,
+    lastIssue: null,
+  } as any;
+
+  patchStore.removeBlock = vi.fn((id: string) => {
+    const block = patch.blocks.get(blockId(id));
+    if (!block) {
+      patchStore.lastIssue = { level: 'warn', message: `Attempted to remove missing block '${id}'` };
+      return;
+    }
+    if (block.type === 'InfiniteTimeRoot') {
+      patchStore.lastIssue = {
+        level: 'warn',
+        message: `Cannot remove protected block '${id}' of type InfiniteTimeRoot`,
+      };
+      return;
+    }
+    patch.blocks.delete(block.id);
+    patch.edges = patch.edges.filter((edge) => edge.from.blockId !== id && edge.to.blockId !== id);
+  });
+
+  return {
+    patchStore,
     selectionStore: {
       selectBlock: vi.fn(),
       selectEdge: vi.fn(),
@@ -323,6 +344,20 @@ function registerRemoveBlockTests(getDeps: DepsGetter): void {
       expect(result.success).toBe(false);
       expect(result.error).toContain('Failed to remove block');
       expect(result.error).toContain('Removal failed');
+    });
+
+    it('fails when PatchStore refuses block removal', () => {
+      const action: RemoveBlockAction = {
+        kind: 'removeBlock',
+        label: 'Remove TimeRoot',
+        blockId: 'block-tr',
+      };
+
+      const result = executeAction(action, getDeps());
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Cannot remove protected block');
+      expect(getDeps().patchStore.removeBlock).toHaveBeenCalledWith('block-tr');
     });
   });
 }

--- a/src/diagnostics/actionExecutor.ts
+++ b/src/diagnostics/actionExecutor.ts
@@ -22,7 +22,7 @@ import type { SelectionStore } from '../stores/SelectionStore';
 import type { DiagnosticsStore } from '../stores/DiagnosticsStore';
 import { requireAnyBlockDef } from '../blocks/registry';
 import type { Block, Edge, Endpoint } from '../graph/Patch';
-import type { PortId } from '../types';
+import { blockId, type PortId } from '../types';
 
 /**
  * Dependencies required for action execution.
@@ -45,12 +45,7 @@ export interface ActionResult {
 function resolveBlockForAction(patchStore: PatchStore, rawBlockId: string): Block | null {
   // [LAW:single-enforcer] ActionExecutor owns action-target resolution and is
   // the only boundary where serialized diagnostic IDs are validated/resolved.
-  for (const block of patchStore.patch.blocks.values()) {
-    if (block.id === rawBlockId) {
-      return block;
-    }
-  }
-  return null;
+  return patchStore.patch.blocks.get(blockId(rawBlockId)) ?? null;
 }
 
 function isKnownPortIdForBlock(block: Block, rawPortId: string): rawPortId is PortId {
@@ -64,7 +59,9 @@ function unsupportedActionKind(_action: never): ActionResult {
 }
 
 function unsupportedTargetKind(_target: never): ActionResult {
-  return { success: false, error: 'Unsupported target kind' };
+  const kind = (_target as { kind?: unknown } | null | undefined)?.kind;
+  const suffix = kind === undefined ? '' : ` (kind: ${String(kind)})`;
+  return { success: false, error: `Unsupported target kind${suffix}` };
 }
 
 type ActionKind = DiagnosticAction['kind'];
@@ -339,8 +336,19 @@ function handleRemoveBlock(
       };
     }
 
-    // Remove block (also removes connected edges automatically)
+    const issueBeforeRemove = patchStore.lastIssue;
     patchStore.removeBlock(block.id);
+
+    if (resolveBlockForAction(patchStore, blockId)) {
+      // [LAW:no-silent-fallbacks] Report refusal to mutate as ActionResult failure.
+      const refusalMessage = patchStore.lastIssue && patchStore.lastIssue !== issueBeforeRemove
+        ? patchStore.lastIssue.message
+        : `Block ${blockId} could not be removed`;
+      return {
+        success: false,
+        error: refusalMessage,
+      };
+    }
 
     return { success: true };
   } catch (err) {


### PR DESCRIPTION
Closes #226

## Summary
- strict deserialization boundary for diagnostic action target IDs
- remove cast-style ID admission in action execution path
- update tests to use explicit valid block/port fixtures
