### PR TITLE
feat(ulu.1): backend-neutral ScenePlan + resource handles

### DIFF
--- a/design-docs/three-migration-scene-plan.md
+++ b/design-docs/three-migration-scene-plan.md
@@ -1,0 +1,156 @@
+# Three Migration ScenePlan: Backend-Neutral Assembly Target
+
+**Date:** 2026-06-23
+**Status:** Groundwork
+**Backlog:** `oscilla-pillars-cleanup-ulu.1`
+**Scope source:** [three-fork-integration-proposal.md](./three-fork-integration-proposal.md) §2.2, §4
+**Ownership/seam canon:** [three-migration-backend-canon.md](./three-migration-backend-canon.md)
+**Proof target shape:** [three-migration-first-proof-contract.md](./three-migration-first-proof-contract.md)
+
+## Purpose
+
+This note records how the backend-neutral `ScenePlan` introduced by
+`oscilla-pillars-cleanup-ulu.1` **replaces** `PipelineInstallPayload` as the
+primary compiler→renderer assembly target — and why that replacement is a clean
+swap, not a second owner running alongside the first.
+
+The types live in [`src/render/scene-plan/`](../src/render/scene-plan/):
+
+| File | Contents |
+|------|----------|
+| `refs.ts` | The six backend-neutral resource handles + their constructors. |
+| `expr.ts` | `PlanExpr` — serializable per-value expressions + builders. |
+| `plan.ts` | `ScenePlan`, `RenderPlan`, resources, scene objects, resource defs. |
+| `index.ts` | Public surface. |
+| `__tests__/scene-plan.test.ts` | Contract tests: shape + handle discipline. |
+
+## What ScenePlan Is
+
+`ScenePlan` is the compiled, backend-neutral description of one renderable
+scene. The compiler assembler (`oscilla-pillars-cleanup-ulu.3`) produces it; the
+Three-backed renderer behind `createWebGPURenderer()`
+(`oscilla-pillars-cleanup-ulu.2`) consumes it.
+
+```
+user patch ─► normalized graph ─► ScenePlan ─► Three backend
+                                   ▲                ▲
+                                 ulu.3            ulu.2
+```
+
+Its nouns:
+
+- **Resource handles** (`GeometryRef`, `MaterialRef`, `TextureRef`,
+  `SceneObjectRef`, `ComputeResourceRef`, `PostChainRef`) — branded string
+  handles, foreign keys into the plan's normalized resource tables. A handle
+  carries identity only; it is never a Three object, UUID, or class.
+- **`PlanExpr`** — a serializable description of how one scalar value is
+  computed from runtime inputs (`time`) and per-instance intrinsics
+  (`index`, `rank`). The renderer translates a `PlanExpr` into a TSL node graph.
+- **`ScenePlan` / `RenderPlan`** — the normalized resource tables, the placed
+  scene objects that compose resources, and the per-frame render orchestration
+  (camera, declared input channels, ordered draws, optional post chain).
+
+`// [LAW:locality-or-seam]` The handles *are* the seam. ulu.3 mints them; ulu.2
+resolves them. Neither side reads the other's internals.
+
+## The Replacement — and Why There Is No Dual Ownership
+
+The legacy path assembled to `PipelineInstallPayload`
+(`src/render/rust/boundary-contract.ts`): `{ manifest, roster }`, a Rust-
+boundary-oriented shape carrying `MemoryManifest`, `RosterEntry`, and the
+custom `ExprIR`. That payload was designed to cross the TS→Rust/WASM boundary
+and feed the custom GPU-IR renderer. The canon lists it under **Dead Concepts**.
+
+`ScenePlan` replaces it as the *primary assembly target*. The replacement is a
+**swap, not a fork of ownership**, and the following rules make that precise:
+
+1. **No wrapping.** `ScenePlan` does not contain, embed, or reference a
+   `PipelineInstallPayload`, `manifest`, `roster`, or any `boundary-contract`
+   type. (Enforced by a source-level contract test: no scene-plan source file
+   imports `boundary-contract`.)
+   `// [LAW:one-source-of-truth]` A concept has one authoritative representation.
+   `ScenePlan` is that representation for the Three path; it does not derive
+   from or sync with the Rust payload.
+
+2. **No round-trip.** Nothing lowers a `ScenePlan` back into a
+   `PipelineInstallPayload` to keep old tooling alive. The canon forbids
+   "rebuild Rust payloads from `ScenePlan` just to preserve old tooling."
+   `// [LAW:no-silent-failure]` A reconstructed legacy payload would be a second
+   source of truth that silently drifts from the plan.
+
+3. **The legacy payload is frozen, not deleted-yet.** `PipelineInstallPayload`
+   and `src/pillars/assembly/payload.ts` remain only as legacy artifacts of the
+   dead Rust path during migration (canon §"Dead Concepts"). New backend work
+   targets `ScenePlan`. The two targets do not co-assemble from one graph: the
+   Three path produces a `ScenePlan`, the (frozen) Rust path produces a
+   `PipelineInstallPayload`, and the migration converges on the former.
+
+`// [LAW:carrying-cost]` A backend-neutral plan composes with any renderer at
+near-zero coupling; a Rust-boundary payload couples the compiler to one dead
+backend. Replacing the target lowers the carrying cost of every downstream
+ticket.
+
+## Concept Mapping
+
+| Legacy (`PipelineInstallPayload` / boundary-contract) | New (`ScenePlan`) |
+|---|---|
+| `PipelineInstallPayload { manifest, roster }` | `ScenePlan { version, resources, objects, render }` |
+| `MemoryManifest` (globals, domains, textures, shapes, samplers) | `ScenePlan.resources` tables, keyed by ref |
+| `StaticGeometrySpec` / shape-bank entry | `GeometryDef` behind a `GeometryRef` |
+| material baked into roster render entry | `MaterialDef` behind a `MaterialRef` |
+| `TextureSpec` (inline) | `TextureDef` behind a `TextureRef` (asset-resolved; ulu.4) |
+| `RosterEntry` (compute/drawPrep/render passes) | `RenderPlan.draws` + scene objects (compute/post deferred) |
+| `ExprIR` (Rust-translated AST) | `PlanExpr` (TSL-translated, backend-neutral) |
+| `InstanceDomainSpec` count + active | `InstancingPlan.count` + per-instance `PlanExpr` transform |
+| `CameraInputContract` `cameraProjection` flag | `CameraPlan` discriminated variant |
+| runtime input shared-buffer fields | `RenderPlan.inputs` (declared `PlanInputChannel`s) |
+
+## Backend-Neutrality Guarantees
+
+A `ScenePlan` is **pure data**:
+
+- It is fully JSON-serializable — no functions, no class instances, no Three
+  objects. (Enforced: a `JSON.parse(JSON.stringify(plan))` round-trip is
+  structurally equal to the original.)
+- It names resources by branded handle, never by renderer object.
+- It imports nothing from `three`, `render/wasm`, or `boundary-contract`.
+
+`// [LAW:behavior-not-structure]` The contract tests assert what the plan
+*means* — that it can represent the `Grid of Squares` proof target and that its
+handles resolve — not how a renderer realizes it.
+
+## Deferred Surface
+
+The first proof target (`Grid of Squares`) needs no textures, compute, or
+postprocessing. Those refs exist (the assembly contract requires all six), but
+their resource definitions are minimal placeholders and their tables are empty
+for the steel thread:
+
+- **Textures** — asset decoding is owned by `oscilla-pillars-cleanup-ulu.4`
+  (`AssetRegistry` + `ThreeLoadingBridge`). `TextureDef.assetId` is a plain
+  string until the branded `AssetId` lands with that ticket.
+- **Compute / storage** — served by TSL compute when a ticket first needs
+  solver-style work (three-fork-deltas.md §3, §4.2).
+- **Post chains** — served by Three post nodes when a ticket first needs
+  postprocessing (three-fork-deltas.md §3).
+
+`// [LAW:dataflow-not-control-flow]` Deferred capabilities are empty collections
+in the plan, not absent fields or mode flags. The shape is fixed; only the
+contents vary.
+
+## Handoff
+
+- `oscilla-pillars-cleanup-ulu.2` realizes a `ScenePlan` behind
+  `createWebGPURenderer()` (translate `PlanExpr`→TSL, `GeometryDef`→Three
+  geometry, `MaterialDef`→`NodeMaterial`).
+- `oscilla-pillars-cleanup-ulu.3` lowers authored patch semantics into a
+  `ScenePlan` (replacing `assemblePipelineInstallPayload`).
+- `oscilla-pillars-cleanup-ulu.5` proves `Grid of Squares` renders through the
+  Three backend per the first-proof contract.
+
+## Related References
+
+- [three-fork-integration-proposal.md](./three-fork-integration-proposal.md) — migration scope source
+- [three-migration-backend-canon.md](./three-migration-backend-canon.md) — ownership, seams, dead concepts
+- [three-fork-deltas.md](./three-fork-deltas.md) — capability surface, tiers, deferred items
+- [three-migration-first-proof-contract.md](./three-migration-first-proof-contract.md) — steel-thread target + verification

