### PR TITLE
build(x80.1): renderer-shell baseline verification gate + contract

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,3 +63,23 @@ jobs:
       - run: sudo apt-get update && sudo apt-get install -y ripgrep
       - run: pnpm install --frozen-lockfile
       - run: pnpm test
+
+  renderer-shell-baseline:
+    # [LAW:single-enforcer] CI runs the same one command a developer runs
+    # locally (npm run verify:renderer-shell), so the Three-migration baseline
+    # has one definition the script owns — not a second copy inlined here.
+    name: Renderer-shell baseline
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps chromium
+      - run: pnpm run verify:renderer-shell

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage/
 *.log
 playwright-report/
 test-results/
+artifacts/three-migration/renderer-shell-baseline/
 
 # Vite cache
 node_modules/.vite/

--- a/design-docs/three-migration-renderer-shell-baseline.md
+++ b/design-docs/three-migration-renderer-shell-baseline.md
@@ -1,0 +1,122 @@
+# Three Migration Renderer-Shell Baseline
+
+**Date:** 2026-06-23
+**Status:** Groundwork
+**Backlog:** `oscilla-pillars-cleanup-x80.1`
+
+## Purpose
+
+Define what counts as a *passing renderer/runtime-shell baseline* and make it
+mechanically checkable, so Three-migration work can be judged by a command
+instead of by guesswork.
+
+`// [LAW:verifiable-goals]` Backend migration tickets need a deterministic "is
+the shell still green?" check before and after their work, not ad hoc manual
+inspection.
+`// [LAW:single-enforcer]` Baseline verification ownership lives in one
+renderer/runtime smoke path, not scattered across each ticket.
+
+## The One Command
+
+```
+npm run verify:renderer-shell
+```
+
+Implementation: [`scripts/verify-renderer-shell-baseline.mjs`](../scripts/verify-renderer-shell-baseline.mjs).
+
+This is the canonical baseline gate. It runs three gates in order, reports each
+result, writes a machine-readable summary, and exits non-zero if any gate fails.
+A green run prints `RENDERER-SHELL BASELINE: PASS`.
+
+`// [LAW:no-silent-failure]` Every gate runs and every result is reported. A
+skipped or swallowed gate would let a red baseline masquerade as green for the
+ticket that builds on top of it.
+
+## The Three Gates
+
+| Gate | What runs | What it proves |
+| --- | --- | --- |
+| `typecheck` | `tsc -b` (`npm run typecheck`) | The TS↔runtime↔render contracts still type. Includes the WebGPU capability shim (`NavigatorWithGpu`). |
+| `runtime-tests` | Vitest over the renderer-shell targeted set (below) | Runtime lifecycle, compile/hot-swap, and render-facade fault policy still behave. |
+| `app-shell-smoke` | Playwright `tests/e2e/editor/demo-bootstrap.spec.ts` | The real app shell boots, the runtime bootstrap probe reaches `succeeded`, and at least one frame renders with no fatal runtime/bootstrap error. |
+
+### Targeted runtime test set
+
+`// [LAW:one-source-of-truth]` The list is declared once in
+`scripts/verify-renderer-shell-baseline.mjs` (`RENDERER_SHELL_TESTS`). This table
+is a description of *why* those files are the set, not a second copy to keep in
+sync.
+
+The set is exactly the tests covering the **"Keep"** surfaces named in
+[three-migration-renderer-seam-inventory.md](./three-migration-renderer-seam-inventory.md):
+
+- runtime lifecycle — `RuntimeService`, `AnimationLoop`
+- compile / hot-swap — `CompileOrchestrator` schedule contract, `LiveRecompile`
+- render-facade fault policy — `renderer-circuit-breaker`
+
+`// [LAW:decomposition]` The cut follows the migration's real joint — the
+surfaces that must stay stable while the renderer underneath
+`createWebGPURenderer()` is replaced — not "tests that look runtime-ish". The
+frozen `gpu-ir` / shape-bank tests are deliberately excluded: they cover the
+legacy backend the migration is replacing.
+
+## Passing Baseline Definition
+
+The renderer-shell baseline is **green** when, on a clean install
+(`pnpm install --frozen-lockfile`):
+
+1. `typecheck` exits 0.
+2. The targeted runtime test set passes with no failures.
+3. The app-shell smoke check passes: bootstrap reaches `succeeded`, a frame
+   renders, and none of the demo-bootstrap failure signals fire.
+
+Equivalently: `npm run verify:renderer-shell` exits 0 and prints
+`RENDERER-SHELL BASELINE: PASS`.
+
+### Artifact
+
+The gate writes
+`artifacts/three-migration/renderer-shell-baseline/summary.json`
+(git-ignored — derived, not authoritative) with per-gate `passed`/`duration_ms`/`reason`,
+the commit, and an overall `passed`. Downstream tickets may assert against it.
+
+## Failure Signals
+
+The baseline is **red** when any of:
+
+- `tsc -b` reports any error (notably any reintroduced `NavigatorWithGpu`
+  capability-shim mismatch — see below).
+- Any targeted runtime test fails.
+- The app shell fails to boot, the bootstrap probe never reaches `succeeded`,
+  no frame renders, or a fatal runtime/bootstrap error is captured.
+
+A red gate makes `verify:renderer-shell` exit non-zero. Fix the regression;
+do not gate it away.
+
+## Baseline State At This Ticket
+
+Verified green at commit `dfcc376a` (origin/master):
+
+- `npm run typecheck` — clean. The `NavigatorWithGpu` typecheck mismatch named
+  in this ticket was already resolved upstream
+  ([`src/render/webgpu/gpu-api.ts`](../src/render/webgpu/gpu-api.ts), PR #235):
+  `getNavigatorGpu()` reads `navigator as Partial<NavigatorWithGpu>` against a
+  module-local interface, so no DOM-lib `navigator.gpu` type conflict remains.
+  There was no live failure to fix; the gate now guards against its return.
+- Full Vitest suite — 207 files / 2076 tests pass (1 file, 3 tests skipped/todo).
+- App-shell smoke (`demo-bootstrap`) — passes.
+
+## Scope Boundary
+
+`// [LAW:locality-or-seam]` This ticket adds verification and documentation only.
+
+This baseline introduces **no** backend implementation: no `ScenePlan`, no
+`ThreeForkRenderer`, no renderer behavior change. The renderer behind
+`createWebGPURenderer()` remains the scorched-earth stub. Those land in the
+`ulu` implementation stack, which must keep this baseline green.
+
+## Related References
+
+- [three-migration-renderer-seam-inventory.md](./three-migration-renderer-seam-inventory.md) — keep/adapter/freeze/delete map and the cut points.
+- [three-migration-first-proof-contract.md](./three-migration-first-proof-contract.md) — the steel-thread proof contract (`ulu.5`), which adds its own `tests/e2e/webgpu/three-grid-of-squares.spec.ts` on top of this shell baseline.
+- [three-migration-backend-canon.md](./three-migration-backend-canon.md) — backend ownership and guardrails.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "test:payload-tester-visible": "node scripts/check-payload-tester-visible.mjs",
     "ci:webgpu-readiness": "node scripts/webgpu-ci-readiness-gate.mjs",
     "test:migration-readiness": "node scripts/webgpu-migration-readiness.mjs",
+    "verify:renderer-shell": "node scripts/verify-renderer-shell-baseline.mjs",
     "bench": "vitest bench",
     "lint": "eslint src",
     "build:rust-renderer": "scripts/build-rust-renderer.sh",

--- a/scripts/verify-renderer-shell-baseline.mjs
+++ b/scripts/verify-renderer-shell-baseline.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+// Renderer/runtime-shell baseline verification gate.
+//
+// [LAW:single-enforcer] This is the ONE command that answers "is the
+// renderer/runtime shell baseline green enough to verify Three-migration work?"
+// Future migration tickets run this instead of ad hoc manual checks, so the
+// answer is mechanical, not a matter of opinion.
+// [LAW:no-silent-failure] Every gate runs, every result is reported explicitly,
+// and any failure makes the whole run exit non-zero. A skipped or swallowed
+// gate would let a red baseline masquerade as green for downstream tickets.
+//
+// Contract: design-docs/three-migration-renderer-shell-baseline.md
+
+import { execSync, spawnSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+// [LAW:one-source-of-truth] The renderer-shell targeted test set is exactly the
+// tests covering the canonical "Keep" surfaces named in
+// design-docs/three-migration-renderer-seam-inventory.md: runtime lifecycle
+// (RuntimeService, AnimationLoop), compile/hot-swap (CompileOrchestrator,
+// LiveRecompile), and render-facade fault policy (renderer-circuit-breaker).
+// It is declared here once; the doc points back to this list, not a copy.
+const RENDERER_SHELL_TESTS = [
+  'src/services/__tests__/RuntimeService.test.ts',
+  'src/services/__tests__/AnimationLoop.test.ts',
+  'src/services/__tests__/runtime-gpu-fault-policy.test.ts',
+  'src/services/__tests__/CompileOrchestrator.schedule-contract.test.ts',
+  'src/services/__tests__/LiveRecompile.test.ts',
+  'src/render/webgpu/__tests__/renderer-circuit-breaker.test.ts',
+];
+
+// [LAW:one-source-of-truth] The app-shell smoke check is the existing
+// demo-bootstrap spec: it boots the real app shell, asserts the runtime
+// bootstrap probe reaches "succeeded", and asserts at least one rendered frame.
+const SMOKE_SPEC = 'tests/e2e/editor/demo-bootstrap.spec.ts';
+
+const ARTIFACT_DIR = 'artifacts/three-migration/renderer-shell-baseline';
+const ARTIFACT_FILE = path.join(ARTIFACT_DIR, 'summary.json');
+
+// The three gates, in order. Each is one self-contained promise about one
+// dimension of the baseline. [LAW:decomposition]
+const GATES = [
+  {
+    id: 'typecheck',
+    title: 'TypeScript typecheck (tsc -b)',
+    command: 'pnpm',
+    args: ['-s', 'typecheck'],
+  },
+  {
+    id: 'runtime-tests',
+    title: 'Targeted renderer/runtime-shell tests',
+    command: 'pnpm',
+    args: ['-s', 'exec', 'vitest', 'run', ...RENDERER_SHELL_TESTS, '--reporter=dot'],
+  },
+  {
+    id: 'app-shell-smoke',
+    title: 'App-shell smoke (demo-bootstrap)',
+    command: 'pnpm',
+    args: ['-s', 'exec', 'playwright', 'test', SMOKE_SPEC, '--reporter=line'],
+  },
+];
+
+function currentCommit() {
+  try {
+    return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function runGate(gate) {
+  process.stdout.write(`\n=== gate: ${gate.id} — ${gate.title} ===\n`);
+  const startedAt = Date.now();
+  const result = spawnSync(gate.command, gate.args, {
+    stdio: 'inherit',
+    env: process.env,
+  });
+  const durationMs = Date.now() - startedAt;
+
+  // [LAW:no-silent-failure] A missing binary or killed process is a gate
+  // failure with a named reason, never a pass-through.
+  if (result.error) {
+    return { id: gate.id, title: gate.title, passed: false, durationMs, reason: result.error.message };
+  }
+  if (result.signal) {
+    return { id: gate.id, title: gate.title, passed: false, durationMs, reason: `terminated by signal ${result.signal}` };
+  }
+  return {
+    id: gate.id,
+    title: gate.title,
+    passed: result.status === 0,
+    durationMs,
+    reason: result.status === 0 ? null : `exit status ${result.status}`,
+  };
+}
+
+function formatDuration(ms) {
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function main() {
+  const commit = currentCommit();
+  const results = GATES.map(runGate);
+  const allPassed = results.every((r) => r.passed);
+
+  // [LAW:verifiable-goals] Emit a machine-readable artifact so downstream
+  // tickets (e.g. ThreeForkRenderer integration) can assert the baseline state
+  // mechanically rather than re-deriving it.
+  mkdirSync(ARTIFACT_DIR, { recursive: true });
+  const summary = {
+    baseline: 'renderer-shell',
+    generated_at: new Date().toISOString(),
+    commit,
+    passed: allPassed,
+    gates: results.map((r) => ({
+      id: r.id,
+      title: r.title,
+      passed: r.passed,
+      duration_ms: r.durationMs,
+      reason: r.reason,
+    })),
+  };
+  writeFileSync(ARTIFACT_FILE, `${JSON.stringify(summary, null, 2)}\n`);
+
+  process.stdout.write('\n================ RENDERER-SHELL BASELINE ================\n');
+  for (const r of results) {
+    const status = r.passed ? 'PASS' : 'FAIL';
+    const reason = r.reason ? `  (${r.reason})` : '';
+    process.stdout.write(`  [${status}] ${r.id.padEnd(16)} ${formatDuration(r.durationMs).padStart(7)}${reason}\n`);
+  }
+  process.stdout.write(`  artifact: ${ARTIFACT_FILE}\n`);
+  process.stdout.write(`  commit:   ${commit}\n`);
+  process.stdout.write('=========================================================\n');
+  process.stdout.write(`RENDERER-SHELL BASELINE: ${allPassed ? 'PASS' : 'FAIL'}\n`);
+
+  process.exit(allPassed ? 0 : 1);
+}
+
+main();


### PR DESCRIPTION
## What

Closes `oscilla-pillars-cleanup-x80.1` — the last Three-migration groundwork prerequisite (blocks `ulu.2`).

Establishes one deterministic gate for the renderer/runtime shell so migration work is judged mechanically, not by guesswork.

## Deliverables

- **`scripts/verify-renderer-shell-baseline.mjs`** + `npm run verify:renderer-shell` — one command running three gates and exiting non-zero on any failure:
  | Gate | Runs | Proves |
  |---|---|---|
  | `typecheck` | `tsc -b` | TS↔runtime↔render contracts type (incl. the `NavigatorWithGpu` shim) |
  | `runtime-tests` | Vitest over the seam-inventory **"Keep"** surfaces | runtime lifecycle, compile/hot-swap, render-facade fault policy |
  | `app-shell-smoke` | Playwright `demo-bootstrap` | app shell boots, bootstrap probe `succeeded`, ≥1 frame renders |
  - `// [LAW:single-enforcer]` one owner of "is the shell baseline green?"
  - `// [LAW:no-silent-failure]` every gate runs and reports; failure is loud.
  - `// [LAW:one-source-of-truth]` the targeted test list is declared once in the script; the doc points back to it.
- **`design-docs/three-migration-renderer-shell-baseline.md`** — defines the passing baseline, failure signals, and the verified-green snapshot at `origin/master`.
- **CI** — a `renderer-shell-baseline` job runs the *same* command, so CI and local share one baseline definition.

## On the ticket's premise

The ticket assumed a red baseline to fix (including "the existing NavigatorWithGpu typecheck mismatch"). On current `master` the baseline is **already green**: typecheck clean, full Vitest suite (207 files / 2076 tests) passing, app-shell smoke passing. The `NavigatorWithGpu` mismatch was resolved upstream in PR #235. So the real deliverable is locking that green state behind a deterministic, automated gate — which is what this PR adds.

## Scope boundary

No backend implementation. The renderer behind `createWebGPURenderer()` stays the scorched-earth stub; `ScenePlan`/`ThreeForkRenderer` land in the `ulu` stack, which must keep this gate green.

## Verification

`npm run verify:renderer-shell` → `RENDERER-SHELL BASELINE: PASS` (typecheck ✓, runtime-tests ✓ 6/6 files, app-shell-smoke ✓). Failure path verified to exit non-zero.