### PR TITLE
feat(ulu.3): compiler lowering — authored patch graph to ScenePlan

### DIFF
--- a/src/pillars/assembly/payload.ts
+++ b/src/pillars/assembly/payload.ts
@@ -1,3 +1,15 @@
+/**
+ * src/pillars/assembly/payload.ts
+ *
+ * FROZEN LEGACY. Assembles the Rust-boundary `PipelineInstallPayload` — the
+ * dead GPU-IR target (design-docs/three-migration-backend-canon.md §"Dead
+ * Concepts"). New backend work targets `ScenePlan` via `compileScenePlan`
+ * (src/pillars/scene), not this assembler. The two targets do not co-assemble
+ * from one graph; see design-docs/three-migration-scene-plan.md §"The
+ * Replacement". Kept only to keep the frozen Rust path operational during
+ * migration — do not extend.
+ */
+
 import type { PipelineInstallPayload } from '../../render/rust/boundary-contract';
 import type { LoweredPasses } from '../lowering/lowered-passes';
 

--- a/src/pillars/fixtures/grid-of-squares.ts
+++ b/src/pillars/fixtures/grid-of-squares.ts
@@ -1,0 +1,66 @@
+/**
+ * src/pillars/fixtures/grid-of-squares.ts
+ *
+ * The first Three-migration proof patch, authored as Oscilla graph semantics:
+ * a 10×10 grid of squares, each rotating over time, colored by an HSL hue that
+ * spreads across the grid by rank and cycles with time.
+ *
+ * Scope source: design-docs/three-migration-first-proof-contract.md
+ *   §"Required Compiler Capabilities"; design-docs/DEMO-PATCHES.md
+ *   §"Grid of Squares".
+ *
+ * This patch carries only declarative *parameters*. The ScenePlan lowering
+ * (src/pillars/scene) synthesizes the per-instance index/rank math from them —
+ * the authored graph never spells out a `PlanExpr` or a Three scene.
+ *
+ * [LAW:one-source-of-truth] These parameters are the canonical authored intent.
+ *   The compiled ScenePlan is derived execution data, produced by
+ *   `compileScenePlan`, never hand-authored alongside this patch.
+ *
+ * It is compiled through `compileScenePlan` (NOT `compilePillarPatch`), so it is
+ * deliberately absent from `PILLAR_FIXTURES`, which feeds the frozen GPU-IR
+ * compiler-tester.
+ */
+
+import type { PillarPatch } from '../types';
+
+export function makeGridOfSquaresPatch(): PillarPatch {
+  return {
+    blocks: [
+      {
+        id: 'grid',
+        kind: 'generator',
+        type: 'InstanceGrid',
+        config: {
+          rows: 10,
+          cols: 10,
+          spacing: 0.1,
+          rotationPerIndex: 0.5,
+          rotationPerTime: 2.0,
+          huePerTime: 0.2,
+          saturation: 0.8,
+          lightness: 0.6,
+        },
+      },
+      {
+        id: 'draw',
+        kind: 'intent',
+        type: 'DrawInstances',
+        config: {
+          size: 0.08,
+          cameraHalfExtentX: 0.6,
+          cameraHalfExtentY: 0.6,
+        },
+      },
+    ],
+    edges: [
+      {
+        id: 'e0',
+        source: 'grid',
+        target: 'draw',
+        inputSlot: 'primary',
+        role: 'primary',
+      },
+    ],
+  };
+}

