### PR TITLE
feat(ulu.2): Three-backed renderer at createWebGPURenderer seam

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "react-dom": "^19.2.3",
     "reactflow": "^11.11.4",
     "simplex-noise": "^4.0.3",
+    "three": "0.184.0",
     "wgsl_reflect": "^1.2.3",
     "zod": "^4.3.6"
   },
@@ -75,6 +76,7 @@
     "@types/earcut": "^3.0.0",
     "@types/estree": "^1.0.8",
     "@types/node": "^25.0.10",
+    "@types/three": "0.184.1",
     "@vitest/coverage-v8": "^2.1.9",
     "dependency-cruiser": "^17.3.8",
     "eslint": "^9.39.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ importers:
       simplex-noise:
         specifier: ^4.0.3
         version: 4.0.3
+      three:
+        specifier: 0.184.0
+        version: 0.184.0
       wgsl_reflect:
         specifier: ^1.2.3
         version: 1.2.3
@@ -116,6 +119,9 @@ importers:
       '@types/node':
         specifier: ^25.0.10
         version: 25.0.10
+      '@types/three':
+        specifier: 0.184.1
+        version: 0.184.1
       '@vitest/coverage-v8':
         specifier: ^2.1.9
         version: 2.1.9(vitest@2.1.9(@types/node@25.0.10)(jsdom@27.4.0))
@@ -277,6 +283,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emotion/babel-plugin@11.13.5':
     resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
