### PR TITLE
feat(pillars-material .4): walker resolves material-role edges into inputMaterials

### DIFF
--- a/src/pillars/lowering/__tests__/walk.test.ts
+++ b/src/pillars/lowering/__tests__/walk.test.ts
@@ -13,7 +13,12 @@ import type {
   ComputePassSpec,
   RenderPassSpec,
 } from '../../../render/rust/boundary-contract';
-import type { LoweredBlock, NodeId } from '../../block-api';
+import type {
+  LoweredBlock,
+  LoweringContext,
+  MaterialSpec,
+  NodeId,
+} from '../../block-api';
 import type { NormalizedGraph } from '../../frontend/normalized-graph';
 import { lowerNormalizedGraph } from '../index';
 
@@ -81,6 +86,88 @@ describe('lowering: walker is opaque over node closures', () => {
     const graph: NormalizedGraph = { nodes: [badSink], edges: [] };
     const result = lowerNormalizedGraph(graph);
     expect(result.errors.some((e) => /returned kind 'bundle'/.test(e))).toBe(true);
+  });
+
+  it('resolves a material-role edge into ctx.inputMaterials', () => {
+    const spec: MaterialSpec = {
+      vertexAst: [],
+      fragmentAst: [],
+      requiredFields: ['pos_x', 'pos_y'],
+      colorVaryingName: 'color',
+      pipelineState: {
+        blendMode: 'opaque',
+        cullMode: 'none',
+        depthWrite: false,
+        depthCompare: 'always',
+      },
+    };
+    const materialNode = {
+      id: 'mat' as NodeId,
+      manifestContribution: {},
+      lower: (): LoweredBlock => ({ kind: 'material', spec }),
+    };
+
+    let captured: Readonly<Record<string, MaterialSpec>> | undefined;
+    const sinkNode = {
+      id: 'sink' as NodeId,
+      manifestContribution: {},
+      lower: (ctx: LoweringContext): LoweredBlock => {
+        captured = ctx.inputMaterials;
+        return { kind: 'intent', passes: [] };
+      },
+    };
+
+    const graph: NormalizedGraph = {
+      nodes: [materialNode, sinkNode],
+      edges: [
+        {
+          id: 'e0',
+          source: 'mat' as NodeId,
+          target: 'sink' as NodeId,
+          inputSlot: 'material',
+          role: 'material',
+        },
+      ],
+    };
+
+    const result = lowerNormalizedGraph(graph);
+    expect(result.errors).toEqual([]);
+    expect(captured).toBeDefined();
+    // The exact spec object flows through untouched — no copy, no rewrite.
+    expect(captured?.material).toBe(spec);
+  });
+
+  it('errors when a material-role edge points at a bundle-returning node', () => {
+    const bundleNode = {
+      id: 'gen' as NodeId,
+      manifestContribution: {},
+      lower: (): LoweredBlock => ({ kind: 'bundle', output: {} }),
+    };
+    const sinkNode = {
+      id: 'sink' as NodeId,
+      manifestContribution: {},
+      lower: (): LoweredBlock => ({ kind: 'intent', passes: [] }),
+    };
+
+    const graph: NormalizedGraph = {
+      nodes: [bundleNode, sinkNode],
+      edges: [
+        {
+          id: 'e0',
+          source: 'gen' as NodeId,
+          target: 'sink' as NodeId,
+          inputSlot: 'material',
+          role: 'material',
+        },
+      ],
+    };
+
+    const result = lowerNormalizedGraph(graph);
+    expect(
+      result.errors.some((e) =>
+        /referenced as a material source but lower\(\) returned 'bundle'/.test(e),
+      ),
+    ).toBe(true);
   });
 
   it('does not need any block-* import to compile or run', () => {

--- a/src/pillars/lowering/walker.ts
+++ b/src/pillars/lowering/walker.ts
@@ -10,7 +10,7 @@
  */
 
 import type { MemoryManifest, RosterEntry } from '../../render/rust/boundary-contract';
-import type { LoweringContext, NodeId, SourceBundle } from '../block-api';
+import type { LoweringContext, MaterialSpec, NodeId, SourceBundle } from '../block-api';
 import type { NormalizedGraph, NormalizedEdge, NormalizedNode } from '../frontend/normalized-graph';
 import { rewriteAsLoadFields, validateCardinality } from './cross-domain';
 
@@ -37,6 +37,11 @@ export function walkAndLower(graph: NormalizedGraph, manifest: MemoryManifest): 
   }
 
   const bundleCache = new Map<NodeId, BundleResolution>();
+  // A resolved material is a MaterialSpec, or null when resolution failed
+  // (unknown node, lower() threw, or the node returned a non-material kind).
+  // null is cached so a multi-fanout material reports its error once, and is
+  // distinct from `undefined` (absent) so the cache hit is unambiguous.
+  const materialCache = new Map<NodeId, MaterialSpec | null>();
   const errors: string[] = [];
   const allPasses: RosterEntry[] = [];
 
@@ -53,10 +58,12 @@ export function walkAndLower(graph: NormalizedGraph, manifest: MemoryManifest): 
     }
 
     const { inputBundles, primaryDomainId } = resolveInputBundles(blockId);