--- a/src/pillars/scene/__tests__/compile.test.ts
+++ b/src/pillars/scene/__tests__/compile.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Integration tests for the ScenePlan compile path (ulu.3).
+ *
+ * The centerpiece compiles the authored `Grid of Squares` patch
+ * (src/pillars/fixtures/grid-of-squares.ts) through `compileScenePlan` and
+ * asserts it satisfies every "Required Compiler Capability" of the first proof
+ * contract (design-docs/three-migration-first-proof-contract.md). Assertions
+ * target what the plan *means* — not the exact PlanExpr tree shape — so the
+ * lowering is free to refactor expression construction.
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+import { compileScenePlan } from '../index';
+import { makeGridOfSquaresPatch } from '../../fixtures/grid-of-squares';
+import { sceneObjectRef } from '../../../render/scene-plan';
+import type { PillarPatch } from '../../types';
+import type { ScenePlan } from '../../../render/scene-plan';
+
+const SCENE_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function compileOk(patch: PillarPatch): ScenePlan {
+  const result = compileScenePlan(patch);
+  if (result.kind !== 'ok') {
+    throw new Error(`Expected ok ScenePlan, got errors: ${result.errors.join('; ')}`);
+  }
+  return result.plan;
+}
+
+describe('compileScenePlan — Grid of Squares proof target', () => {
+  const plan = compileOk(makeGridOfSquaresPatch());
+  const object = plan.objects[sceneObjectRef('draw')];
+
+  it('compiles the authored patch to an ok ScenePlan', () => {
+    expect(plan.version).toBe(1);
+    expect(object).toBeDefined();
+  });
+
+  it('declares one instance domain with count = 100 (rows × cols)', () => {
+    expect(object.instancing.count).toBe(100);
+  });
+
+  it('exposes index and rank as per-instance intrinsics', () => {
+    const transform = JSON.stringify(object.instancing.transform);
+    expect(transform).toContain('"intrinsic"');
+    expect(transform).toContain('"index"');
+    const color = JSON.stringify(plan.resources.materials[object.material].color);
+    expect(color).toContain('"rank"');
+  });
+
+  it('binds time as a derived runtime input channel, not a compile-time constant', () => {
+    expect(plan.render.inputs).toEqual(['time']);
+    const rotation = JSON.stringify(object.instancing.transform.rotation);
+    expect(rotation).toContain('"input"');
+    expect(rotation).toContain('"time"');
+  });
+
+  it('carries a per-instance transform with both position and rotation', () => {
+    const { transform } = object.instancing;
+    expect(transform.positionX).toBeDefined();
+    expect(transform.positionY).toBeDefined();
+    expect(transform.rotation).toBeDefined();
+    // Position varies per instance: it references the index intrinsic.
+    expect(JSON.stringify(transform.positionX)).toContain('"index"');
+  });
+
+  it('references one canonical rectangle geometry by handle', () => {
+    const geo = plan.resources.geometries[object.geometry];
+    expect(geo.kind).toBe('rectangle');
+    if (geo.kind !== 'rectangle') return;
+    expect(geo.width).toBe(0.08);
+    expect(geo.height).toBe(0.08);
+  });
+
+  it('references one unlit HSL color material with a per-instance color payload', () => {
+    const material = plan.resources.materials[object.material];
+    expect(material.kind).toBe('unlitColor');
+    expect(material.color.space).toBe('hsl');
+  });
+
+  it('emits one draw item targeting the preview canvas', () => {
+    expect(plan.render.draws).toHaveLength(1);
+    expect(plan.render.draws[0].target).toBe('previewCanvas');
+    expect(plan.render.draws[0].object).toBe(sceneObjectRef('draw'));
+  });
+
+  it('frames the scene with an orthographic camera from the authored half-extents', () => {
+    expect(plan.render.camera.kind).toBe('orthographic');
+    expect(plan.render.camera.halfExtentX).toBe(0.6);
+    expect(plan.render.camera.halfExtentY).toBe(0.6);
+  });
+
+  it('leaves the deferred resource tables empty', () => {
+    expect(plan.resources.textures).toEqual({});
+    expect(plan.resources.computeResources).toEqual({});
+    expect(plan.resources.postChains).toEqual({});
+    expect(plan.render.postChain).toBeNull();
+  });
+
+  it('is fully JSON-serializable — pure data, no renderer objects or closures', () => {
+    const roundTripped = JSON.parse(JSON.stringify(plan));
+    expect(roundTripped).toEqual(plan);
+  });
+
+  it('resolves draw → object → resources by handle', () => {
+    const draw = plan.render.draws[0];
+    const resolved = plan.objects[draw.object];
+    expect(resolved).toBeDefined();
+    expect(plan.resources.geometries[resolved.geometry]).toBeDefined();
+    expect(plan.resources.materials[resolved.material]).toBeDefined();
+  });
+});
+
+describe('compileScenePlan — loud failures', () => {
+  it('reports an unknown block type', () => {
+    const result = compileScenePlan({
+      blocks: [{ id: 'x', kind: 'generator', type: 'NotARealBlock', config: {} }],
+      edges: [],
+    });
+    expect(result.kind).toBe('error');
+    if (result.kind !== 'error') return;
+    expect(result.errors.join('\n')).toContain('NotARealBlock');
+  });
+
+  it('reports a draw block with no primary input edge', () => {
+    const result = compileScenePlan({
+      blocks: [
+        { id: 'draw', kind: 'intent', type: 'DrawInstances',
+          config: { size: 0.08, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 } },
+      ],
+      edges: [],
+    });
+    expect(result.kind).toBe('error');
+    if (result.kind !== 'error') return;
+    expect(result.errors.join('\n')).toMatch(/no primary input edge/);
+  });
+
+  it('reports a draw whose primary source is not an instance source', () => {
+    const result = compileScenePlan({
+      blocks: [
+        { id: 'a', kind: 'intent', type: 'DrawInstances',
+          config: { size: 0.08, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 } },
+        { id: 'b', kind: 'intent', type: 'DrawInstances',
+          config: { size: 0.08, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 } },
+      ],
+      edges: [{ id: 'e', source: 'a', target: 'b', inputSlot: 'primary', role: 'primary' }],
+    });
+    expect(result.kind).toBe('error');
+    if (result.kind !== 'error') return;
+    expect(result.errors.join('\n')).toMatch(/not an instance source/);
+  });
+
+  it('reports invalid generator config (collects all bad fields)', () => {
+    const result = compileScenePlan({
+      blocks: [
+        { id: 'grid', kind: 'generator', type: 'InstanceGrid',
+          config: { rows: -1, cols: 0, spacing: 0, rotationPerIndex: 'x',
+            rotationPerTime: 1, huePerTime: 1, saturation: 1, lightness: 1 } },
+      ],
+      edges: [],
+    });
+    expect(result.kind).toBe('error');
+    if (result.kind !== 'error') return;
+    const message = result.errors.join('\n');
+    expect(message).toContain("'rows'");
+    expect(message).toContain("'cols'");
+    expect(message).toContain("'spacing'");
+    expect(message).toContain("'rotationPerIndex'");
+  });
+
+  it('reports a patch with no draw block', () => {
+    const result = compileScenePlan({
+      blocks: [
+        { id: 'grid', kind: 'generator', type: 'InstanceGrid',
+          config: { rows: 10, cols: 10, spacing: 0.1, rotationPerIndex: 0.5,
+            rotationPerTime: 2, huePerTime: 0.2, saturation: 0.8, lightness: 0.6 } },
+      ],
+      edges: [],
+    });
+    expect(result.kind).toBe('error');
+    if (result.kind !== 'error') return;
+    expect(result.errors.join('\n')).toMatch(/renders nothing/);
+  });
+});
+
+describe('compileScenePlan — backend neutrality (source-level)', () => {
+  it('imports nothing from the Rust boundary or any renderer backend', () => {
+    const collect = (dir: string): string[] => {
+      const out: string[] = [];
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === '__tests__') continue;
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...collect(full));
+        else if (entry.name.endsWith('.ts')) out.push(readFileSync(full, 'utf8'));
+      }
+      return out;
+    };
+    const sources = collect(SCENE_DIR);
+    expect(sources.length).toBeGreaterThan(0);
+    for (const src of sources) {
+      // Assert the *imports*, not mere mentions: doc comments may discuss these
+      // concepts ([LAW:behavior-not-structure] — test the dependency, not prose).
+      // [LAW:one-source-of-truth] No dependency on the frozen Rust payload.
+      expect(src).not.toMatch(/from ['"][^'"]*boundary-contract/);
+      // [LAW:locality-or-seam] No Three / WASM coupling in the compiler output.
+      expect(src).not.toMatch(/from ['"]three/);
+      expect(src).not.toMatch(/from ['"][^'"]*render\/wasm/);
+    }
+  });
+});

--- a/src/pillars/scene/assemble.ts
+++ b/src/pillars/scene/assemble.ts
@@ -1,0 +1,156 @@
+/**
+ * src/pillars/scene/assemble.ts
+ *
+ * Joins resolved block contributions into a normalized `ScenePlan`.
+ *
+ * Each draw block is joined to the instance source on its primary edge: the
+ * draw's shell (geometry, material kind, camera) plus the source's bundle
+ * (count, transform, color) become one `SceneObject` + `DrawItem`. Resources
+ * are normalized into ref-keyed tables.
+ *
+ * [LAW:one-source-of-truth] Each geometry/material is defined exactly once in
+ *   its table and referenced by handle from the scene object — no inline
+ *   duplication.
+ * [LAW:no-silent-failure] A draw with no primary edge, or whose source is not an
+ *   instance source, is a surfaced error — never a silently-dropped draw.
+ */
+
+import type { PillarEdge } from '../types';
+import {
+  SCENE_PLAN_VERSION,
+  defineScenePlan,
+  geometryRef,
+  materialRef,
+  sceneObjectRef,
+  type CameraPlan,
+  type DrawItem,
+  type GeometryDef,
+  type GeometryRef,
+  type MaterialDef,
+  type MaterialRef,
+  type ScenePlan,
+  type SceneObject,
+  type SceneObjectRef,
+} from '../../render/scene-plan';
+import type { SceneContribution } from './scene-block';
+import { collectInputChannels, colorChannels } from './inputs';
+
+export type SceneCompileResult =
+  | { readonly kind: 'ok'; readonly plan: ScenePlan }
+  | { readonly kind: 'error'; readonly errors: readonly string[] };
+
+/**
+ * The deferred resource tables: textures, compute, and post are owned by later
+ * tickets (asset bridge ulu.4; TSL compute/post per three-fork-deltas.md).
+ *
+ * [LAW:dataflow-not-control-flow] Deferred capabilities are present-but-empty
+ *   collections, not absent fields — the shape is fixed; only contents vary.
+ */
+function emptyDeferredResources(): Pick<
+  ScenePlan['resources'],
+  'textures' | 'computeResources' | 'postChains'
+> {
+  return { textures: {}, computeResources: {}, postChains: {} };
+}
+
+/**
+ * Reconcile the cameras declared by every draw into the single scene camera.
+ * One scene has one camera; if draws disagree, that is a loud error rather than
+ * an arbitrary winner.
+ */
+function reconcileCamera(cameras: readonly CameraPlan[], errors: string[]): CameraPlan | null {
+  if (cameras.length === 0) return null;
+  const [first, ...rest] = cameras;
+  const firstKey = JSON.stringify(first);
+  for (const camera of rest) {
+    if (JSON.stringify(camera) !== firstKey) {
+      errors.push('[scene] draw blocks declare conflicting cameras; a scene has one camera');
+      return null;
+    }
+  }
+  return first;
+}
+
+export function assembleScenePlan(
+  edges: readonly PillarEdge[],
+  contributions: ReadonlyMap<string, SceneContribution>,
+): SceneCompileResult {
+  const errors: string[] = [];
+
+  const geometries: Record<GeometryRef, GeometryDef> = {};
+  const materials: Record<MaterialRef, MaterialDef> = {};
+  const objects: Record<SceneObjectRef, SceneObject> = {};
+  const draws: DrawItem[] = [];
+  const cameras: CameraPlan[] = [];
+
+  const drawEntries = [...contributions].filter(
+    (entry): entry is [string, Extract<SceneContribution, { role: 'draw' }>] =>
+      entry[1].role === 'draw',
+  );
+  if (drawEntries.length === 0) {
+    errors.push('[scene] no draw block: the patch renders nothing');
+  }
+
+  for (const [drawId, contribution] of drawEntries) {
+    const primaryEdge = edges.find((e) => e.target === drawId && e.role === 'primary');
+    if (!primaryEdge) {
+      errors.push(`[scene] draw block '${drawId}' has no primary input edge`);
+      continue;
+    }
+    const source = contributions.get(primaryEdge.source);
+    if (!source || source.role !== 'instanceSource') {
+      errors.push(
+        `[scene] draw block '${drawId}' primary source '${primaryEdge.source}' is not an instance source`,
+      );
+      continue;
+    }
+
+    const { shell } = contribution;
+    const { bundle } = source;
+
+    const geoRef = geometryRef(`${drawId}:geometry`);
+    const matRef = materialRef(`${drawId}:material`);
+    const objRef = sceneObjectRef(drawId);
+
+    geometries[geoRef] = shell.geometry;
+    // Join: the material shell's kind + the upstream bundle's per-instance color.
+    materials[matRef] = { kind: shell.material.kind, color: bundle.color };
+    objects[objRef] = {
+      geometry: geoRef,
+      material: matRef,
+      instancing: { count: bundle.count, transform: bundle.transform },
+    };
+    draws.push({ target: shell.target, object: objRef });
+    cameras.push(shell.camera);
+  }
+
+  const camera = reconcileCamera(cameras, errors);
+
+  if (errors.length > 0 || camera === null) {
+    return { kind: 'error', errors };
+  }
+
+  // Inputs are derived from every per-instance expression the plan contains.
+  const exprs = [
+    ...Object.values(objects).flatMap((o) => [
+      o.instancing.transform.positionX,
+      o.instancing.transform.positionY,
+      o.instancing.transform.rotation,
+    ]),
+    ...Object.values(materials).flatMap((m) => colorChannels(m.color)),
+  ];
+
+  const plan = defineScenePlan({
+    version: SCENE_PLAN_VERSION,
+    resources: { geometries, materials, ...emptyDeferredResources() },
+    objects,
+    render: {
+      camera,
+      inputs: collectInputChannels(exprs),
+      draws,
+      postChain: null,
+    },
+  });
+
+  return { kind: 'ok', plan };
+}

--- a/src/pillars/scene/blocks/draw-instances.ts
+++ b/src/pillars/scene/blocks/draw-instances.ts
@@ -1,0 +1,54 @@
+/**
+ * src/pillars/scene/blocks/draw-instances.ts
+ *
+ * Draw (sink) block: wraps an upstream instance bundle in a rendering shell —
+ * a rectangle geometry, an unlit color material, an orthographic camera — and
+ * draws it to the preview canvas.
+ *
+ * [LAW:decomposition] This block owns *how the instances are drawn* (geometry,
+ *   material kind, framing, target); the instance-source block owns *what
+ *   varies per instance*. The lowering joins the two at the primary edge.
+ * [LAW:locality-or-seam] The shell names a geometry/material by shape only; the
+ *   handles that turn it into resource-table entries are minted by the lowering,
+ *   and the Three classes that realize them live behind the renderer seam.
+ */
+
+import type { SceneBlockDefinition, SceneContribution } from '../scene-block';
+import { readPositiveNumber } from '../scene-block';
+
+interface DrawInstancesConfig {
+  readonly size: number;
+  readonly cameraHalfExtentX: number;
+  readonly cameraHalfExtentY: number;
+}
+
+export const DrawInstancesBlock: SceneBlockDefinition<DrawInstancesConfig> = {
+  type: 'DrawInstances',
+  role: 'draw',
+
+  readConfig: (raw, blockId, diagnostics) => {
+    const size = readPositiveNumber(raw, 'size', blockId, diagnostics);
+    const cameraHalfExtentX = readPositiveNumber(raw, 'cameraHalfExtentX', blockId, diagnostics);
+    const cameraHalfExtentY = readPositiveNumber(raw, 'cameraHalfExtentY', blockId, diagnostics);
+
+    if (size === null || cameraHalfExtentX === null || cameraHalfExtentY === null) {
+      return null;
+    }
+    return { size, cameraHalfExtentX, cameraHalfExtentY };
+  },
+
+  contribute: (config): SceneContribution => ({
+    role: 'draw',
+    shell: {
+      geometry: { kind: 'rectangle', width: config.size, height: config.size },
+      material: { kind: 'unlitColor' },
+      camera: {
+        kind: 'orthographic',
+        halfExtentX: config.cameraHalfExtentX,
+        halfExtentY: config.cameraHalfExtentY,
+      },
+      // One render target exists today; the type pins it as a value, not a flag.
+      target: 'previewCanvas',
+    },
+  }),
+};

--- a/src/pillars/scene/blocks/index.ts
+++ b/src/pillars/scene/blocks/index.ts
@@ -1,0 +1,15 @@
+/**
+ * src/pillars/scene/blocks/index.ts
+ *
+ * The full set of scene blocks the ScenePlan lowering knows how to compile.
+ * Adding a block is adding a row here, not editing the lowering.
+ */
+
+import type { SceneBlockDefinition } from '../scene-block';
+import { InstanceGridBlock } from './instance-grid';
+import { DrawInstancesBlock } from './draw-instances';
+
+export const ALL_SCENE_BLOCKS: readonly SceneBlockDefinition<unknown>[] = [
+  InstanceGridBlock as SceneBlockDefinition<unknown>,
+  DrawInstancesBlock as SceneBlockDefinition<unknown>,
+];

--- a/src/pillars/scene/blocks/instance-grid.ts
+++ b/src/pillars/scene/blocks/instance-grid.ts
@@ -1,0 +1,110 @@
+/**
+ * src/pillars/scene/blocks/instance-grid.ts
+ *
+ * Instance-source block: lays a `rows × cols` grid of animated instances and
+ * emits the per-instance field bundle (position, rotation, color) as PlanExprs.
+ *
+ * This is where authored *parameters* become backend-neutral *expressions* —
+ * the "Oscilla fields/expressions → TSL expressions" mapping of the migration
+ * (design-docs/three-fork-integration-proposal.md §3). The block stores scalar
+ * grid/animation parameters; the lowering synthesizes the index/rank math.
+ *
+ * [LAW:one-source-of-truth] `rows`/`cols`/`spacing`/animation coefficients are
+ *   the canonical authored intent; the `PlanExpr` trees below are derived from
+ *   them, never stored alongside them.
+ * [LAW:dataflow-not-control-flow] Per-instance variation lives in the *values*
+ *   (the `index`/`rank` intrinsics flowing through the expressions), not in any
+ *   per-instance branch.
+ */
+
+import {
+  add,
+  div,
+  floor,
+  input,
+  intrinsic,
+  konst,
+  mod,
+  mul,
+} from '../../../render/scene-plan';
+import {
+  readFiniteNumber,
+  readPositiveInt,
+  readPositiveNumber,
+  type SceneBlockDefinition,
+  type SceneContribution,
+} from '../scene-block';
+
+interface InstanceGridConfig {
+  readonly rows: number;
+  readonly cols: number;
+  readonly spacing: number;
+  readonly rotationPerIndex: number;
+  readonly rotationPerTime: number;
+  readonly huePerTime: number;
+  readonly saturation: number;
+  readonly lightness: number;
+}
+
+export const InstanceGridBlock: SceneBlockDefinition<InstanceGridConfig> = {
+  type: 'InstanceGrid',
+  role: 'instanceSource',
+
+  readConfig: (raw, blockId, diagnostics) => {
+    const rows = readPositiveInt(raw, 'rows', blockId, diagnostics);
+    const cols = readPositiveInt(raw, 'cols', blockId, diagnostics);
+    const spacing = readPositiveNumber(raw, 'spacing', blockId, diagnostics);
+    const rotationPerIndex = readFiniteNumber(raw, 'rotationPerIndex', blockId, diagnostics);
+    const rotationPerTime = readFiniteNumber(raw, 'rotationPerTime', blockId, diagnostics);
+    const huePerTime = readFiniteNumber(raw, 'huePerTime', blockId, diagnostics);
+    const saturation = readFiniteNumber(raw, 'saturation', blockId, diagnostics);
+    const lightness = readFiniteNumber(raw, 'lightness', blockId, diagnostics);
+
+    if (
+      rows === null ||
+      cols === null ||
+      spacing === null ||
+      rotationPerIndex === null ||
+      rotationPerTime === null ||
+      huePerTime === null ||
+      saturation === null ||
+      lightness === null
+    ) {
+      return null;
+    }
+    return { rows, cols, spacing, rotationPerIndex, rotationPerTime, huePerTime, saturation, lightness };
+  },
+
+  contribute: (config): SceneContribution => {
+    const index = intrinsic('index');
+    const rank = intrinsic('rank');
+    const time = input('time');
+
+    // Grid placement: row-major. col = index % cols; row = floor(index / cols).
+    const col = mod(index, konst(config.cols));
+    const row = floor(div(index, konst(config.cols)));
+
+    return {
+      role: 'instanceSource',
+      bundle: {
+        count: config.rows * config.cols,
+        transform: {
+          positionX: mul(col, konst(config.spacing)),
+          positionY: mul(row, konst(config.spacing)),
+          // rotation = index * rotationPerIndex + time * rotationPerTime
+          rotation: add(
+            mul(index, konst(config.rotationPerIndex)),
+            mul(time, konst(config.rotationPerTime)),
+          ),
+        },
+        color: {
+          space: 'hsl',
+          // hue spreads across the grid by normalized rank and cycles over time.
+          h: add(rank, mul(time, konst(config.huePerTime))),
+          s: konst(config.saturation),
+          l: konst(config.lightness),
+        },
+      },
+    };
+  },
+};

--- a/src/pillars/scene/compile.ts
+++ b/src/pillars/scene/compile.ts
@@ -1,0 +1,51 @@
+/**
+ * src/pillars/scene/compile.ts
+ *
+ * The ScenePlan compile entry: an authored `PillarPatch` → backend-neutral
+ * `ScenePlan`. This is the NEW primary assembly target for the Three migration
+ * (design-docs/three-migration-scene-plan.md). It replaces
+ * `assemblePipelineInstallPayload` as the thing new backend work produces.
+ *
+ * [LAW:one-source-of-truth] This path never touches `boundary-contract`: it does
+ *   not wrap, embed, or round-trip through `PipelineInstallPayload`. The Rust
+ *   payload remains a frozen legacy artifact; the two targets do not co-assemble
+ *   from one graph (canon §"Dead Concepts").
+ * [LAW:no-silent-failure] Every block validates its config and the assembler
+ *   validates graph wiring; all errors are collected and returned, never
+ *   swallowed.
+ */
+
+import type { PillarPatch } from '../types';
+import { ALL_SCENE_BLOCKS } from './blocks';
+import {
+  buildSceneRegistry,
+  type SceneContribution,
+  type SceneDiagnostic,
+} from './scene-block';
+import { assembleScenePlan, type SceneCompileResult } from './assemble';
+
+export function compileScenePlan(patch: PillarPatch): SceneCompileResult {
+  const registry = buildSceneRegistry(ALL_SCENE_BLOCKS);
+  const diagnostics: SceneDiagnostic[] = [];
+  const contributions = new Map<string, SceneContribution>();
+
+  for (const block of patch.blocks) {
+    const def = registry.get(block.type);
+    if (!def) {
+      diagnostics.push({
+        blockId: block.id,
+        message: `[scene] block '${block.id}': unknown block type '${block.type}'`,
+      });
+      continue;
+    }
+    const config = def.readConfig(block.config, block.id, diagnostics);
+    if (config === null) continue;
+    contributions.set(block.id, def.contribute(config));
+  }
+
+  if (diagnostics.length > 0) {
+    return { kind: 'error', errors: diagnostics.map((d) => d.message) };
+  }
+
+  return assembleScenePlan(patch.edges, contributions);
+}

--- a/src/pillars/scene/index.ts
+++ b/src/pillars/scene/index.ts
@@ -1,0 +1,25 @@
+/**
+ * src/pillars/scene/index.ts
+ *
+ * Public surface of the ScenePlan compile path — authored `PillarPatch` lowered
+ * to the backend-neutral `ScenePlan` (src/render/scene-plan).
+ *
+ * Producer of: `ScenePlan` (consumed by the Three-backed renderer, ulu.2).
+ * Replaces, for new backend work, `assemblePipelineInstallPayload`
+ * (design-docs/three-migration-scene-plan.md).
+ */
+
+export { compileScenePlan } from './compile';
+export type { SceneCompileResult } from './assemble';
+
+export { ALL_SCENE_BLOCKS } from './blocks';
+export {
+  buildSceneRegistry,
+  type SceneBlockDefinition,
+  type SceneContribution,
+  type SceneDiagnostic,
+  type InstanceBundle,
+  type DrawShell,
+  type MaterialShell,
+  type SceneRegistry,
+} from './scene-block';

--- a/src/pillars/scene/inputs.ts
+++ b/src/pillars/scene/inputs.ts
@@ -1,0 +1,55 @@
+/**
+ * src/pillars/scene/inputs.ts
+ *
+ * Derives the set of runtime input channels a ScenePlan reads, by walking every
+ * `PlanExpr` it contains.
+ *
+ * [LAW:one-source-of-truth] `RenderPlan.inputs` is the renderer-facing list of
+ *   channels to feed each frame. It is *derived* from the expressions that read
+ *   them, not hand-declared on the patch where it could drift. The expressions
+ *   are the single source of truth; this is their projection.
+ * [LAW:dataflow-not-control-flow] The walk visits every node unconditionally and
+ *   collects `input` leaves; channel membership is data, not a code path.
+ */
+
+import type { ColorBinding, PlanExpr, PlanInputChannel } from '../../render/scene-plan';
+
+function collectFromExpr(expr: PlanExpr, into: Set<PlanInputChannel>): void {
+  switch (expr.kind) {
+    case 'const':
+    case 'intrinsic':
+      return;
+    case 'input':
+      into.add(expr.channel);
+      return;
+    case 'unary':
+      collectFromExpr(expr.arg, into);
+      return;
+    case 'binary':
+      collectFromExpr(expr.lhs, into);
+      collectFromExpr(expr.rhs, into);
+      return;
+  }
+}
+
+/** The PlanExprs of a color binding, regardless of color space. */
+export function colorChannels(color: ColorBinding): readonly PlanExpr[] {
+  switch (color.space) {
+    case 'hsl':
+      return [color.h, color.s, color.l];
+    case 'rgb':
+      return [color.r, color.g, color.b];
+    case 'rgba':
+      return [color.r, color.g, color.b, color.a];
+  }
+}
+
+/**
+ * Collect the distinct runtime input channels referenced anywhere in the given
+ * expressions, returned in a stable (sorted) order so the plan is deterministic.
+ */
+export function collectInputChannels(exprs: Iterable<PlanExpr>): readonly PlanInputChannel[] {
+  const channels = new Set<PlanInputChannel>();
+  for (const expr of exprs) collectFromExpr(expr, channels);
+  return Array.from(channels).sort();
+}

--- a/src/pillars/scene/scene-block.ts
+++ b/src/pillars/scene/scene-block.ts
@@ -1,0 +1,206 @@
+/**
+ * src/pillars/scene/scene-block.ts
+ *
+ * The ABI between scene-block authors and the ScenePlan lowering.
+ *
+ * Scope source: design-docs/three-fork-integration-proposal.md §2.1, §2.2, §3.
+ * Ownership/seam canon: design-docs/three-migration-backend-canon.md
+ *   (Oscilla owns "compile/lower stages from authored graph to backend-neutral
+ *   execution data"; ScenePlan is that data).
+ * Replacement narrative: design-docs/three-migration-scene-plan.md §"Concept
+ *   Mapping".
+ *
+ * This is the NEW lowering ABI for the Three migration. It is deliberately NOT
+ * the GPU-IR `BlockDefinition` (src/pillars/block-api.ts): that ABI's `lower`
+ * produces `ExprIR`/`RosterEntry` for the frozen Rust-boundary payload (canon
+ * §"Dead Concepts"). A scene block instead `contribute`s backend-neutral
+ * ScenePlan fragments.
+ *
+ * [LAW:decomposition] A scene block is a genuinely different part from a GPU-IR
+ *   block — different target representation, different seam — so it gets its own
+ *   ABI rather than being forced through the GPU-IR contract.
+ * [LAW:effects-at-boundaries] `contribute` is pure: declarative config in,
+ *   ScenePlan-fragment description out. Nothing here touches a renderer.
+ * [LAW:types-are-the-program] The contribution is a discriminated union on
+ *   `role`; the lowering joins the parts by role without re-deriving block kind.
+ */
+
+import type {
+  CameraPlan,
+  ColorBinding,
+  GeometryDef,
+  RenderTarget,
+  TransformBinding,
+} from '../../render/scene-plan';
+
+// ---------------------------------------------------------------------------
+// Diagnostics — the loud-failure channel for config validation.
+// ---------------------------------------------------------------------------
+
+/**
+ * A config-validation failure. There is no `warning`/`info` severity here: a
+ * scene block either has a usable config or it does not.
+ *
+ * [LAW:no-silent-failure] An invalid config is a collected, surfaced error, not
+ *   a silently-defaulted value that renders the wrong scene.
+ */
+export interface SceneDiagnostic {
+  readonly message: string;
+  readonly blockId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Contributions — what a block hands the lowering, before parts are joined.
+// ---------------------------------------------------------------------------
+
+/**
+ * The per-instance field bundle an instance-source block emits: how many
+ * instances exist and the fields that vary across them. Each field is a
+ * `PlanExpr` (carried inside `TransformBinding` / `ColorBinding`), so it may
+ * reference `index`/`rank` intrinsics and runtime inputs.
+ *
+ * [LAW:one-source-of-truth] The bundle is the canonical per-instance data; the
+ *   draw block wraps it (geometry, material shell, camera) without re-deriving
+ *   any of these fields.
+ */
+export interface InstanceBundle {
+  readonly count: number;
+  readonly transform: TransformBinding;
+  readonly color: ColorBinding;
+}
+
+/**
+ * A material whose per-instance color is supplied by the upstream
+ * `InstanceBundle`. Only the surface *kind* is a draw-block decision; the color
+ * channels come from the bundle, so the shell carries no color of its own.
+ *
+ * [LAW:no-mode-explosion] One material kind today. New kinds are added as
+ *   variants here; the lowering's join stays a total switch.
+ */
+export type MaterialShell = { readonly kind: 'unlitColor' };
+
+/**
+ * What a draw (sink) block contributes before it is joined to its instance
+ * bundle: the rendering shell around the per-instance data.
+ */
+export interface DrawShell {
+  readonly geometry: GeometryDef;
+  readonly material: MaterialShell;
+  readonly camera: CameraPlan;
+  readonly target: RenderTarget;
+}
+
+/**
+ * The discriminated contribution every scene block produces. The lowering
+ * joins an `instanceSource` to the `draw` that reads it (via the primary edge).
+ */
+export type SceneContribution =
+  | { readonly role: 'instanceSource'; readonly bundle: InstanceBundle }
+  | { readonly role: 'draw'; readonly shell: DrawShell };
+
+// ---------------------------------------------------------------------------
+// Block definition — the contract every scene block file exports.
+// ---------------------------------------------------------------------------
+
+/**
+ * The shape every scene-block file exports as a named constant.
+ *
+ * `readConfig` validates/narrows raw authored config (loud diagnostics on bad
+ * input, never throws on user input). `contribute` is the pure mapping from the
+ * narrowed config to a backend-neutral ScenePlan fragment.
+ */
+export interface SceneBlockDefinition<TConfig> {
+  readonly type: string;
+  readonly role: SceneContribution['role'];
+  readonly readConfig: (
+    raw: Readonly<Record<string, unknown>>,
+    blockId: string,
+    diagnostics: SceneDiagnostic[],
+  ) => TConfig | null;
+  readonly contribute: (config: TConfig) => SceneContribution;
+}
+
+// ---------------------------------------------------------------------------
+// Registry — value-constructor, no module-level singleton (mirrors frontend).
+// ---------------------------------------------------------------------------
+
+export interface SceneRegistry {
+  readonly get: (type: string) => SceneBlockDefinition<unknown> | undefined;
+}
+
+export function buildSceneRegistry(
+  blocks: readonly SceneBlockDefinition<unknown>[],
+): SceneRegistry {
+  const byType = new Map<string, SceneBlockDefinition<unknown>>();
+  for (const block of blocks) {
+    if (byType.has(block.type)) {
+      throw new Error(`[scene] Duplicate scene block type in registry: '${block.type}'`);
+    }
+    byType.set(block.type, block);
+  }
+  return { get: (type) => byType.get(type) };
+}
+
+// ---------------------------------------------------------------------------
+// Config-reading helpers — one loud, validated read per primitive.
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a finite number from raw config, pushing a diagnostic if absent or not a
+ * finite number. Returns null on failure so the caller can keep collecting
+ * other field errors before bailing.
+ */
+export function readFiniteNumber(
+  raw: Readonly<Record<string, unknown>>,
+  key: string,
+  blockId: string,
+  diagnostics: SceneDiagnostic[],
+): number | null {
+  const value = raw[key];
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    diagnostics.push({
+      blockId,
+      message: `[scene] block '${blockId}': config '${key}' must be a finite number`,
+    });
+    return null;
+  }
+  return value;
+}
+
+/** Read a number that must be strictly positive (e.g. a spacing or size). */
+export function readPositiveNumber(
+  raw: Readonly<Record<string, unknown>>,
+  key: string,
+  blockId: string,
+  diagnostics: SceneDiagnostic[],
+): number | null {
+  const value = readFiniteNumber(raw, key, blockId, diagnostics);
+  if (value === null) return null;
+  if (value <= 0) {
+    diagnostics.push({
+      blockId,
+      message: `[scene] block '${blockId}': config '${key}' must be > 0 (got ${value})`,
+    });
+    return null;
+  }
+  return value;
+}
+
+/** Read a positive integer (e.g. a grid row/column count). */
+export function readPositiveInt(
+  raw: Readonly<Record<string, unknown>>,
+  key: string,
+  blockId: string,
+  diagnostics: SceneDiagnostic[],
+): number | null {
+  const value = readFiniteNumber(raw, key, blockId, diagnostics);
+  if (value === null) return null;
+  if (!Number.isInteger(value) || value <= 0) {
+    diagnostics.push({
+      blockId,
+      message: `[scene] block '${blockId}': config '${key}' must be a positive integer (got ${value})`,
+    });
+    return null;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Lowers an **authored `PillarPatch` → backend-neutral `ScenePlan`** (the artifact ulu.2's `ThreeForkRenderer` consumes), replacing `assemblePipelineInstallPayload` as the primary assembly target for new backend work. Implements `oscilla-pillars-cleanup-ulu.3`; unblocks the steel thread (ulu.5).

Scope source: `three-fork-integration-proposal.md` §2.1/§2.2/§3 · proof target: `three-migration-first-proof-contract.md` · ownership: `three-migration-backend-canon.md` · replacement narrative: `three-migration-scene-plan.md`.

## Design

The existing `src/pillars/` pipeline lowers blocks to GPU-IR (`PipelineInstallPayload`) — the canon's **Dead Concepts**. Its `BlockDefinition.lower` ABI is hardwired to `boundary-contract`, so the ScenePlan path is a **new, self-contained lowering** under `src/pillars/scene/` rather than a reuse of those closures. The frozen GPU-IR path stays intact ("frozen, not deleted-yet"); the two targets do not co-assemble from one graph.

Authored patches carry **declarative parameters** (`rows`, `cols`, `spacing`, `rotationPerIndex`, `huePerTime`); the lowering **synthesizes** the `PlanExpr` trees (`col = mod(index,cols)`, `rotation = index*k + time*k`). Params are canonical; PlanExprs are derived (`[LAW:one-source-of-truth]`). That is the explicit fields/expressions mapping the ticket asks for.

| File | Role |
|---|---|
| `scene/scene-block.ts` | Scene lowering ABI + registry + loud config helpers |
| `scene/blocks/instance-grid.ts` | Generator: params → per-instance index/rank PlanExprs |
| `scene/blocks/draw-instances.ts` | Sink: geometry + material shell + camera + draw |
| `scene/assemble.ts` | Joins draw↔source by primary edge; normalizes ref-keyed resource tables; reconciles camera; deferred-empty solver/post |
| `scene/inputs.ts` | Derives `RenderPlan.inputs` by walking every PlanExpr |
| `scene/compile.ts` | `compileScenePlan` entry — never imports `boundary-contract` |
| `fixtures/grid-of-squares.ts` | First proof patch, authored as graph semantics |

Concept mapping (acceptance criterion 2) is explicit for **materials**, **fields/expressions**, **scene objects** (concrete) and **solver resources** / **fullscreen-post** (explicit deferred-empty tables, per the proof contract).

## Verification

- **18 new scene tests** assert every "Required Compiler Capability": count 100, index/rank intrinsics, derived `time` input channel, rectangle geometry, unlit HSL material, single `previewCanvas` draw, per-instance transform+color, JSON-serializable, empty deferred tables — plus loud-failure paths and source-level backend neutrality (no `boundary-contract`/`three`/`render/wasm` imports).
- `npm run typecheck` clean · `npm run lint` clean · full suite **2124 pass / 0 fail** (+18) · **0 new** dependency-cruiser violations · **`verify:renderer-shell` PASS**.

## Notes for review
- The Grid-of-Squares fixture is deliberately **absent from `PILLAR_FIXTURES`** (that list feeds the frozen GPU-IR compiler-tester, whose registry lacks `InstanceGrid`/`DrawInstances`).
- No app wiring here: `compileScenePlan` has no non-test consumers yet — ulu.5 wires it into `AnimationLoop`/`RuntimeService`.