@@ -1093,6 +1102,9 @@ packages:
   '@ts-morph/common@0.28.1':
     resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -1226,8 +1238,17 @@ packages:
   '@types/react@19.2.8':
     resolution: {integrity: sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.184.1':
+    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
+
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@typescript-eslint/eslint-plugin@8.54.0':
     resolution: {integrity: sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==}
@@ -2124,6 +2145,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@1.7.0:
     resolution: {integrity: sha512-UxKlfCRuCBxSXU4C6t9scbDyWZ4VlaFFdojKtzJuSkuOBQ5CNFum+zZXFwHjo+CxBC1t6zlYPgHIgFjL8ggoEQ==}
     engines: {node: '>=0.10.0'}
@@ -2590,6 +2614,9 @@ packages:
 
   mermaid@11.12.2:
     resolution: {integrity: sha512-n34QPDPEKmaeCG4WDMGy0OT6PSyxKCfy2pJgShP+Qow2KLrvWjclwbc3yXfSIf4BanqWEhQEpngWwNp/XhZt6w==}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -3218,6 +3245,9 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
+  three@0.184.0:
+    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
+
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -3782,6 +3812,8 @@ snapshots:
   '@csstools/css-syntax-patches-for-csstree@1.0.25': {}
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -4482,6 +4514,8 @@ snapshots:
       path-browserify: 1.0.1
       tinyglobby: 0.2.15
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/aria-query@5.0.4': {}
 
   '@types/bezier-js@4.1.3': {}
@@ -4631,8 +4665,21 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.184.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/trusted-types@2.0.7':
     optional: true
+
+  '@types/webxr@0.5.24': {}
 
   '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)':
     dependencies:
@@ -5715,6 +5762,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fflate@0.8.3: {}
+
   figures@1.7.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -6226,6 +6275,8 @@ snapshots:
       stylis: 4.3.6
       ts-dedent: 2.2.0
       uuid: 11.1.0
+
+  meshoptimizer@1.1.1: {}
 
   min-indent@1.0.1: {}
 
@@ -6822,6 +6873,8 @@ snapshots:
       minimatch: 9.0.5
 
   text-table@0.2.0: {}
+
+  three@0.184.0: {}
 
   through@2.3.8: {}
 

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -13,6 +13,7 @@ export type {
   WebGPURenderer,
   GpuFault,
   GpuFaultCallback,
+  RuntimeInputChannelValues,
   WebGPURendererExecutionState,
 } from './webgpu';
 export { WEBGPU_RENDER_CONTRACT } from './webgpu/shaders';

--- a/src/render/webgpu/index.ts
+++ b/src/render/webgpu/index.ts
@@ -1,50 +1,48 @@
+/**
+ * src/render/webgpu/index.ts
+ *
+ * The single app-facing renderer construction seam. `createWebGPURenderer()` is
+ * the one boundary the app/runtime uses to obtain a renderer; everything behind
+ * it is backend-local (canon: design-docs/three-migration-backend-canon.md
+ * §"Stable Seams"). The scorched-earth stub is replaced here by the Three
+ * backend (oscilla-pillars-cleanup-ulu.2).
+ *
+ * [LAW:single-enforcer] This file is the only place the renderer backend is
+ *   chosen and constructed; RuntimeService depends on the seam, never on
+ *   `ThreeForkRenderer` directly.
+ * [LAW:locality-or-seam] The return type is the backend-neutral
+ *   `WebGPURenderer` contract; no `three` type escapes this module to app code.
+ */
+
 export type { WebGPURendererExecutionState } from './renderer-circuit-breaker';
 
-// Stubs — RustWasmWebGPURenderer deleted during scorched earth, rebuilt in Phase 4.
-// These satisfy downstream imports until the renderer facade is rebuilt.
+export type {
+  WebGPURenderer,
+  GpuFault,
+  GpuFaultCallback,
+  RuntimeInputChannelValues,
+} from './three/renderer-contract';
 
-export interface GpuFault {
-  readonly message: string;
-  readonly source: string;
-  readonly fatal: boolean;
-  readonly severity: 'fatal' | 'error' | 'warning';
-  readonly code: string;
-  readonly recoverable: boolean;
-}
-
-export type GpuFaultCallback = ((fault: GpuFault) => void) | null;
-
-export interface WebGPURenderer {
-  dispose(): void;
-  setGpuFaultCallback(callback: GpuFaultCallback): void;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getLatestRuntimeTelemetry(): any;
-  getInstalledGpuPassIds(): readonly string[];
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getLatestSinkTableSample(): any;
-  getLifecycleState(): string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getLatestBoundaryFixturePayloadV1(): any;
-  setTelemetryEnabled(enabled: boolean): void;
-}
+import type { GpuFault, WebGPURenderer } from './three/renderer-contract';
+import { ThreeForkRenderer } from './three/ThreeForkRenderer';
 
 export async function createWebGPURenderer(
-  _canvas: HTMLCanvasElement,
-  _options?: { onGpuFault?: (fault: GpuFault) => void },
+  canvas: HTMLCanvasElement,
+  options?: { onGpuFault?: (fault: GpuFault) => void },
 ): Promise<WebGPURenderer> {
-  // Stub — renderer not yet rebuilt
-  return {
-    dispose() {},
-    setGpuFaultCallback() {},
-    getLatestRuntimeTelemetry() { return null; },
-    getInstalledGpuPassIds() { return []; },
-    getLatestSinkTableSample() { return null; },
-    getLifecycleState() { return 'stub'; },
-    getLatestBoundaryFixturePayloadV1() { return null; },
-    setTelemetryEnabled() {},
-  };
+  const renderer = new ThreeForkRenderer(canvas);
+  // [LAW:no-ambient-temporal-coupling] The GPU device is acquired lazily on the
+  //   first frame, so construction never requires a WebGPU adapter — the app
+  //   shell boots even where no device is available, and a plan can be
+  //   installed before any frame is drawn.
+  if (options?.onGpuFault) {
+    renderer.setGpuFaultCallback(options.onGpuFault);
+  }
+  return renderer;
 }
 
 export function assertWebGPUStartupContract(): void {
-  // Stub — no validation needed until renderer is rebuilt
+  // The Three backend negotiates device/adapter (with WebGL fallback) lazily at
+  // first frame and reports any failure as a fatal GpuFault, so there is no
+  // separate startup contract to assert here.
 }

--- a/src/render/webgpu/three/ThreeForkRenderer.ts
+++ b/src/render/webgpu/three/ThreeForkRenderer.ts
@@ -1,0 +1,171 @@
+/**
+ * src/render/webgpu/three/ThreeForkRenderer.ts
+ *
+ * The Three-backed renderer behind `createWebGPURenderer()`. It owns a Three
+ * `WebGPURenderer` device, realizes an installed `ScenePlan` into a scene
+ * graph, and draws frames driven by runtime input channels.
+ *
+ * Scope source: design-docs/three-fork-integration-proposal.md §2.3, §6.
+ * Ownership/seam canon: design-docs/three-migration-backend-canon.md — this is
+ *   backend-local; it never calls upward into patch/editor/compiler services.
+ * Capability tier: design-docs/three-fork-deltas.md §1 Tier B (upstream Three +
+ *   backend-local composition). The fork-delta register is EMPTY; this uses
+ *   plain upstream Three, no fork.
+ *
+ * [LAW:effects-at-boundaries] This is the one effectful unit in the backend: it
+ *   touches the GPU. The plan→scene-graph translation it depends on
+ *   (scene-plan-realizer, plan-expr-tsl) is pure and lives in separate modules.
+ * [LAW:no-ambient-temporal-coupling] The GPU device has one explicit owner and a
+ *   named lifecycle ('idle' → 'active' → 'disposed'). The device is acquired
+ *   lazily on the first frame, not at construction — so constructing a renderer
+ *   (and the app shell that does so on boot) never requires a GPU adapter, and a
+ *   plan can be installed before any device exists.
+ */
+
+import { WebGPURenderer as ThreeWebGPURenderer } from 'three/webgpu';
+
+import type { ScenePlan } from '../../scene-plan';
+import { realizeScenePlan, type RealizedScene } from './scene-plan-realizer';
+import type {
+  GpuFault,
+  GpuFaultCallback,
+  RuntimeInputChannelValues,
+  WebGPURenderer,
+} from './renderer-contract';
+
+type Lifecycle = 'idle' | 'active' | 'disposed';
+
+function deviceInitFault(error: unknown): GpuFault {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    message: `Three WebGPU device initialization failed: ${message}`,
+    source: 'ThreeForkRenderer',
+    fatal: true,
+    severity: 'fatal',
+    code: 'THREE_DEVICE_INIT_FAILED',
+    recoverable: false,
+  };
+}
+
+export class ThreeForkRenderer implements WebGPURenderer {
+  private lifecycle: Lifecycle = 'idle';
+  private device: ThreeWebGPURenderer | null = null;
+  private realized: RealizedScene | null = null;
+  private onGpuFault: GpuFaultCallback = null;
+  private deviceInit: Promise<ThreeWebGPURenderer> | null = null;
+
+  constructor(private readonly canvas: HTMLCanvasElement) {}
+
+  installScenePlan(plan: ScenePlan): void {
+    this.assertNotDisposed('installing a ScenePlan');
+    // [LAW:one-source-of-truth] A renderer holds exactly one realized scene; a
+    //   new plan replaces the old one and releases its resources.
+    this.realized?.dispose();
+    // realizeScenePlan throws on an incompatible version or dangling handle
+    // ([LAW:no-silent-failure]); the throw propagates to the installer.
+    this.realized = realizeScenePlan(plan);
+  }
+
+  async renderFrame(values: RuntimeInputChannelValues): Promise<void> {
+    this.assertNotDisposed('rendering a frame');
+    const realized = this.realized;
+    // [LAW:no-silent-failure] Drawing before a plan is installed is a caller
+    //   sequencing error, surfaced loudly rather than drawing nothing.
+    if (!realized) {
+      throw new Error('ThreeForkRenderer: install a ScenePlan before rendering a frame');
+    }
+
+    const device = await this.ensureDevice();
+
+    for (const [channel, node] of realized.inputs) {
+      const value = values[channel];
+      // [LAW:no-silent-failure] A declared input channel with no per-frame value
+      //   would silently freeze at its last value; require it explicitly.
+      if (value === undefined) {
+        throw new Error(
+          `ThreeForkRenderer: render plan declares input channel '${channel}' but no value was provided for this frame`,
+        );
+      }
+      node.value = value;
+    }
+
+    await device.renderAsync(realized.scene, realized.camera);
+  }
+
+  private async ensureDevice(): Promise<ThreeWebGPURenderer> {
+    if (this.device) {
+      return this.device;
+    }
+    // [LAW:no-ambient-temporal-coupling] A single in-flight init promise owns
+    //   device creation, so concurrent frames cannot race two devices into
+    //   existence.
+    if (!this.deviceInit) {
+      this.deviceInit = this.createDevice();
+    }
+    return this.deviceInit;
+  }
+
+  private async createDevice(): Promise<ThreeWebGPURenderer> {
+    const device = new ThreeWebGPURenderer({ canvas: this.canvas, alpha: true, antialias: true });
+    try {
+      await device.init();
+    } catch (error) {
+      // [LAW:no-silent-failure] Device init failure is a fatal, reported fault —
+      //   not a swallowed error that leaves a half-built renderer.
+      this.deviceInit = null;
+      this.onGpuFault?.(deviceInitFault(error));
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+    device.setSize(this.canvas.width, this.canvas.height, false);
+    device.setClearColor(0x000000, 1);
+    this.device = device;
+    this.lifecycle = 'active';
+    return device;
+  }
+
+  dispose(): void {
+    this.realized?.dispose();
+    this.realized = null;
+    this.device?.dispose();
+    this.device = null;
+    this.deviceInit = null;
+    this.lifecycle = 'disposed';
+  }
+
+  setGpuFaultCallback(callback: GpuFaultCallback): void {
+    this.onGpuFault = callback;
+  }
+
+  getLifecycleState(): string {
+    return this.lifecycle;
+  }
+
+  // The Three backend has no GPU-IR passes, sink tables, or Rust-boundary
+  // payloads — those are the dead legacy path. These accessors report their
+  // absence honestly rather than fabricating legacy-shaped telemetry.
+  getLatestRuntimeTelemetry(): null {
+    return null;
+  }
+
+  getInstalledGpuPassIds(): readonly string[] {
+    return [];
+  }
+
+  getLatestSinkTableSample(): null {
+    return null;
+  }
+
+  getLatestBoundaryFixturePayloadV1(): null {
+    return null;
+  }
+
+  setTelemetryEnabled(_enabled: boolean): void {
+    // No GPU-IR telemetry stream exists on this backend; nothing to toggle.
+  }
+
+  private assertNotDisposed(action: string): void {
+    if (this.lifecycle === 'disposed') {
+      throw new Error(`ThreeForkRenderer: cannot ${action} after dispose()`);
+    }
+  }
+}

--- a/src/render/webgpu/three/__tests__/ThreeForkRenderer.test.ts
+++ b/src/render/webgpu/three/__tests__/ThreeForkRenderer.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Lifecycle + seam tests for the Three-backed renderer.
+ *
+ * The GPU-bound draw path (device acquisition + `renderAsync`) needs a real
+ * WebGPU adapter and is proven by ulu.5's `--no-headless` e2e — NOT here. What
+ * is deterministic without a device is the seam contract: lazy device
+ * acquisition (construction needs no GPU), plan-install validation, loud
+ * sequencing errors, disposal, and the honest legacy-telemetry accessors. Those
+ * are what keep `verify:renderer-shell` green when the app shell boots this
+ * renderer headlessly.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  SCENE_PLAN_VERSION,
+  defineScenePlan,
+  geometryRef,
+  konst,
+  materialRef,
+  sceneObjectRef,
+  type ScenePlan,
+} from '../../../scene-plan';
+import { createWebGPURenderer } from '../../index';
+import { ThreeForkRenderer } from '../ThreeForkRenderer';
+
+// The Three backend implementation modules live one level up from __tests__.
+const THREE_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+// The renderer never touches the canvas until a device is acquired (first
+// frame), so a structural stand-in is sufficient for the device-free contract.
+const fakeCanvas = { width: 256, height: 256 } as unknown as HTMLCanvasElement;
+
+function buildStaticPlan(version: number = SCENE_PLAN_VERSION): ScenePlan {
+  const square = geometryRef('o:square');
+  const unlit = materialRef('o:unlit');
+  const object = sceneObjectRef('o:object');
+  return {
+    version,
+    resources: {
+      geometries: { [square]: { kind: 'rectangle', width: 1, height: 1 } },
+      materials: {
+        [unlit]: { kind: 'unlitColor', color: { space: 'rgb', r: konst(1), g: konst(0), b: konst(0) } },
+      },
+      textures: {},
+      computeResources: {},
+      postChains: {},
+    },
+    objects: {
+      [object]: {
+        geometry: square,
+        material: unlit,
+        instancing: { count: 1, transform: { positionX: konst(0), positionY: konst(0), rotation: konst(0) } },
+      },
+    },
+    render: {
+      camera: { kind: 'orthographic', halfExtentX: 1, halfExtentY: 1 },
+      inputs: [],
+      draws: [{ target: 'previewCanvas', object }],
+      postChain: null,
+    },
+  } as ScenePlan;
+}
+
+describe('ThreeForkRenderer — lifecycle and seam', () => {
+  it('constructs idle without acquiring a GPU device', () => {
+    const renderer = new ThreeForkRenderer(fakeCanvas);
+    expect(renderer.getLifecycleState()).toBe('idle');
+  });
+
+  it('installs a valid ScenePlan without a device', () => {
+    const renderer = new ThreeForkRenderer(fakeCanvas);
+    expect(() => renderer.installScenePlan(buildStaticPlan())).not.toThrow();
+    renderer.dispose();
+  });
+
+  it('rejects an incompatible ScenePlan version on install', () => {
+    const renderer = new ThreeForkRenderer(fakeCanvas);
+    expect(() => renderer.installScenePlan(buildStaticPlan(2))).toThrow(/incompatible ScenePlan version/);
+  });
+
+  it('refuses to render before a plan is installed', async () => {
+    const renderer = new ThreeForkRenderer(fakeCanvas);
+    await expect(renderer.renderFrame({})).rejects.toThrow(/install a ScenePlan before rendering/);
+  });
+
+  it('reports the dead GPU-IR telemetry surface as empty, not fabricated', () => {
+    const renderer = new ThreeForkRenderer(fakeCanvas);
+    expect(renderer.getInstalledGpuPassIds()).toEqual([]);
+    expect(renderer.getLatestRuntimeTelemetry()).toBeNull();
+    expect(renderer.getLatestSinkTableSample()).toBeNull();
+    expect(renderer.getLatestBoundaryFixturePayloadV1()).toBeNull();
+  });
+
+  it('refuses to install or render after disposal', async () => {
+    const renderer = new ThreeForkRenderer(fakeCanvas);
+    renderer.dispose();
+    expect(renderer.getLifecycleState()).toBe('disposed');
+    expect(() => renderer.installScenePlan(buildStaticPlan())).toThrow(/after dispose/);
+    await expect(renderer.renderFrame({})).rejects.toThrow(/after dispose/);
+  });
+});
+
+describe('createWebGPURenderer — app-facing seam', () => {
+  it('returns a renderer that is idle until first use', async () => {
+    const renderer = await createWebGPURenderer(fakeCanvas);
+    expect(renderer.getLifecycleState()).toBe('idle');
+    expect(typeof renderer.installScenePlan).toBe('function');
+    expect(typeof renderer.renderFrame).toBe('function');
+    renderer.dispose();
+  });
+});
+
+describe('Three backend — no dependency on the frozen Rust boundary', () => {
+  it('imports nothing from boundary-contract', () => {
+    // [LAW:one-source-of-truth] ScenePlan is the sole assembly target; the Three
+    //   backend must not reach into the frozen PipelineInstallPayload contract.
+    const sources = readdirSync(THREE_DIR)
+      .filter((f) => f.endsWith('.ts'))
+      .map((f) => readFileSync(join(THREE_DIR, f), 'utf8'));
+    expect(sources.length).toBeGreaterThan(0);
+    for (const source of sources) {
+      expect(source).not.toMatch(/boundary-contract/);
+    }
+  });
+});

