### PR TITLE
feat(pillars-material .1–.3): Pillar 3 Material foundation — kind, MaterialSpec ABI, DotMaterialBlock

### DIFF
--- a/src/pillars/block-api.ts
+++ b/src/pillars/block-api.ts
@@ -24,8 +24,10 @@ import type {
   GlobalSpec,
   InstanceDomainSpec,
   MemoryManifest,
+  PipelineStateSpec,
   RosterEntry,
   SamplerSpec,
+  StatementIR,
   StaticGeometrySpec,
   TextureSpec,
 } from '../render/rust/boundary-contract';
@@ -95,12 +97,61 @@ export interface LoweredIntent {
 }
 
 /**
+ * A MaterialSpec is the WGSL composition a Material block (Pillar 3) emits:
+ * the vertex/fragment AST a render sink draws with, the optional compute AST
+ * a texture-materialize sink runs, and the data contract (`requiredFields`)
+ * the spec demands of whatever bundle is paired with it.
+ *
+ * It lives here — not in boundary-contract — because it appears in a block's
+ * `lower()` signature (`LoweredMaterial`, `LoweringContext.inputMaterials`),
+ * which is precisely what block-api.ts owns. It is NOT a boundary-crossing
+ * serialized type: `colorVaryingName`, `requiredFields`, and `wgslPreamble`
+ * are TS-only and never reach Rust. The block-dsl `defineMaterialSpec`
+ * constructor imports this type from here (block-dsl → block-api is allowed;
+ * the reverse is not). [LAW:one-way-deps]
+ *
+ * `requiredFields` is the single source of truth for "what fields must the
+ * paired bundle contain" — sinks validate against this list, they do not
+ * hand-check field names. [LAW:single-enforcer]
+ *
+ * Keep the shape minimal; do not add fields without a consumer.
+ * [LAW:no-mode-explosion]
+ */
+export interface MaterialSpec {
+  readonly vertexAst: readonly StatementIR[];
+  readonly fragmentAst: readonly StatementIR[];
+  /** For texture-materialize sinks, which have no vertex/fragment stage. */
+  readonly computeAst?: readonly StatementIR[];
+  readonly requiredFields: readonly string[];
+  /** Name of the color varying passed vertex → fragment. Typically 'color'. */
+  readonly colorVaryingName: string;
+  readonly pipelineState: PipelineStateSpec;
+  /** Optional helper WGSL (e.g. OKLab conversion fns); consumed by a later epic. */
+  readonly wgslPreamble?: string;
+}
+
+/**
+ * Result of lowering a Material block: a MaterialSpec carrying the WGSL
+ * fragments that turn a bundle into a color. A Material is wired into a sink
+ * via a `'material'`-role edge; the walker resolves it into
+ * `LoweringContext.inputMaterials`.
+ *
+ * This is a distinct variant from LoweredBundle because a material carries
+ * WGSL composition, not field expressions — different value, different
+ * behavior. [LAW:one-type-per-behavior]
+ */
+export interface LoweredMaterial {
+  readonly kind: 'material';
+  readonly spec: MaterialSpec;
+}
+
+/**
  * The discriminated union of every possible lowering result. The walker
  * checks `result.kind` to know what to do with the result, but it does
  * NOT use any field to determine what KIND of node produced the result —
  * that information is irrecoverable from the closure.
  */
-export type LoweredBlock = LoweredBundle | LoweredIntent;
+export type LoweredBlock = LoweredBundle | LoweredIntent | LoweredMaterial;
 
 // ---------------------------------------------------------------------------
 // LoweringContext — the only thing the closure receives at lowering time
@@ -119,15 +170,20 @@ export type LoweredBlock = LoweredBundle | LoweredIntent;
  *   - No graph reference (the walker is the only thing that walks the
  *     graph; nodes only see their resolved inputs).
  *