+    const inputMaterials = resolveInputMaterials(blockId);
 
-    // inputMaterials is always present (empty until the walker resolves
-    // material-role edges in a later slice). [LAW:dataflow-not-control-flow]
-    const ctx: LoweringContext = { inputBundles, inputMaterials: {}, manifest };
+    // The same two resolutions run for every node; a node with no material
+    // edges simply gets an empty inputMaterials map, not a skipped step.
+    // [LAW:dataflow-not-control-flow]
+    const ctx: LoweringContext = { inputBundles, inputMaterials, manifest };
 
     let result;
     try {
@@ -96,6 +103,9 @@ export function walkAndLower(graph: NormalizedGraph, manifest: MemoryManifest): 
 
     const resolvedBySlot = new Map<string, { edge: NormalizedEdge; resolution: BundleResolution }>();
     for (const edge of incoming) {
+      // Material-role edges live in a separate value space (inputMaterials);
+      // resolveInputMaterials owns them. [LAW:one-type-per-behavior]
+      if (edge.role === 'material') continue;
       if (resolvedBySlot.has(edge.inputSlot)) {
         errors.push(
           `[pillars walker] Block '${targetBlockId}' has multiple edges targeting input slot '${edge.inputSlot}'`,
@@ -154,14 +164,82 @@ export function walkAndLower(graph: NormalizedGraph, manifest: MemoryManifest): 
     return { inputBundles, primaryDomainId };
   }
 
+  /**
+   * Resolve a single material node to its MaterialSpec. Mirrors resolveBundle
+   * but simpler: a Material block has no inputs, so it lowers against an empty
+   * context, and there is no cross-domain rewriting or cardinality validation
+   * (a material has no domain). Returns null and records an error if the node
+   * is unknown, throws, or returns a non-material kind. [LAW:no-silent-failure]
+   */
+  function resolveMaterial(blockId: NodeId): MaterialSpec | null {
+    const cached = materialCache.get(blockId);
+    if (cached !== undefined) return cached;
+
+    const node = nodeById.get(blockId);
+    if (!node) {
+      errors.push(`[pillars walker] Unknown node id: '${blockId}'`);
+      materialCache.set(blockId, null);
+      return null;
+    }
+
+    // Material blocks have no inputs; both maps are empty by contract.
+    const ctx: LoweringContext = { inputBundles: {}, inputMaterials: {}, manifest };
+
+    let result;
+    try {
+      result = node.lower(ctx);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push(
+        `[pillars walker] Material '${blockId}' failed to lower: ${message}`,
+      );
+      materialCache.set(blockId, null);
+      return null;
+    }
+    if (result.kind !== 'material') {
+      errors.push(
+        `[pillars walker] Block '${blockId}' is referenced as a material source but lower() returned '${result.kind}'`,
+      );
+      materialCache.set(blockId, null);
+      return null;
+    }
+
+    materialCache.set(blockId, result.spec);
+    return result.spec;
+  }
+
+  function resolveInputMaterials(targetBlockId: NodeId): Record<string, MaterialSpec> {
+    const incoming = edgesByTarget.get(targetBlockId) ?? [];
+
+    const inputMaterials: Record<string, MaterialSpec> = {};
+    const seenSlots = new Set<string>();
+    for (const edge of incoming) {
+      if (edge.role !== 'material') continue;
+      if (seenSlots.has(edge.inputSlot)) {
+        errors.push(
+          `[pillars walker] Block '${targetBlockId}' has multiple edges targeting material slot '${edge.inputSlot}'`,
+        );
+        continue;
+      }
+      seenSlots.add(edge.inputSlot);
+      const spec = resolveMaterial(edge.source);
+      // null already reported by resolveMaterial; leave the slot unfilled so
+      // the consuming sink surfaces a "missing material" error on its own.
+      if (spec === null) continue;
+      inputMaterials[edge.inputSlot] = spec;
+    }
+    return inputMaterials;
+  }
+
   // Sink set: zero out-degree.
   for (const node of graph.nodes) {
     if ((outDegree.get(node.id) ?? 0) > 0) continue;
 
     const { inputBundles } = resolveInputBundles(node.id);
-    // inputMaterials is always present (empty until the walker resolves
-    // material-role edges in a later slice). [LAW:dataflow-not-control-flow]
-    const ctx: LoweringContext = { inputBundles, inputMaterials: {}, manifest };
+    const inputMaterials = resolveInputMaterials(node.id);
+    // Same resolutions as every other node; an unmaterialed sink gets an
+    // empty inputMaterials map. [LAW:dataflow-not-control-flow]
+    const ctx: LoweringContext = { inputBundles, inputMaterials, manifest };
 
     let result;
     try {


### PR DESCRIPTION
## What

Ticket **oscilla-pillars-material-saxf.4** — fourth slice of the Pillar 3 Material epic, and the **first behavioral change** in it.

The opaque walker now splits a node's incoming edges by role:
- `'primary' | 'secondary'` → existing `resolveBundle` path → `ctx.inputBundles`
- `'material'` → **new** `resolveMaterial()` path → `ctx.inputMaterials`

Both `LoweringContext` construction sites (bundle-node resolution + sink loop) now populate `inputMaterials` uniformly, replacing the placeholder `inputMaterials: {}` literals left in place by `.1`.

## Design notes

- **`resolveMaterial` mirrors `resolveBundle` but simpler.** A Material block has no inputs (lowers against an empty context), no domain (no cross-domain rewriting), and no cardinality validation. Memoized via a dedicated `materialCache` (`MaterialSpec | null`, where `null` caches a failed resolution so multi-fanout reports its error once and is distinct from `undefined`/absent).
- **Material edges are split out of `resolveInputBundles`.** Without this, the existing bundle path would call `resolveBundle` on a material source and spuriously error with "referenced as a bundle but returned 'material'". Bundles and materials are different value types in separate maps. `[LAW:one-type-per-behavior]`
- **Dataflow, not control flow.** Both resolutions run for every node; a node with no material edges just gets an empty map — not a skipped step. `[LAW:dataflow-not-control-flow]`
- **No silent failure.** A material-role edge whose upstream returns a non-material kind (or throws, or is an unknown node) records a hard walker error; the slot is left unfilled so the consuming sink surfaces its own "missing material" error. `[LAW:no-silent-failure]`

## Scope / non-goals

No fixture wires a material edge yet (that's `.6`), and sinks don't yet *consume* materials (that's `.5`). So **all 106 existing pillar tests pass unchanged**; behavior is observable only through the new hand-rolled walker test.

## Tests

`src/pillars/lowering/__tests__/walk.test.ts` gains two tests:
- **positive**: a material-role edge into a sink lands the exact `MaterialSpec` in `ctx.inputMaterials` untouched (identity check — no copy, no rewrite)
- **negative**: a material-role edge from a bundle-returning node produces the expected walker error

## Verification

- `npx tsc --noEmit 2>&1 | grep src/pillars` → clean
- `npx vitest run src/pillars/` → **108 passed** (106 prior + 2 new)
- `depcruise --config .dependency-cruiser.cjs src/pillars/` → no new pillar violations (the one reported error is a pre-existing `render/gpu-ir ↔ render/rust` cycle, untouched by this diff)