--- a/src/render/webgpu/three/__tests__/plan-expr-tsl.test.ts
+++ b/src/render/webgpu/three/__tests__/plan-expr-tsl.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Behavioral tests for the PlanExpr → TSL translator.
+ *
+ * The translator's exhaustiveness over `PlanExpr.kind` and the operator unions
+ * is enforced at COMPILE time by the typed lookup tables and the `assertNever`
+ * default — it cannot be asserted at runtime. What these tests pin is the
+ * runtime contract that the type cannot: every expr kind produces a node, and a
+ * plan that reads an undeclared input channel fails loudly rather than
+ * defaulting silently.
+ */
+
+import { uniform } from 'three/tsl';
+import { describe, it, expect } from 'vitest';
+
+import { add, cos, intrinsic, konst, input, mod, mul } from '../../../scene-plan';
+import { planExprToTSL, type PlanExprContext, type TSLNode } from '../plan-expr-tsl';
+
+const ctx: PlanExprContext = {
+  instanceCount: 16,
+  inputs: { time: uniform(0, 'float') as unknown as TSLNode },
+};
+
+describe('planExprToTSL', () => {
+  it('produces a node for every PlanExpr kind', () => {
+    expect(planExprToTSL(konst(1), ctx)).toBeDefined(); // const
+    expect(planExprToTSL(input('time'), ctx)).toBeDefined(); // input
+    expect(planExprToTSL(intrinsic('index'), ctx)).toBeDefined(); // intrinsic index
+    expect(planExprToTSL(intrinsic('rank'), ctx)).toBeDefined(); // intrinsic rank
+    expect(planExprToTSL(cos(konst(0.5)), ctx)).toBeDefined(); // unary
+    expect(planExprToTSL(add(konst(1), konst(2)), ctx)).toBeDefined(); // binary
+    expect(planExprToTSL(mod(intrinsic('index'), konst(10)), ctx)).toBeDefined();
+    expect(planExprToTSL(mul(intrinsic('rank'), input('time')), ctx)).toBeDefined();
+  });
+
+  it('throws when an expression reads an input channel the context did not declare', () => {
+    // [LAW:no-silent-failure] An undeclared channel is a contract break, not a
+    //   zero default.
+    expect(() => planExprToTSL(input('mouseX'), ctx)).toThrow(/input channel 'mouseX'/);
+  });
+});