- * The context contains exactly two fields:
- *   - `inputBundles`: bundles resolved from this node's incoming edges,
- *     keyed by inputSlot name. The walker has already done cross-domain
- *     rewriting before populating this.
+ * The context contains:
+ *   - `inputBundles`: bundles resolved from this node's incoming bundle
+ *     edges (primary/secondary), keyed by inputSlot name. The walker has
+ *     already done cross-domain rewriting before populating this.
+ *   - `inputMaterials`: MaterialSpecs resolved from this node's incoming
+ *     material-role edges, keyed by inputSlot name. Kept SEPARATE from
+ *     `inputBundles` because a material and a bundle are different value
+ *     types with different behavior. [LAW:one-type-per-behavior]
  *   - `manifest`: the fully-merged MemoryManifest, frozen at this point
  *     in the pipeline.
  */
 export interface LoweringContext {
   readonly inputBundles: Readonly<Record<string, SourceBundle>>;
+  readonly inputMaterials: Readonly<Record<string, MaterialSpec>>;
   readonly manifest: MemoryManifest;
 }
 

--- a/src/pillars/block-dsl/materials/material-spec.ts
+++ b/src/pillars/block-dsl/materials/material-spec.ts
@@ -1,0 +1,68 @@
+/**
+ * src/pillars/block-dsl/materials/material-spec.ts
+ *
+ * The authoring vocabulary for Material blocks (Pillar 3): the
+ * `defineMaterialSpec` constructor a material block's `lower()` uses to
+ * build the value it returns.
+ *
+ * The MaterialSpec *type* lives in block-api.ts — it is part of the
+ * `lower()` ABI (`LoweredMaterial`, `LoweringContext.inputMaterials`), and
+ * block-api cannot import from block-dsl (dependency-cruiser leaf rule), so
+ * the type cannot live here. This module re-exports it so block authors get
+ * both the type and its constructor from one import. block-dsl → block-api
+ * is the established direction (see `dot-material.ts`, `compute-from-bundle.ts`).
+ * [LAW:one-source-of-truth] one MaterialSpec definition, here re-exported.
+ *
+ * This module is a leaf — it imports only block-api (for the MaterialSpec
+ * type) and the boundary contract (for StatementIR / PipelineStateSpec).
+ *
+ * ## The `computeAst` contract
+ *
+ * A material serves two sink stages from one spec:
+ *   - Render sinks (DrawBundle) consume `vertexAst` + `fragmentAst`. The
+ *     vertex stage produces a `vec4<f32>` color varying named
+ *     `colorVaryingName`; the fragment stage emits it.
+ *   - Texture-materialize sinks (Materialize) consume `computeAst`, which
+ *     has no vertex/fragment stage.
+ *
+ * `computeAst` is a list of statements with a single, consistent shape for
+ * every material: its final statement `let_`-binds `colorVaryingName` to a
+ * `vec4<f32>` value. The texture-materialize pass builder binds the spec's
+ * `requiredFields` from the bundle, runs these statements, then appends a
+ * `TextureStore` that reads `ref(colorVaryingName)`. The material owns how
+ * the color is composed; the sink only stores the named result.
+ * [LAW:single-enforcer] one color seam (`colorVaryingName`) across all stages.
+ */
+
+import type { PipelineStateSpec, StatementIR } from '../../../render/rust/boundary-contract';
+import type { MaterialSpec } from '../../block-api';
+
+export type { MaterialSpec };
+
+/**
+ * Arguments to `defineMaterialSpec`. Identical to MaterialSpec except
+ * `colorVaryingName` is optional and defaults to `'color'` — the single
+ * authoring affordance this constructor adds over an object literal, plus a
+ * one place for future material-construction invariants to live.
+ */
+export interface DefineMaterialSpecArgs {
+  readonly vertexAst: readonly StatementIR[];
+  readonly fragmentAst: readonly StatementIR[];
+  readonly computeAst?: readonly StatementIR[];
+  readonly requiredFields: readonly string[];
+  /** Defaults to 'color'. */
+  readonly colorVaryingName?: string;
+  readonly pipelineState: PipelineStateSpec;
+  readonly wgslPreamble?: string;
+}
+
+/**
+ * Construct a MaterialSpec, defaulting `colorVaryingName` to `'color'`.
+ *
+ * Pure: returns a fresh value per call, no side effects.
+ */
+export function defineMaterialSpec(args: DefineMaterialSpecArgs): MaterialSpec {
+  // Default-first spread: an omitted colorVaryingName falls through to
+  // 'color'; a provided one overrides. No branching. [LAW:dataflow-not-control-flow]
+  return { colorVaryingName: 'color', ...args };
+}

