### PR TITLE
fix(ulu.3): assertNever guards on ScenePlan input-channel consumers

### DIFF
--- a/src/pillars/scene/inputs.ts
+++ b/src/pillars/scene/inputs.ts
@@ -29,6 +29,11 @@ function collectFromExpr(expr: PlanExpr, into: Set<PlanInputChannel>): void {
       collectFromExpr(expr.lhs, into);
       collectFromExpr(expr.rhs, into);
       return;
+    default:
+      // [LAW:types-are-the-program] A new PlanExpr kind is a compile error here
+      //   until handled — it cannot silently fall through and drop an input
+      //   channel from `render.inputs`.
+      return assertNever(expr);
   }
 }
 
@@ -41,7 +46,24 @@ export function colorChannels(color: ColorBinding): readonly PlanExpr[] {
       return [color.r, color.g, color.b];
     case 'rgba':
       return [color.r, color.g, color.b, color.a];
+    default:
+      // [LAW:types-are-the-program] A new color space is a compile error here
+      //   until its channels are enumerated — never an undefined return.
+      return assertNever(color);
   }
+}
+
+/**
+ * Exhaustiveness guard: forces every union consumer above to handle every
+ * member. Mirrors the renderer-side consumers (plan-expr-tsl.ts,
+ * scene-plan-realizer.ts) so the ScenePlan's producer and consumer share the
+ * same total-dispatch discipline.
+ *
+ * [LAW:single-enforcer] Both switches in this module route their unreachable
+ *   arm through this one helper rather than each throwing ad hoc.
+ */
+function assertNever(value: never): never {
+  throw new Error(`[scene] unhandled union member: ${JSON.stringify(value)}`);
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #360, surfaced by an adversarial self-review of the merged ulu.3 lowering.

`src/pillars/scene/inputs.ts` walks every `PlanExpr` to derive `RenderPlan.inputs`. Its two switches — over `PlanExpr.kind` and `ColorBinding.space` — were exhaustive but **unguarded**, and `noImplicitReturns` is off in tsconfig. Consequences if the unions grow:

- a new `PlanExpr.kind` falls through `collectFromExpr` **silently** → a runtime input channel is quietly dropped from `render.inputs`;
- a new `ColorBinding.space` makes `colorChannels` return `undefined` → a downstream crash.

This contradicts the unions' own design promise (`expr.ts`: *"New operators are added to these unions; consumers stay exhaustive"*) and is inconsistent with the **renderer-side** consumers (`plan-expr-tsl.ts`, `scene-plan-realizer.ts`), which already `assertNever`. The compiler-side producer now matches them.

`[LAW:types-are-the-program]` A new union member is now a **compile error at the consumer** until handled — variability the type forces the code to handle, rather than a silent fall-through. `[LAW:single-enforcer]` Both switches route their unreachable arm through one file-local `assertNever` (the codebase's established file-local convention).

## Verification
Two-`default`-arm change. `npm run typecheck` clean · `npm run lint` clean · scene suite 18/18 pass. No behavior change on any valid plan (the guards are unreachable for today's unions).