--- a/src/render/webgpu/three/__tests__/scene-plan-realizer.test.ts
+++ b/src/render/webgpu/three/__tests__/scene-plan-realizer.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Behavioral tests for the ScenePlan → Three scene-graph realizer.
+ *
+ * These assert WHAT realization produces (a scene with the right instanced
+ * draw, camera framing, declared inputs) and that a malformed plan fails LOUDLY
+ * — never how the TSL graph is shaped internally. Realization is pure CPU work,
+ * so no GPU device is needed: the actual draw is proven by ulu.5's `--no-headless`
+ * e2e, not here.
+ */
+
+import { InstancedMesh, MeshBasicNodeMaterial, OrthographicCamera } from 'three/webgpu';
+import { describe, it, expect } from 'vitest';
+
+import {
+  SCENE_PLAN_VERSION,
+  add,
+  defineScenePlan,
+  div,
+  floor,
+  geometryRef,
+  input,
+  intrinsic,
+  konst,
+  materialRef,
+  mod,
+  mul,
+  sceneObjectRef,
+  type ScenePlan,
+} from '../../../scene-plan';
+import { realizeScenePlan } from '../scene-plan-realizer';
+
+/** The `Grid of Squares` first proof target, built through the public API. */
+function buildGridPlan(overrides?: { count?: number }): ScenePlan {
+  const square = geometryRef('grid:square');
+  const unlit = materialRef('grid:unlit-hsl');
+  const grid = sceneObjectRef('grid:object');
+  const index = intrinsic('index');
+  const rank = intrinsic('rank');
+  const time = input('time');
+  const col = mod(index, konst(10));
+  const row = floor(div(index, konst(10)));
+
+  return defineScenePlan({
+    version: SCENE_PLAN_VERSION,
+    resources: {
+      geometries: { [square]: { kind: 'rectangle', width: 0.08, height: 0.08 } },
+      materials: {
+        [unlit]: {
+          kind: 'unlitColor',
+          color: { space: 'hsl', h: add(rank, mul(time, konst(0.2))), s: konst(0.8), l: konst(0.6) },
+        },
+      },
+      textures: {},
+      computeResources: {},
+      postChains: {},
+    },
+    objects: {
+      [grid]: {
+        geometry: square,
+        material: unlit,
+        instancing: {
+          count: overrides?.count ?? 100,
+          transform: {
+            positionX: mul(col, konst(0.1)),
+            positionY: mul(row, konst(0.1)),
+            rotation: add(mul(index, konst(0.5)), mul(time, konst(2.0))),
+          },
+        },
+      },
+    },
+    render: {
+      camera: { kind: 'orthographic', halfExtentX: 0.6, halfExtentY: 0.6 },
+      inputs: ['time'],
+      draws: [{ target: 'previewCanvas', object: grid }],
+      postChain: null,
+    },
+  });
+}
+
+describe('realizeScenePlan — Grid of Squares', () => {
+  it('realizes one instanced mesh with the declared instance count', () => {
+    const realized = realizeScenePlan(buildGridPlan({ count: 100 }));
+    const meshes = realized.scene.children.filter((c): c is InstancedMesh => c instanceof InstancedMesh);
+    expect(meshes).toHaveLength(1);
+    expect(meshes[0].count).toBe(100);
+    realized.dispose();
+  });
+
+  it('shades the instances with an unlit color NodeMaterial carrying color + position graphs', () => {
+    const realized = realizeScenePlan(buildGridPlan());
+    const mesh = realized.scene.children.find((c): c is InstancedMesh => c instanceof InstancedMesh)!;
+    expect(mesh.material).toBeInstanceOf(MeshBasicNodeMaterial);
+    const material = mesh.material as MeshBasicNodeMaterial;
+    // Per-instance color and placement are TSL graphs, not CPU payload bags.
+    expect(material.colorNode).not.toBeNull();
+    expect(material.positionNode).not.toBeNull();
+    realized.dispose();
+  });
+
+  it('frames the scene with an orthographic camera matching the plan half-extents', () => {
+    const realized = realizeScenePlan(buildGridPlan());
+    expect(realized.camera).toBeInstanceOf(OrthographicCamera);
+    expect(realized.camera.left).toBe(-0.6);
+    expect(realized.camera.right).toBe(0.6);
+    expect(realized.camera.top).toBe(0.6);
+    expect(realized.camera.bottom).toBe(-0.6);
+    realized.dispose();
+  });
+
+  it('exposes one runtime uniform per declared input channel', () => {
+    const realized = realizeScenePlan(buildGridPlan());
+    expect([...realized.inputs.keys()]).toEqual(['time']);
+    realized.dispose();
+  });
+
+  it('neutralizes per-instance matrices to identity so the material owns placement', () => {
+    const realized = realizeScenePlan(buildGridPlan({ count: 3 }));
+    const mesh = realized.scene.children.find((c): c is InstancedMesh => c instanceof InstancedMesh)!;
+    // A zero matrix (the default allocation) would collapse instances; identity
+    // means placement is delegated entirely to the material's positionNode.
+    expect(mesh.instanceMatrix.array.slice(0, 16)).toEqual(new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]));
+    realized.dispose();
+  });
+});
+
+describe('realizeScenePlan — loud failure on malformed plans', () => {
+  it('rejects an incompatible plan version', () => {
+    const plan = { ...buildGridPlan(), version: 999 } as unknown as ScenePlan;
+    expect(() => realizeScenePlan(plan)).toThrow(/incompatible ScenePlan version/);
+  });
+
+  it('rejects a dangling geometry handle', () => {
+    const plan = buildGridPlan();
+    const broken: ScenePlan = {
+      ...plan,
+      resources: { ...plan.resources, geometries: {} },
+    };
+    expect(() => realizeScenePlan(broken)).toThrow(/geometry resource .* is not defined/);
+  });
+
+  it('rejects a dangling scene-object handle', () => {
+    const plan = buildGridPlan();
+    const broken: ScenePlan = { ...plan, objects: {} };
+    expect(() => realizeScenePlan(broken)).toThrow(/scene object .* is not defined/);
+  });
+
+  it('rejects a non-positive instance count', () => {
+    expect(() => realizeScenePlan(buildGridPlan({ count: 0 }))).toThrow(/non-positive instance count/);
+  });
+});