--- a/src/render/scene-plan/__tests__/scene-plan.test.ts
+++ b/src/render/scene-plan/__tests__/scene-plan.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Contract tests for the backend-neutral ScenePlan.
+ *
+ * These assert plan SHAPE and HANDLE discipline, never Three implementation
+ * details (there are none to assert — that is the point). The centerpiece is
+ * building the first proof target, `Grid of Squares`
+ * (design-docs/three-migration-first-proof-contract.md §"Required Compiler
+ * Capabilities"), entirely through the public ScenePlan API: if the type can
+ * represent that patch, ulu.3 has a lowering target and ulu.2 has a contract.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+import {
+  SCENE_PLAN_VERSION,
+  defineScenePlan,
+  geometryRef,
+  materialRef,
+  sceneObjectRef,
+  konst,
+  input,
+  intrinsic,
+  floor,
+  mul,
+  add,
+  mod,
+  div,
+  type ScenePlan,
+} from '../index';
+
+const SCENE_PLAN_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Build the `Grid of Squares` proof target: a 10×10 grid of squares with
+ * per-instance rotation and HSL color animated over time. Pure index/rank math;
+ * no GridLayout block (design-docs/DEMO-PATCHES.md §"Grid of Squares").
+ */
+function buildGridOfSquares(): ScenePlan {
+  const square = geometryRef('grid:square');
+  const unlit = materialRef('grid:unlit-hsl');
+  const grid = sceneObjectRef('grid:object');
+
+  const index = intrinsic('index');
+  const rank = intrinsic('rank');
+  const time = input('time');
+
+  // col = mod(index, 10); row = floor(index / 10)
+  const col = mod(index, konst(10));
+  const row = floor(div(index, konst(10)));
+
+  return defineScenePlan({
+    version: SCENE_PLAN_VERSION,
+    resources: {
+      geometries: { [square]: { kind: 'rectangle', width: 0.08, height: 0.08 } },
+      materials: {
+        [unlit]: {
+          kind: 'unlitColor',
+          color: {
+            space: 'hsl',
+            // hue = rank + time * 0.2
+            h: add(rank, mul(time, konst(0.2))),
+            s: konst(0.8),
+            l: konst(0.6),
+          },
+        },
+      },
+      textures: {},
+      computeResources: {},
+      postChains: {},
+    },
+    objects: {
+      [grid]: {
+        geometry: square,
+        material: unlit,
+        instancing: {
+          count: 100,
+          transform: {
+            // pos_x = col * 0.1, pos_y = row * 0.1
+            positionX: mul(col, konst(0.1)),
+            positionY: mul(row, konst(0.1)),
+            // rotation = index * 0.5 + time * 2.0
+            rotation: add(mul(index, konst(0.5)), mul(time, konst(2.0))),
+          },
+        },
+      },
+    },
+    render: {
+      camera: { kind: 'orthographic', halfExtentX: 0.6, halfExtentY: 0.6 },
+      inputs: ['time'],
+      draws: [{ target: 'previewCanvas', object: grid }],
+      postChain: null,
+    },
+  });
+}
+
+describe('ScenePlan — Grid of Squares proof target', () => {
+  const plan = buildGridOfSquares();
+
+  it('declares the plan schema version', () => {
+    expect(plan.version).toBe(SCENE_PLAN_VERSION);
+  });
+
+  it('declares one instance domain with count 100', () => {
+    const grid = plan.objects[sceneObjectRef('grid:object')];
+    expect(grid.instancing.count).toBe(100);
+  });
+
+  it('exposes index and rank as per-instance intrinsics in the transform', () => {
+    const grid = plan.objects[sceneObjectRef('grid:object')];
+    // rotation = index * 0.5 + time * 2.0 — index intrinsic + time input present.
+    expect(JSON.stringify(grid.instancing.transform.rotation)).toContain('"intrinsic"');
+    expect(JSON.stringify(grid.instancing.transform.rotation)).toContain('"index"');
+  });
+
+  it('binds time as a runtime input channel, not a compile-time constant', () => {
+    expect(plan.render.inputs).toContain('time');
+    const grid = plan.objects[sceneObjectRef('grid:object')];
+    // The time term is an `input`, structurally distinct from a `const`.
+    const rotation = JSON.stringify(grid.instancing.transform.rotation);
+    expect(rotation).toContain('"input"');
+    expect(rotation).toContain('"time"');
+  });
+
+  it('references one canonical rectangle geometry resource by handle', () => {
+    const grid = plan.objects[sceneObjectRef('grid:object')];
+    const geo = plan.resources.geometries[grid.geometry];
+    expect(geo.kind).toBe('rectangle');
+  });
+
+  it('references one unlit HSL color material by handle', () => {
+    const grid = plan.objects[sceneObjectRef('grid:object')];
+    const mat = plan.resources.materials[grid.material];
+    expect(mat.kind).toBe('unlitColor');
+    expect(mat.color.space).toBe('hsl');
+  });
+
+  it('emits one draw item targeting the preview canvas', () => {
+    expect(plan.render.draws).toHaveLength(1);
+    expect(plan.render.draws[0].target).toBe('previewCanvas');
+    expect(plan.render.draws[0].object).toBe(sceneObjectRef('grid:object'));
+  });
+
+  it('leaves deferred resource tables empty for the steel thread', () => {
+    expect(plan.resources.textures).toEqual({});
+    expect(plan.resources.computeResources).toEqual({});
+    expect(plan.resources.postChains).toEqual({});
+    expect(plan.render.postChain).toBeNull();
+  });
+});
+
+describe('ScenePlan — handle discipline', () => {
+  it('resolves a draw item to its scene object, and that object to its resources', () => {
+    const plan = buildGridOfSquares();
+    const draw = plan.render.draws[0];
+    const object = plan.objects[draw.object];
+    expect(object).toBeDefined();
+    // Foreign-key resolution: object handles index into the resource tables.
+    expect(plan.resources.geometries[object.geometry]).toBeDefined();
+    expect(plan.resources.materials[object.material]).toBeDefined();
+  });
+
+  it('is fully JSON-serializable — no functions, no renderer objects', () => {
+    const plan = buildGridOfSquares();
+    const roundTripped = JSON.parse(JSON.stringify(plan));
+    // A backend object (Three mesh/material) or a closure would not survive a
+    // JSON round-trip unchanged. Structural equality proves the plan is data.
+    expect(roundTripped).toEqual(plan);
+  });
+});
+
+describe('ScenePlan — backend neutrality (source-level)', () => {
+  it('imports nothing from the Rust boundary or any renderer backend', () => {
+    const sources = readdirSync(SCENE_PLAN_DIR)
+      .filter((f) => f.endsWith('.ts'))
+      .map((f) => readFileSync(join(SCENE_PLAN_DIR, f), 'utf8'));
+    expect(sources.length).toBeGreaterThan(0);
+    for (const src of sources) {
+      // [LAW:one-source-of-truth] ScenePlan must not re-derive or depend on the
+      // frozen Rust-boundary payload (no dual ownership).
+      expect(src).not.toContain('boundary-contract');
+      // [LAW:locality-or-seam] No Three / WASM coupling leaks into the plan types.
+      expect(src).not.toMatch(/from ['"]three/);
+      expect(src).not.toContain('render/wasm');
+    }
+  });
+});

--- a/src/render/scene-plan/expr.ts
+++ b/src/render/scene-plan/expr.ts
@@ -1,0 +1,101 @@
+/**
+ * src/render/scene-plan/expr.ts
+ *
+ * Backend-neutral per-value expressions for the compiled ScenePlan.
+ *
+ * Scope source: design-docs/three-fork-integration-proposal.md §3 (Oscilla
+ * fields/expressions align with TSL expressions), §4.4.
+ * Proof target: design-docs/three-migration-first-proof-contract.md
+ *   ("pure math expressions for grid layout and rotation").
+ *
+ * A PlanExpr is a serializable description of how one scalar value is computed
+ * from runtime inputs and per-instance intrinsics. It is NOT a renderer object:
+ * the Three backend (ulu.2) translates a PlanExpr into a TSL node graph; the
+ * compiler (ulu.3) produces PlanExprs from authored patch semantics.
+ *
+ * [LAW:effects-at-boundaries] The plan carries a *description* of the
+ *   computation, not the computation itself. The act of evaluating it (in TSL,
+ *   on the GPU) happens behind the renderer seam.
+ * [LAW:dataflow-not-control-flow] A PlanExpr's structure mirrors its data flow;
+ *   `kind` is the single discriminant and variability lives in the operands.
+ * [LAW:no-mode-explosion] The operator vocabulary is sized to the demo patches
+ *   the first proof targets require (Grid of Squares, Spirograph, Kaleidoscope).
+ *   New operators are added to these unions; consumers stay exhaustive.
+ */
+
+/**
+ * A runtime-updated scalar input channel the plan may read.
+ *
+ * [LAW:one-source-of-truth] These mirror the runtime input envelope (see
+ *   src/render/types.ts RuntimeInputSignalContract) by semantic name, so the
+ *   renderer can bind a channel to the per-frame value without the plan
+ *   coupling to the worker transport shape.
+ *
+ * `time` is the only channel the first proof target (Grid of Squares) requires;
+ * the rest mirror the existing runtime envelope for later patches.
+ */
+export type PlanInputChannel =
+  | 'time'
+  | 'mouseX'
+  | 'mouseY'
+  | 'mouseButtons'
+  | 'audioLow'
+  | 'audioMid'
+  | 'audioHigh'
+  | 'gaugeActive';
+
+/**
+ * A per-instance Field intrinsic. `index` is the integer instance ordinal;
+ * `rank` is the normalized [0, 1) position of the instance within its domain.
+ */
+export type PlanIntrinsic = 'index' | 'rank';
+
+/** Single-operand math operators. */
+export type PlanUnaryOp = 'floor' | 'sin' | 'cos' | 'negate';
+
+/** Two-operand math operators. */
+export type PlanBinaryOp = 'add' | 'sub' | 'mul' | 'div' | 'mod';
+
+/**
+ * A backend-neutral scalar expression.
+ *
+ * The `input` vs `const` split structurally encodes the proof-contract
+ * requirement that time is "a runtime-updated input channel, not a
+ * compile-time constant": a runtime value is `input`, a baked value is `const`,
+ * and they are different shapes rather than a flag on one shape.
+ */
+export type PlanExpr =
+  | { readonly kind: 'const'; readonly value: number }
+  | { readonly kind: 'input'; readonly channel: PlanInputChannel }
+  | { readonly kind: 'intrinsic'; readonly name: PlanIntrinsic }
+  | { readonly kind: 'unary'; readonly op: PlanUnaryOp; readonly arg: PlanExpr }
+  | {
+      readonly kind: 'binary';
+      readonly op: PlanBinaryOp;
+      readonly lhs: PlanExpr;
+      readonly rhs: PlanExpr;
+    };
+
+// ---------------------------------------------------------------------------
+// Builders — terse constructors for readable plan construction and tests.
+// ---------------------------------------------------------------------------
+
+export const konst = (value: number): PlanExpr => ({ kind: 'const', value });
+export const input = (channel: PlanInputChannel): PlanExpr => ({ kind: 'input', channel });
+export const intrinsic = (name: PlanIntrinsic): PlanExpr => ({ kind: 'intrinsic', name });
+
+const unary = (op: PlanUnaryOp) => (arg: PlanExpr): PlanExpr => ({ kind: 'unary', op, arg });
+const binary =
+  (op: PlanBinaryOp) =>
+  (lhs: PlanExpr, rhs: PlanExpr): PlanExpr => ({ kind: 'binary', op, lhs, rhs });
+
+export const floor = unary('floor');
+export const sin = unary('sin');
+export const cos = unary('cos');
+export const negate = unary('negate');
+
+export const add = binary('add');
+export const sub = binary('sub');
+export const mul = binary('mul');
+export const div = binary('div');
+export const mod = binary('mod');

--- a/src/render/scene-plan/index.ts
+++ b/src/render/scene-plan/index.ts
@@ -1,0 +1,73 @@
+/**
+ * src/render/scene-plan/index.ts
+ *
+ * Public surface of the backend-neutral ScenePlan — the primary compiler→
+ * renderer assembly target for the Three migration.
+ *
+ * Producers: the compiler assembler (oscilla-pillars-cleanup-ulu.3).
+ * Consumers: the Three-backed renderer (oscilla-pillars-cleanup-ulu.2).
+ *
+ * See design-docs/three-migration-scene-plan.md for how this replaces
+ * PipelineInstallPayload without dual ownership.
+ */
+
+// Resource handles.
+export type {
+  GeometryRef,
+  MaterialRef,
+  TextureRef,
+  SceneObjectRef,
+  ComputeResourceRef,
+  PostChainRef,
+} from './refs';
+export {
+  geometryRef,
+  materialRef,
+  textureRef,
+  sceneObjectRef,
+  computeResourceRef,
+  postChainRef,
+} from './refs';
+
+// Per-value expressions.
+export type {
+  PlanExpr,
+  PlanInputChannel,
+  PlanIntrinsic,
+  PlanUnaryOp,
+  PlanBinaryOp,
+} from './expr';
+export {
+  konst,
+  input,
+  intrinsic,
+  floor,
+  sin,
+  cos,
+  negate,
+  add,
+  sub,
+  mul,
+  div,
+  mod,
+} from './expr';
+
+// Plan structure.
+export type {
+  ScenePlan,
+  ScenePlanResources,
+  SceneObject,
+  InstancingPlan,
+  TransformBinding,
+  RenderPlan,
+  CameraPlan,
+  DrawItem,
+  RenderTarget,
+  GeometryDef,
+  MaterialDef,
+  ColorBinding,
+  TextureDef,
+  ComputeResourceDef,
+  PostChainDef,
+} from './plan';
+export { SCENE_PLAN_VERSION, defineScenePlan } from './plan';

--- a/src/render/scene-plan/plan.ts
+++ b/src/render/scene-plan/plan.ts
@@ -1,0 +1,217 @@
+/**
+ * src/render/scene-plan/plan.ts
+ *
+ * The backend-neutral ScenePlan: the primary compiler→renderer assembly target
+ * for the Three migration. Replaces PipelineInstallPayload as the thing the
+ * compiler produces and the renderer consumes.
+ *
+ * Scope source: design-docs/three-fork-integration-proposal.md §2.2, §4.
+ * Ownership/seam canon: design-docs/three-migration-backend-canon.md.
+ * Proof target shape: design-docs/three-migration-first-proof-contract.md.
+ * Replacement narrative: design-docs/three-migration-scene-plan.md.
+ *
+ * [LAW:one-source-of-truth] ScenePlan is THE assembly target. It does not wrap,
+ *   embed, or round-trip to PipelineInstallPayload; the two are alternative
+ *   targets and the Rust-boundary payload is frozen legacy (canon §"Dead
+ *   Concepts"). There is no dual ownership.
+ * [LAW:locality-or-seam] Every renderer-specific decision (which Three class
+ *   realizes a geometry, how a material compiles to TSL) lives behind the
+ *   renderer seam. This module names resources and their composition only.
+ * [LAW:types-are-the-program] Resources are normalized: each is defined once in
+ *   a table keyed by its ref, and referenced everywhere else by that handle.
+ */
+
+import type {
+  GeometryRef,
+  MaterialRef,
+  TextureRef,
+  SceneObjectRef,
+  ComputeResourceRef,
+  PostChainRef,
+} from './refs';
+import type { PlanExpr, PlanInputChannel } from './expr';
+
+/**
+ * ScenePlan schema version. The renderer asserts compatibility on install.
+ *
+ * [LAW:no-silent-failure] An incompatible plan version is an explicit, loud
+ *   contract mismatch, not a silently-misread payload.
+ */
+export const SCENE_PLAN_VERSION = 1 as const;
+
+// ---------------------------------------------------------------------------
+// Resource definitions — the value type stored in each ref-keyed table.
+// ---------------------------------------------------------------------------
+
+/**
+ * A geometry resource: the per-object shape, in object-local units. Per-object
+ * placement (position, rotation) is applied by the instancing transform, not
+ * baked here.
+ */
+export type GeometryDef =
+  | { readonly kind: 'rectangle'; readonly width: number; readonly height: number }
+  | { readonly kind: 'point' };
+
+/**
+ * A color, expressed in a named color space. Each channel is a PlanExpr, so a
+ * channel may be uniform (`const`) or vary per instance / per frame by
+ * referencing an intrinsic or input.
+ */
+export type ColorBinding =
+  | { readonly space: 'hsl'; readonly h: PlanExpr; readonly s: PlanExpr; readonly l: PlanExpr }
+  | { readonly space: 'rgb'; readonly r: PlanExpr; readonly g: PlanExpr; readonly b: PlanExpr }
+  | {
+      readonly space: 'rgba';
+      readonly r: PlanExpr;
+      readonly g: PlanExpr;
+      readonly b: PlanExpr;
+      readonly a: PlanExpr;
+    };
+
+/** A material resource: how an object's surface is shaded. */
+export type MaterialDef = { readonly kind: 'unlitColor'; readonly color: ColorBinding };
+
+/**
+ * A texture resource, resolved from an Oscilla asset by the asset bridge.
+ *
+ * DEFERRED: asset decoding is owned by oscilla-pillars-cleanup-ulu.4
+ *   (AssetRegistry + ThreeLoadingBridge). `assetId` is a plain string here; the
+ *   branded AssetId and registry land with that ticket. The first proof target
+ *   uses no textures, so this table is empty for the steel thread.
+ */
+export type TextureDef = { readonly kind: 'asset'; readonly assetId: string };
+
+/**
+ * A compute resource (storage buffer / compute job).
+ *
+ * DEFERRED (three-fork-deltas.md §3, §4.2): served by TSL compute when a ticket
+ *   first needs solver-style work. Defined minimally so the ref is meaningful;
+ *   the owning ticket expands it. Empty for the steel thread.
+ */
+export type ComputeResourceDef = { readonly kind: 'storage'; readonly byteLength: number };
+
+/**
+ * A post-processing chain.
+ *
+ * DEFERRED (three-fork-deltas.md §3): served by Three post nodes when a ticket
+ *   first needs postprocessing. The backend resolves each pass id to a Three
+ *   post node. Empty for the steel thread.
+ */
+export type PostChainDef = { readonly kind: 'passes'; readonly passes: readonly string[] };
+
+/**
+ * The normalized resource tables. Each resource is defined exactly once here,
+ * keyed by its ref; everything else references it by handle.
+ */
+export interface ScenePlanResources {
+  readonly geometries: Readonly<Record<GeometryRef, GeometryDef>>;
+  readonly materials: Readonly<Record<MaterialRef, MaterialDef>>;
+  readonly textures: Readonly<Record<TextureRef, TextureDef>>;
+  readonly computeResources: Readonly<Record<ComputeResourceRef, ComputeResourceDef>>;
+  readonly postChains: Readonly<Record<PostChainRef, PostChainDef>>;
+}
+
+// ---------------------------------------------------------------------------
+// Scene objects — placed renderables that compose resources.
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-instance affine placement. Each field is a PlanExpr evaluated per
+ * instance, so a transform may reference `index`/`rank` intrinsics and runtime
+ * inputs. Position is in world units; rotation is in radians about Z.
+ *
+ * Scale is intentionally absent: the first proof targets vary only position and
+ * rotation per instance (proof contract). A uniform shape size lives on the
+ * geometry. Per-instance scale is added when a patch first requires it.
+ */
+export interface TransformBinding {
+  readonly positionX: PlanExpr;
+  readonly positionY: PlanExpr;
+  readonly rotation: PlanExpr;
+}
+
+/** Instancing: how many copies of an object exist and how each is placed. */
+export interface InstancingPlan {
+  readonly count: number;
+  readonly transform: TransformBinding;
+}
+
+/**
+ * A renderable placed in the scene: a geometry shaded by a material, drawn
+ * `instancing.count` times. The object's identity is the key under which it is
+ * stored in `ScenePlan.objects`, not a field here.
+ */
+export interface SceneObject {
+  readonly geometry: GeometryRef;
+  readonly material: MaterialRef;
+  readonly instancing: InstancingPlan;
+}
+
+// ---------------------------------------------------------------------------
+// Render plan — how a frame is drawn from the scene.
+// ---------------------------------------------------------------------------
+
+/**
+ * The camera framing the scene.
+ *
+ * One variant today (orthographic 2D); perspective is added when a patch first
+ * needs it, as a new variant of this union (the legacy boundary modeled this as
+ * a `cameraProjection` flag — here it is a discriminated value).
+ */
+export interface CameraPlan {
+  readonly kind: 'orthographic';
+  /** Visible region is [-halfExtentX, +halfExtentX] on X. */
+  readonly halfExtentX: number;
+  /** Visible region is [-halfExtentY, +halfExtentY] on Y. */
+  readonly halfExtentY: number;
+}
+
+/** Where a draw item renders to. */
+export type RenderTarget = 'previewCanvas';
+
+/** One ordered draw: render a scene object into a target. */
+export interface DrawItem {
+  readonly target: RenderTarget;
+  readonly object: SceneObjectRef;
+}
+
+/**
+ * The per-frame rendering orchestration: camera, the runtime input channels the
+ * plan reads, the ordered draws, and an optional post chain.
+ *
+ * [LAW:dataflow-not-control-flow] `inputs` is the explicit set of runtime-
+ *   updated channels the renderer must feed each frame, declared as data rather
+ *   than discovered by walking every expression.
+ */
+export interface RenderPlan {
+  readonly camera: CameraPlan;
+  readonly inputs: readonly PlanInputChannel[];
+  readonly draws: readonly DrawItem[];
+  readonly postChain: PostChainRef | null;
+}
+
+// ---------------------------------------------------------------------------
+// ScenePlan — the top-level compiled artifact.
+// ---------------------------------------------------------------------------
+
+/**
+ * The compiled, backend-neutral description of one renderable scene. The
+ * compiler (ulu.3) produces it; the Three renderer (ulu.2) consumes it.
+ */
+export interface ScenePlan {
+  readonly version: typeof SCENE_PLAN_VERSION;
+  readonly resources: ScenePlanResources;
+  readonly objects: Readonly<Record<SceneObjectRef, SceneObject>>;
+  readonly render: RenderPlan;
+}
+
+/**
+ * Identity helper that pins ScenePlan construction to this module.
+ *
+ * [LAW:single-enforcer] Compiler assembly constructs plans through this helper,
+ *   so the canonical shape has one named construction site (mirrors
+ *   defineDrawPrepRenderContract in src/render/types.ts).
+ */
+export function defineScenePlan(plan: ScenePlan): ScenePlan {
+  return plan;
+}

--- a/src/render/scene-plan/refs.ts
+++ b/src/render/scene-plan/refs.ts
@@ -1,0 +1,56 @@
+/**
+ * src/render/scene-plan/refs.ts
+ *
+ * Backend-neutral resource handles for the compiled ScenePlan.
+ *
+ * Scope source: design-docs/three-fork-integration-proposal.md §4.3
+ * Ownership/seam canon: design-docs/three-migration-backend-canon.md
+ *
+ * A *ref* is a stable, opaque handle that the compiled plan uses to name a
+ * resource. It is a foreign key into one of the ScenePlan's resource tables —
+ * never a renderer object.
+ *
+ * [LAW:locality-or-seam] These handles ARE the compiler→renderer seam. The
+ *   compiler (ulu.3) mints them; the renderer (ulu.2) resolves them to backend
+ *   objects. Neither side sees the other's internals.
+ * [LAW:types-are-the-program] Each ref is branded, so a GeometryRef cannot be
+ *   passed where a MaterialRef is wanted even though both erase to `string`.
+ *   The illegal "wrong handle" state is unrepresentable, not guarded at runtime.
+ * [LAW:locality-or-seam] A ref carries identity only — no Three UUID, class,
+ *   or scene-graph object (canon §"Non-Goals"; proposal §4.5).
+ */
+
+import type { Brand } from '../../core/ids';
+
+/** Handle for a geometry resource (e.g. a rectangle or point primitive). */
+export type GeometryRef = Brand<string, 'GeometryRef'>;
+
+/** Handle for a material resource (e.g. an unlit color material). */
+export type MaterialRef = Brand<string, 'MaterialRef'>;
+
+/** Handle for a texture resource, resolved from an asset by the asset bridge. */
+export type TextureRef = Brand<string, 'TextureRef'>;
+
+/** Handle for a placed renderable (geometry + material + instancing). */
+export type SceneObjectRef = Brand<string, 'SceneObjectRef'>;
+
+/** Handle for a compute resource (storage buffer / compute job). */
+export type ComputeResourceRef = Brand<string, 'ComputeResourceRef'>;
+
+/** Handle for a post-processing chain. */
+export type PostChainRef = Brand<string, 'PostChainRef'>;
+
+// ---------------------------------------------------------------------------
+// Factory functions — zero-cost casts.
+// ---------------------------------------------------------------------------
+
+// [LAW:single-enforcer] Refs are minted only through these constructors, so the
+// brand is applied in exactly one place per resource kind. The cast is the
+// single point where a raw string becomes a typed handle.
+
+export const geometryRef = (id: string): GeometryRef => id as GeometryRef;
+export const materialRef = (id: string): MaterialRef => id as MaterialRef;
+export const textureRef = (id: string): TextureRef => id as TextureRef;
+export const sceneObjectRef = (id: string): SceneObjectRef => id as SceneObjectRef;
+export const computeResourceRef = (id: string): ComputeResourceRef => id as ComputeResourceRef;
+export const postChainRef = (id: string): PostChainRef => id as PostChainRef;


### PR DESCRIPTION
## What

Introduces `ScenePlan`/`RenderPlan` as the backend-neutral compiler→renderer assembly target for the Three migration, plus the six resource handles. This is the **seam-definition** ticket (`oscilla-pillars-cleanup-ulu.1`): it defines the types ulu.3 lowers *into* and ulu.2 renders *from*. No renderer or lowering code is implemented here.

Scope source: `three-fork-integration-proposal.md` §2.2, §4 · canon: `three-migration-backend-canon.md` · proof shape: `three-migration-first-proof-contract.md`.

## New module — `src/render/scene-plan/`

- **`refs.ts`** — six branded handles (`GeometryRef`, `MaterialRef`, `TextureRef`, `SceneObjectRef`, `ComputeResourceRef`, `PostChainRef`) + constructors. Nominal handles → a wrong-handle is a compile error, not a runtime guard. `[LAW:types-are-the-program]`
- **`expr.ts`** — `PlanExpr`: backend-neutral, JSON-serializable per-value expressions (`const`/`input`/`intrinsic`/`unary`/`binary`), sized to the proof demos (Grid of Squares, Spirograph, Kaleidoscope). The Three backend translates these to TSL. `[LAW:effects-at-boundaries]`
- **`plan.ts`** — `ScenePlan`/`RenderPlan` + normalized, ref-keyed resource tables; per-instance variation lives in `PlanExpr` referencing `index`/`rank`/`time`. `[LAW:one-source-of-truth]`
- **`__tests__/scene-plan.test.ts`** — builds the **Grid of Squares** proof target through the public API and asserts shape + handle discipline + backend neutrality (JSON round-trip; no `boundary-contract`/`three` imports). `[LAW:behavior-not-structure]`

## Replacement without dual ownership

`design-docs/three-migration-scene-plan.md` documents how `ScenePlan` replaces `PipelineInstallPayload`: no wrapping, no round-trip, legacy payload frozen. Includes the old→new concept mapping.

## Verification

- `npm run verify:renderer-shell` — **PASS** before and after (no backend code touched; `createWebGPURenderer()` stays the stub).
- Full suite: **208 files / 2087 tests pass** (+11 new contract tests).
- `tsc -b` clean · eslint clean · dependency-cruiser clean.

Unblocks `oscilla-pillars-cleanup-ulu.2` (Three renderer) and `oscilla-pillars-cleanup-ulu.3` (lowering).