--- a/src/pillars/blocks/dot-material-block.ts
+++ b/src/pillars/blocks/dot-material-block.ts
@@ -1,0 +1,125 @@
+/**
+ * src/pillars/blocks/dot-material-block.ts
+ *
+ * DotMaterial — Material (Pillar 3). The first concrete material block.
+ * Emits the WGSL that turns a particle bundle into a per-instance colored
+ * dot: a vertex/fragment pair for render sinks (DrawBundle) and a compute
+ * body for texture-materialize sinks (Materialize).
+ *
+ * The shader bodies are ported verbatim from the legacy `makeDotMaterial`
+ * helper (block-dsl/materials/dot-material.ts) — the change is structural:
+ * the composition is now a first-class block wired into a sink via a
+ * `'material'`-role edge, not an inline call inside the sink's `lower()`.
+ * [LAW:one-source-of-truth] this block is the sole owner of dot color
+ * composition; sinks forward its fragments and never inline a vec4.
+ *
+ * Materials declare no manifest resources and have no inputs: `lower`
+ * ignores `ctx` and builds the spec from config alone.
+ */
+
+import type { SymbolId } from '../../render/rust/boundary-contract';
+import type {
+  BlockDefinition,
+  Diagnostic,
+  LoweredBlock,
+  LoweringContext,
+  ManifestContribution,
+} from '../block-api';
+import {
+  binop,
+  construct,
+  intrinsic,
+  let_,
+  litF32,
+  loadField,
+  ref,
+  returnFragment,
+  returnVertex,
+  swizzle,
+} from '../../render/gpu-ir/ir-builders';
+import { defineMaterialSpec } from '../block-dsl/materials/material-spec';
+
+interface DotMaterialConfig {
+  readonly domainId: string;
+}
+
+type DotMaterialLowerArgs = DotMaterialConfig;
+
+/**
+ * The fields the dot material reads from the paired bundle. The single
+ * source of truth for "what the bundle must contain"; sinks validate
+ * against this list rather than hand-checking names. [LAW:single-enforcer]
+ */
+const REQUIRED_FIELDS: readonly string[] = [
+  'pos_x',
+  'pos_y',
+  'color_r',
+  'color_g',
+  'color_b',
+];
+
+function readConfig(
+  raw: Readonly<Record<string, unknown>>,
+  diagnostics: Diagnostic[],
+): DotMaterialConfig | null {
+  const domainId = raw.domainId;
+  if (typeof domainId !== 'string') {
+    diagnostics.push({ severity: 'error', message: '[DotMaterial] config.domainId must be a string' });
+    return null;
+  }
+  return { domainId };
+}
+
+function buildManifestContribution(_config: DotMaterialConfig): ManifestContribution {
+  // Materials compose color from fields the upstream generator already
+  // declared; they own no GPU resources of their own.
+  return {};
+}
+
+function lower(args: DotMaterialLowerArgs, _ctx: LoweringContext): LoweredBlock {
+  const fieldSymbol = (name: string): SymbolId => `${args.domainId}:${name}` as SymbolId;
+
+  const spec = defineMaterialSpec({
+    vertexAst: [
+      let_('iid', intrinsic('instance_index')),
+      let_('px', loadField(fieldSymbol('pos_x'), ref('iid'))),
+      let_('py', loadField(fieldSymbol('pos_y'), ref('iid'))),
+      let_('cr', loadField(fieldSymbol('color_r'), ref('iid'))),
+      let_('cg', loadField(fieldSymbol('color_g'), ref('iid'))),
+      let_('cb', loadField(fieldSymbol('color_b'), ref('iid'))),
+      returnVertex(
+        construct('vec4<f32>', [
+          binop('+', swizzle(ref('position'), 'x'), ref('px')),
+          binop('+', swizzle(ref('position'), 'y'), ref('py')),
+          litF32(0),
+          litF32(1),
+        ]),
+        { color: construct('vec4<f32>', [ref('cr'), ref('cg'), ref('cb'), litF32(1)]) },
+      ),
+    ],
+    fragmentAst: [returnFragment({ color: ref('color') })],
+    // computeAst contract (see material-spec.ts): the texture-materialize
+    // pass binds requiredFields from the bundle, then this final statement
+    // let_-binds the color varying to a vec4<f32> the pass stores.
+    computeAst: [
+      let_('color', construct('vec4<f32>', [ref('color_r'), ref('color_g'), ref('color_b'), litF32(1)])),
+    ],
+    requiredFields: REQUIRED_FIELDS,
+    pipelineState: {
+      blendMode: 'opaque',
+      cullMode: 'none',
+      depthWrite: false,
+      depthCompare: 'always',
+    },
+  });
+
+  return { kind: 'material', spec };
+}
+
+export const DotMaterialBlock: BlockDefinition<DotMaterialConfig, DotMaterialLowerArgs> = {
+  type: 'DotMaterial',
+  readConfig,
+  buildManifestContribution,
+  buildLowerArgs: (config) => config,
+  lower,
+};