--- a/src/render/webgpu/three/plan-expr-tsl.ts
+++ b/src/render/webgpu/three/plan-expr-tsl.ts
@@ -1,0 +1,131 @@
+/**
+ * src/render/webgpu/three/plan-expr-tsl.ts
+ *
+ * Translates a backend-neutral `PlanExpr` into a Three TSL node graph.
+ *
+ * This is the renderer side of the seam established in
+ * `src/render/scene-plan/expr.ts`: the compiler (ulu.3) produces `PlanExpr`s
+ * from authored patch semantics; this module realizes one into the TSL
+ * expression a `NodeMaterial` evaluates on the GPU.
+ *
+ * Scope source: design-docs/three-fork-integration-proposal.md §3
+ *   ("Oscilla fields/expressions align with TSL expressions").
+ * Capability tier: design-docs/three-fork-deltas.md §1 Tier B — backend-local
+ *   composition on upstream TSL, NOT a fork delta.
+ *
+ * [LAW:effects-at-boundaries] This is a pure description→description mapping. It
+ *   builds a TSL node graph (inert data) and performs no GPU work; the act of
+ *   evaluating the graph happens in the renderer when it draws.
+ * [LAW:dataflow-not-control-flow] Operator selection is a value lookup in a
+ *   total table keyed by the op, not a branch ladder. A new `PlanUnaryOp` /
+ *   `PlanBinaryOp` is a compile error here until its row is added, so consumers
+ *   cannot silently miss a case.
+ * [LAW:single-enforcer] This is the one place a `PlanExpr` becomes TSL. The
+ *   scene-plan realizer and the renderer both go through `planExprToTSL`.
+ */
+
+import type { Node } from 'three/webgpu';
+import { add, cos, div, floor, instanceIndex, mod, mul, negate, sin, sub, float } from 'three/tsl';
+
+import type {
+  PlanBinaryOp,
+  PlanExpr,
+  PlanInputChannel,
+  PlanIntrinsic,
+  PlanUnaryOp,
+} from '../../scene-plan';
+
+/**
+ * A scalar TSL node. A `PlanExpr` is always scalar-valued: every leaf and
+ * combinator in this module produces and consumes `float`-typed nodes, so the
+ * whole translation unifies under one node type.
+ */
+export type TSLNode = Node<'float'>;
+
+/**
+ * What the translator needs from the surrounding scene to resolve the two
+ * non-local leaf kinds:
+ *
+ * - `input` leaves resolve to a runtime-updated uniform node, supplied per
+ *   declared channel by the realizer.
+ * - `rank` is normalized against the instance count, so the count is needed to
+ *   build `index / count`.
+ *
+ * [LAW:no-shared-mutable-globals] Both come in as explicit parameters; the
+ *   translator reads no ambient renderer state.
+ */
+export interface PlanExprContext {
+  /** Instance count of the domain this expression is evaluated over (>= 1). */
+  readonly instanceCount: number;
+  /** TSL uniform node per runtime input channel the render plan declared. */
+  readonly inputs: Readonly<Partial<Record<PlanInputChannel, TSLNode>>>;
+}
+
+// [LAW:dataflow-not-control-flow] Total op tables. `Record<…Op, …>` makes every
+// operator in the union mandatory, so exhaustiveness is enforced by the type.
+const UNARY_OPS: Record<PlanUnaryOp, (arg: TSLNode) => TSLNode> = {
+  floor: (arg) => floor(arg),
+  sin: (arg) => sin(arg),
+  cos: (arg) => cos(arg),
+  negate: (arg) => negate(arg),
+};
+
+const BINARY_OPS: Record<PlanBinaryOp, (lhs: TSLNode, rhs: TSLNode) => TSLNode> = {
+  add: (lhs, rhs) => add(lhs, rhs),
+  sub: (lhs, rhs) => sub(lhs, rhs),
+  mul: (lhs, rhs) => mul(lhs, rhs),
+  div: (lhs, rhs) => div(lhs, rhs),
+  mod: (lhs, rhs) => mod(lhs, rhs),
+};
+
+function intrinsicToTSL(name: PlanIntrinsic, ctx: PlanExprContext): TSLNode {
+  // [LAW:dataflow-not-control-flow] `index` and `rank` are two values derived
+  // from the same per-instance ordinal; both are expressed unconditionally.
+  const index = float(instanceIndex);
+  const INTRINSICS: Record<PlanIntrinsic, () => TSLNode> = {
+    index: () => index,
+    rank: () => div(index, float(ctx.instanceCount)),
+  };
+  return INTRINSICS[name]();
+}
+
+function resolveInput(channel: PlanInputChannel, ctx: PlanExprContext): TSLNode {
+  const node = ctx.inputs[channel];
+  // [LAW:no-silent-failure] A plan expression reading a channel the render plan
+  // never declared in `render.inputs` is a contract break, surfaced loudly —
+  // not silently defaulted to zero (which would render wrong but look fine).
+  if (!node) {
+    throw new Error(
+      `plan-expr-tsl: PlanExpr reads input channel '${channel}', but it was not provided in the expression context (the render plan must declare it in render.inputs)`,
+    );
+  }
+  return node;
+}
+
+/**
+ * Translate one backend-neutral `PlanExpr` into a scalar TSL node.
+ *
+ * [LAW:types-are-the-program] The switch is exhaustive over `PlanExpr.kind`;
+ *   `assertNever` makes a future variant a compile error rather than a silent
+ *   fall-through.
+ */
+export function planExprToTSL(expr: PlanExpr, ctx: PlanExprContext): TSLNode {
+  switch (expr.kind) {
+    case 'const':
+      return float(expr.value);
+    case 'input':
+      return resolveInput(expr.channel, ctx);
+    case 'intrinsic':
+      return intrinsicToTSL(expr.name, ctx);
+    case 'unary':
+      return UNARY_OPS[expr.op](planExprToTSL(expr.arg, ctx));
+    case 'binary':
+      return BINARY_OPS[expr.op](planExprToTSL(expr.lhs, ctx), planExprToTSL(expr.rhs, ctx));
+    default:
+      return assertNever(expr);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`plan-expr-tsl: unhandled PlanExpr variant: ${JSON.stringify(value)}`);
+}

--- a/src/render/webgpu/three/renderer-contract.ts
+++ b/src/render/webgpu/three/renderer-contract.ts
@@ -1,0 +1,93 @@
+/**
+ * src/render/webgpu/three/renderer-contract.ts
+ *
+ * The app-facing renderer seam contract: the interface `createWebGPURenderer()`
+ * returns, plus the fault model the runtime handles. Backend-neutral — it
+ * names capabilities, never Three classes.
+ *
+ * Ownership/seam canon: design-docs/three-migration-backend-canon.md.
+ *   `createWebGPURenderer()` (src/render/webgpu/index.ts) is the single
+ *   app-facing renderer construction boundary; this module is the contract that
+ *   boundary promises. RuntimeService and AnimationLoop depend only on this.
+ *
+ * [LAW:locality-or-seam] This interface IS the boundary between app/runtime and
+ *   the render backend. The Three implementation lives behind it; no `three`
+ *   type appears in this file, so the app never depends on a Three object
+ *   identity (three-fork-deltas.md §3 capability surface).
+ * [LAW:single-enforcer] One contract module, imported by both the seam
+ *   (`index.ts`) and the implementation (`ThreeForkRenderer.ts`), so the shape
+ *   has a single source of truth.
+ */
+
+import type { PlanInputChannel, ScenePlan } from '../../scene-plan';
+
+/**
+ * A render-backend fault, surfaced to the runtime fault handler.
+ *
+ * [LAW:no-silent-failure] Faults are explicit, classified values — never a
+ *   swallowed error or a silent degrade.
+ */
+export interface GpuFault {
+  readonly message: string;
+  readonly source: string;
+  readonly fatal: boolean;
+  readonly severity: 'fatal' | 'error' | 'warning';
+  readonly code: string;
+  readonly recoverable: boolean;
+}
+
+export type GpuFaultCallback = ((fault: GpuFault) => void) | null;
+
+/**
+ * Per-frame runtime input values, keyed by the plan's own channel vocabulary.
+ *
+ * [LAW:one-source-of-truth] Keyed by `PlanInputChannel` (the plan's declared
+ *   inputs), not by the worker transport field names. The runtime maps its
+ *   envelope onto these channel names at the call site; the renderer reads only
+ *   the channels its installed plan declared.
+ */
+export type RuntimeInputChannelValues = Readonly<Partial<Record<PlanInputChannel, number>>>;
+
+/**
+ * The renderer behind `createWebGPURenderer()`.
+ *
+ * The `getLatest*` / `getInstalledGpuPassIds` accessors are the legacy
+ * GPU-IR/Rust-worker telemetry surface the runtime still reads. The Three
+ * backend has no GPU-IR passes or sink tables, so they report "nothing here"
+ * (`null` / `[]`) honestly rather than fabricating legacy-shaped data.
+ */
+export interface WebGPURenderer {
+  /**
+   * Install a compiled `ScenePlan`, realizing it into the backend's scene
+   * graph. Replaces any previously installed plan. Pure CPU work — no GPU
+   * device is required until the first {@link WebGPURenderer.renderFrame}.
+   *
+   * [LAW:no-silent-failure] Throws on an incompatible plan version or a
+   *   dangling resource handle.
+   */
+  installScenePlan(plan: ScenePlan): void;
+
+  /**
+   * Draw one frame of the installed plan, feeding the declared runtime input
+   * channels from `values`. Acquires the GPU device lazily on first call.
+   *
+   * [LAW:no-silent-failure] Throws if no plan is installed, or if a channel the
+   *   plan declared in `render.inputs` has no value in `values`.
+   */
+  renderFrame(values: RuntimeInputChannelValues): Promise<void>;
+
+  dispose(): void;
+  setGpuFaultCallback(callback: GpuFaultCallback): void;
+  // Legacy GPU-IR/Rust-worker telemetry accessors. Typed `any` to match the
+  // runtime consumers that read snapshot-shaped fields off them; the Three
+  // backend reports null since it has no GPU-IR telemetry.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getLatestRuntimeTelemetry(): any;
+  getInstalledGpuPassIds(): readonly string[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getLatestSinkTableSample(): any;
+  getLifecycleState(): string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  getLatestBoundaryFixturePayloadV1(): any;
+  setTelemetryEnabled(enabled: boolean): void;
+}

--- a/src/render/webgpu/three/scene-plan-realizer.ts
+++ b/src/render/webgpu/three/scene-plan-realizer.ts
@@ -1,0 +1,279 @@
+/**
+ * src/render/webgpu/three/scene-plan-realizer.ts
+ *
+ * Realizes a backend-neutral `ScenePlan` into a Three scene graph: a `Scene`, an
+ * `OrthographicCamera`, one `InstancedMesh` per placed object, each shaded by a
+ * `NodeMaterial` whose color and per-instance transform are TSL graphs built
+ * from the plan's `PlanExpr`s.
+ *
+ * Scope source: design-docs/three-fork-integration-proposal.md §2.3, §6.
+ * Consumes the seam defined in src/render/scene-plan/. Capability tier:
+ * design-docs/three-fork-deltas.md §1 Tier B — composing upstream Three APIs to
+ * express an Oscilla `ScenePlan`. NOT a fork delta.
+ *
+ * [LAW:effects-at-boundaries] Realization is pure: Three objects (geometries,
+ *   materials, meshes, camera) are inert CPU data until a renderer draws them.
+ *   This module touches no GPU device, so it is fully unit-testable without one.
+ *   The device-bound act of drawing lives in ThreeForkRenderer.
+ * [LAW:locality-or-seam] Every "which Three class realizes this resource"
+ *   decision lives here, behind the renderer seam. The plan names resources;
+ *   this module is the one place those names become Three objects.
+ * [LAW:no-silent-failure] A plan that references a missing resource, declares a
+ *   degenerate instance count, or carries an incompatible version fails loudly
+ *   at realization rather than producing an empty or wrong scene that looks fine.
+ */
+
+import {
+  InstancedMesh,
+  Matrix4,
+  MeshBasicNodeMaterial,
+  OrthographicCamera,
+  PlaneGeometry,
+  Scene,
+  type BufferGeometry,
+  type Node,
+} from 'three/webgpu';
+import { add, cos, max, min, mod, mul, positionLocal, sin, sub, uniform, vec3, float } from 'three/tsl';
+
+import {
+  SCENE_PLAN_VERSION,
+  type CameraPlan,
+  type ColorBinding,
+  type GeometryDef,
+  type InstancingPlan,
+  type MaterialDef,
+  type PlanInputChannel,
+  type ScenePlan,
+  type SceneObjectRef,
+} from '../../scene-plan';
+import { planExprToTSL, type PlanExprContext, type TSLNode } from './plan-expr-tsl';
+
+/** A settable float uniform node, updated each frame from an input channel. */
+function floatUniform(value: number) {
+  return uniform(value, 'float');
+}
+export type InputUniform = ReturnType<typeof floatUniform>;
+
+/**
+ * A realized scene: everything the renderer needs to draw and to drive the
+ * declared runtime inputs each frame.
+ *
+ * [LAW:locality-or-seam] This is internal to the renderer backend. The Three
+ *   `Scene`/`OrthographicCamera` it holds never cross back to app code — the
+ *   renderer exposes capabilities, not these objects.
+ */
+export interface RealizedScene {
+  readonly scene: Scene;
+  readonly camera: OrthographicCamera;
+  /** Uniform node per declared input channel; the renderer writes `.value`. */
+  readonly inputs: ReadonlyMap<PlanInputChannel, InputUniform>;
+  /** Releases every GPU-backed resource this scene allocated. */
+  dispose(): void;
+}
+
+// 'point' has no proof-target patch yet (Grid of Squares uses 'rectangle'); it
+// is realized as a unit quad so the instanced-draw path is uniform across both
+// geometry kinds. A true point primitive lands with the first point-based demo
+// (Spirograph), the same way textures/compute/post are deferred.
+const POINT_QUAD_WORLD_SIZE = 1;
+
+function geometryDefToGeometry(def: GeometryDef): BufferGeometry {
+  // [LAW:dataflow-not-control-flow] Both kinds take the same draw path; only the
+  //   quad dimensions differ as values.
+  switch (def.kind) {
+    case 'rectangle':
+      return new PlaneGeometry(def.width, def.height);
+    case 'point':
+      return new PlaneGeometry(POINT_QUAD_WORLD_SIZE, POINT_QUAD_WORLD_SIZE);
+    default:
+      return assertNever(def);
+  }
+}
+
+/** Branchless HSL→RGB (h,s,l in [0,1]) as a TSL graph. */
+function hslToRgb(h: TSLNode, s: TSLNode, l: TSLNode): Node<'vec3'> {
+  const a = mul(s, min(l, sub(float(1), l)));
+  const channel = (n: number): TSLNode => {
+    const k = mod(add(float(n), mul(h, float(12))), float(12));
+    const m = max(float(-1), min(min(sub(k, float(3)), sub(float(9), k)), float(1)));
+    return sub(l, mul(a, m));
+  };
+  return vec3(channel(0), channel(8), channel(4));
+}
+
+interface ColorNodes {
+  readonly colorNode: Node<'vec3'>;
+  readonly opacityNode: TSLNode | null;
+}
+
+function colorBindingToNodes(binding: ColorBinding, ctx: PlanExprContext): ColorNodes {
+  // [LAW:dataflow-not-control-flow] The color space is a discriminated value;
+  //   each arm maps its channels through the same `PlanExpr`→TSL translator.
+  const e = (expr: Parameters<typeof planExprToTSL>[0]): TSLNode => planExprToTSL(expr, ctx);
+  switch (binding.space) {
+    case 'rgb':
+      return { colorNode: vec3(e(binding.r), e(binding.g), e(binding.b)), opacityNode: null };
+    case 'rgba':
+      return { colorNode: vec3(e(binding.r), e(binding.g), e(binding.b)), opacityNode: e(binding.a) };
+    case 'hsl':
+      return { colorNode: hslToRgb(e(binding.h), e(binding.s), e(binding.l)), opacityNode: null };
+    default:
+      return assertNever(binding);
+  }
+}
+
+function materialDefToMaterial(def: MaterialDef, ctx: PlanExprContext): MeshBasicNodeMaterial {
+  // [LAW:dataflow-not-control-flow] One material kind today; a switch keeps the
+  //   addition of a future kind a compile error rather than a silent default.
+  switch (def.kind) {
+    case 'unlitColor': {
+      const material = new MeshBasicNodeMaterial();
+      const { colorNode, opacityNode } = colorBindingToNodes(def.color, ctx);
+      material.colorNode = colorNode;
+      if (opacityNode) {
+        material.opacityNode = opacityNode;
+        material.transparent = true;
+      }
+      return material;
+    }
+    default:
+      return assertNever(def.kind);
+  }
+}
+
+/**
+ * The per-instance vertex position: rotate the geometry's local XY by the
+ * instance's rotation, then translate by its position. Each operand is a
+ * `PlanExpr` evaluated per instance (it may reference `index`/`rank`/inputs), so
+ * placement is computed on the GPU from intrinsics — no per-instance CPU
+ * payload bag.
+ */
+function instanceTransformNode(transform: InstancingPlan['transform'], ctx: PlanExprContext): Node<'vec3'> {
+  const rotation = planExprToTSL(transform.rotation, ctx);
+  const px = planExprToTSL(transform.positionX, ctx);
+  const py = planExprToTSL(transform.positionY, ctx);
+  const c = cos(rotation);
+  const s = sin(rotation);
+  const lx = positionLocal.x;
+  const ly = positionLocal.y;
+  const rx = sub(mul(lx, c), mul(ly, s));
+  const ry = add(mul(lx, s), mul(ly, c));
+  return vec3(add(rx, px), add(ry, py), positionLocal.z);
+}
+
+function buildCamera(plan: CameraPlan): OrthographicCamera {
+  switch (plan.kind) {
+    case 'orthographic': {
+      const camera = new OrthographicCamera(
+        -plan.halfExtentX,
+        plan.halfExtentX,
+        plan.halfExtentY,
+        -plan.halfExtentY,
+        0.1,
+        100,
+      );
+      camera.position.z = 10;
+      camera.updateProjectionMatrix();
+      return camera;
+    }
+    default:
+      return assertNever(plan.kind);
+  }
+}
+
+// InstancedMesh allocates its instance matrices uninitialized (zero matrices,
+// which collapse every instance). Placement is owned by the material's
+// positionNode, so each instance transform is neutralized to identity once.
+function initIdentityInstances(mesh: InstancedMesh): void {
+  const identity = new Matrix4();
+  for (let i = 0; i < mesh.count; i += 1) {
+    mesh.setMatrixAt(i, identity);
+  }
+  mesh.instanceMatrix.needsUpdate = true;
+}
+
+function requireResource<T>(table: Readonly<Record<string, T>>, ref: string, kind: string): T {
+  const def = table[ref];
+  // [LAW:no-silent-failure] A dangling resource handle is a broken plan, not a
+  //   thing to skip.
+  if (!def) {
+    throw new Error(`scene-plan-realizer: ${kind} resource '${ref}' referenced by the plan is not defined`);
+  }
+  return def;
+}
+
+/**
+ * Realize a `ScenePlan` into a Three scene graph.
+ *
+ * @throws if the plan version is incompatible, a referenced resource is
+ *   missing, or an object declares a non-positive instance count.
+ */
+export function realizeScenePlan(plan: ScenePlan): RealizedScene {
+  // [LAW:no-silent-failure] An incompatible plan is a loud contract mismatch,
+  //   not a best-effort partial render. Mirrors SCENE_PLAN_VERSION's intent.
+  if (plan.version !== SCENE_PLAN_VERSION) {
+    throw new Error(
+      `scene-plan-realizer: incompatible ScenePlan version ${String(plan.version)}; renderer supports ${SCENE_PLAN_VERSION}`,
+    );
+  }
+
+  const inputs = new Map<PlanInputChannel, InputUniform>();
+  for (const channel of plan.render.inputs) {
+    if (!inputs.has(channel)) {
+      inputs.set(channel, uniform(0));
+    }
+  }
+  const inputNodes: Partial<Record<PlanInputChannel, TSLNode>> = {};
+  for (const [channel, node] of inputs) {
+    inputNodes[channel] = node;
+  }
+
+  const scene = new Scene();
+  const disposables: Array<{ dispose(): void }> = [];
+  const placed = new Set<SceneObjectRef>();
+
+  for (const draw of plan.render.draws) {
+    if (placed.has(draw.object)) {
+      continue;
+    }
+    placed.add(draw.object);
+
+    const object = requireResource(plan.objects, draw.object, 'scene object');
+    // [LAW:no-silent-failure] A zero/negative count would build a draw that
+    //   renders nothing while looking installed; reject it.
+    if (object.instancing.count <= 0) {
+      throw new Error(
+        `scene-plan-realizer: scene object '${draw.object}' declares non-positive instance count ${object.instancing.count}`,
+      );
+    }
+
+    const ctx: PlanExprContext = { instanceCount: object.instancing.count, inputs: inputNodes };
+    const geometry = geometryDefToGeometry(requireResource(plan.resources.geometries, object.geometry, 'geometry'));
+    const material = materialDefToMaterial(requireResource(plan.resources.materials, object.material, 'material'), ctx);
+    material.positionNode = instanceTransformNode(object.instancing.transform, ctx);
+
+    const mesh = new InstancedMesh(geometry, material, object.instancing.count);
+    initIdentityInstances(mesh);
+    scene.add(mesh);
+
+    disposables.push(geometry, material);
+  }
+
+  const camera = buildCamera(plan.render.camera);
+
+  return {
+    scene,
+    camera,
+    inputs,
+    dispose() {
+      for (const d of disposables) {
+        d.dispose();
+      }
+      scene.clear();
+    },
+  };
+}
+
+function assertNever(value: never): never {
+  throw new Error(`scene-plan-realizer: unhandled variant: ${JSON.stringify(value)}`);
+}


### PR DESCRIPTION
## What

Replaces the scorched-earth stub behind `createWebGPURenderer()` with a real **Three-backed renderer** that consumes the backend-neutral `ScenePlan` shipped by ulu.1 (#358). This is the renderer integration for the Three migration steel thread.

Scope source: `three-fork-integration-proposal.md` §2.3/§6. Ownership/seam canon: `three-migration-backend-canon.md`. Capability tier: `three-fork-deltas.md` §1–§3 (fork-delta register **EMPTY** — plain upstream Three, Tier B composition only).

## How it's cut

| Module | Role | Pure? |
|---|---|---|
| `three/plan-expr-tsl.ts` | `PlanExpr` → TSL node graph; operator selection is a typed total lookup table | ✅ pure |
| `three/scene-plan-realizer.ts` | `ScenePlan` → Three scene graph (geometry/material/instancing/camera, branchless HSL→RGB) | ✅ pure (no GPU) |
| `three/ThreeForkRenderer.ts` | the one effectful unit: owns the Three `WebGPURenderer` device | ⚡ effectful |
| `three/renderer-contract.ts` | backend-neutral seam contract; no `three` type crosses it | — |

**Central design constraint:** the GPU device is acquired **lazily on first frame**, never at construction. So the app shell boots headless (no adapter) and a plan can be installed before any device exists — which is exactly why `verify:renderer-shell` stays green. `[LAW:no-ambient-temporal-coupling]` / `[LAW:effects-at-boundaries]`

## Acceptance criteria

- ✅ `createWebGPURenderer` returns a real Three-backed implementation behind the existing facade.
- ✅ RuntimeService lifecycle, fault handling, and disposal work through the same seam (interface preserved + extended; dispose/fault/telemetry intact).
- ✅ Backend accepts a `ScenePlan` (`installScenePlan(plan)`) without exposing Three classes to app code.
- ✅ Verification automated: 19 new unit tests + `verify:renderer-shell`.

## Verification

- `npm run verify:renderer-shell` — **PASS before AND after** (typecheck + targeted runtime tests + headless app-shell smoke).
- Full suite: **2106 pass / 0 fail** (+19 new tests).
- tsc clean, eslint clean, **0 new dependency-cruiser violations**.
- `three@0.184.0` + `@types/three@0.184.1` pinned exactly (no `^`).
- Source-level test forbids any Three backend file from importing `boundary-contract` (ScenePlan is the sole assembly target — no dual ownership).

The GPU draw path (device + `renderAsync`) needs a real adapter and is proven by **ulu.5's `--no-headless` e2e**, not here.

Closes oscilla-pillars-cleanup-ulu.2