--- a/src/pillars/blocks/index.ts
+++ b/src/pillars/blocks/index.ts
@@ -12,6 +12,7 @@ import { ExpressionModifierBlock } from './expression-modifier';
 import { DrawBundleBlock } from './draw-bundle';
 import { TextureGridBlock } from './texture-grid';
 import { MaterializeBlock } from './materialize';
+import { DotMaterialBlock } from './dot-material-block';
 
 export const ALL_BLOCKS: readonly BlockDefinition<unknown, unknown>[] = [
   ParticlePoolBlock as BlockDefinition<unknown, unknown>,
@@ -20,4 +21,5 @@ export const ALL_BLOCKS: readonly BlockDefinition<unknown, unknown>[] = [
   DrawBundleBlock as BlockDefinition<unknown, unknown>,
   TextureGridBlock as BlockDefinition<unknown, unknown>,
   MaterializeBlock as BlockDefinition<unknown, unknown>,
+  DotMaterialBlock as BlockDefinition<unknown, unknown>,
 ];

--- a/src/pillars/frontend/normalized-graph.ts
+++ b/src/pillars/frontend/normalized-graph.ts
@@ -19,7 +19,7 @@ export interface NormalizedEdge {
   readonly source: NodeId;
   readonly target: NodeId;
   readonly inputSlot: string;
-  readonly role: 'primary' | 'secondary';
+  readonly role: 'primary' | 'secondary' | 'material';
 }
 
 export interface NormalizedGraph {

--- a/src/pillars/lowering/walker.ts
+++ b/src/pillars/lowering/walker.ts
@@ -54,7 +54,9 @@ export function walkAndLower(graph: NormalizedGraph, manifest: MemoryManifest): 
 
     const { inputBundles, primaryDomainId } = resolveInputBundles(blockId);
 
-    const ctx: LoweringContext = { inputBundles, manifest };
+    // inputMaterials is always present (empty until the walker resolves
+    // material-role edges in a later slice). [LAW:dataflow-not-control-flow]
+    const ctx: LoweringContext = { inputBundles, inputMaterials: {}, manifest };
 
     let result;
     try {
@@ -157,7 +159,9 @@ export function walkAndLower(graph: NormalizedGraph, manifest: MemoryManifest): 
     if ((outDegree.get(node.id) ?? 0) > 0) continue;
 
     const { inputBundles } = resolveInputBundles(node.id);
-    const ctx: LoweringContext = { inputBundles, manifest };
+    // inputMaterials is always present (empty until the walker resolves
+    // material-role edges in a later slice). [LAW:dataflow-not-control-flow]
+    const ctx: LoweringContext = { inputBundles, inputMaterials: {}, manifest };
 
     let result;
     try {

--- a/src/pillars/types.ts
+++ b/src/pillars/types.ts
@@ -6,7 +6,7 @@
  * etc.) live in block-api.ts and the phase directories.
  */
 
-export type PillarKind = 'generator' | 'modifier' | 'intent';
+export type PillarKind = 'generator' | 'modifier' | 'material' | 'intent';
 
 export interface PillarBlock {
   readonly id: string;
@@ -20,7 +20,7 @@ export interface PillarEdge {
   readonly source: string;
   readonly target: string;
   readonly inputSlot: string;
-  readonly role: 'primary' | 'secondary';
+  readonly role: 'primary' | 'secondary' | 'material';
 }
 
 export interface PillarPatch {


### PR DESCRIPTION
## Summary

Behavior-free foundation for **Materials as Pillar 3 first-class blocks** (epic `oscilla-pillars-material-saxf`). Batches the three type-level slices the epic blesses as a single unit (`.1`, `.2`, `.3`). Nothing produces or consumes a material value yet, so all 106 pillar tests pass unchanged and the four fixtures render identically (no visual change to validate).

| Ticket | What |
|---|---|
| `.1` | `material` block kind + `'material'` edge role; `MaterialSpec` + `LoweredMaterial` added to the `lower()` ABI; `LoweringContext.inputMaterials` |
| `.2` | `defineMaterialSpec` constructor + documented `computeAst` contract |
| `.3` | `DotMaterialBlock` — first concrete Material; registered in `ALL_BLOCKS` (6 → 7) |

## Key architectural decision — where `MaterialSpec` lives

The epic sketch placed `MaterialSpec` in `block-dsl/materials/material-spec.ts`. That breaks the build: `block-api.ts` must reference `MaterialSpec` (in `LoweredMaterial` and `LoweringContext.inputMaterials`), but the dependency-cruiser leaf rule `pillars-block-api-is-leaf` forbids `block-api → block-dsl`.

Resolution (`[LAW:one-way-deps]`, `[LAW:one-source-of-truth]`):
- The **type** `MaterialSpec` lives in `block-api.ts` — it's part of the `lower()` signature, exactly what block-api owns (alongside `SourceBundle`, `LoweredBundle`). Not in `boundary-contract` because its `colorVaryingName`/`requiredFields`/`wgslPreamble` fields are TS-only and never cross to Rust.
- The **constructor** `defineMaterialSpec` lives in `block-dsl/`, importing the type from `block-api` — the same direction `dot-material.ts` already imports `SourceBundle`. `block-dsl → block-api` is allowed (the leaf rule forbids only `frontend|lowering|assembly|blocks`); the ticket's "no block-api import" prose is stricter than the enforced rule and conflicts with existing code.

## The `computeAst` contract (decided in `.2`)

One color seam across all sink stages: `computeAst`'s final statement `let_`-binds `colorVaryingName` (default `'color'`) to a `vec4<f32>`. The texture-materialize pass binds `requiredFields` from the bundle, runs the statements, then stores `ref(colorVaryingName)` — mirroring how the vertex path produces a `color` varying. Sinks never inline a vec4. `[LAW:single-enforcer]`

## Verification

- `npx tsc --noEmit` — clean (whole repo).
- `npx vitest run src/pillars/` — 106/106 pass, no count change.
- `depcruise` — no new pillar violations (the one reported error is a pre-existing `gpu-ir ↔ boundary-contract` cycle, untouched here).
- `ALL_BLOCKS` length 6 → 7; registry builds with `DotMaterial`.

## Not in this PR

`.4` walker resolution of material edges, `.5` sink consumption + deletion of legacy `dot-material.ts`, `.6` fixture migration — these introduce behavior and land as separate PRs. Integration coverage for `DotMaterialBlock` arrives with `.4`/`.6`.