### PR TITLE
feat(pillars-material .6): wire DotMaterial into all 4 fixtures — epic complete

### DIFF
--- a/src/pillars/__tests__/compile.test.ts
+++ b/src/pillars/__tests__/compile.test.ts
@@ -612,12 +612,18 @@ describe('pillar compiler: cross-domain-follow fixture', () => {
           config: { expression: 'pos_x = primary.pos_x + a.pos_x\npos_y = primary.pos_y + a.pos_y' } },
         { id: 'sinkB', kind: 'intent', type: 'DrawBundle',
           config: { domainId: 'pool_b', shapeId: 'pool_b_quad', quadScale: 0.018, attachment: loadCanvas() } },
+        // Both sinks require a material; wire one each so compilation reaches
+        // the cardinality check rather than tripping the missing-material guard.
+        { id: 'materialA', kind: 'material', type: 'DotMaterial', config: { domainId: 'pool_a' } },
+        { id: 'materialB', kind: 'material', type: 'DotMaterial', config: { domainId: 'pool_b' } },
       ],
       edges: [
         { id: 'e0', source: 'genA', target: 'sinkA', inputSlot: 'primary', role: 'primary' },
         { id: 'e1', source: 'genB', target: 'modB', inputSlot: 'primary', role: 'primary' },
         { id: 'e2', source: 'genA', target: 'modB', inputSlot: 'a', role: 'secondary' },
         { id: 'e3', source: 'modB', target: 'sinkB', inputSlot: 'primary', role: 'primary' },
+        { id: 'e4', source: 'materialA', target: 'sinkA', inputSlot: 'material', role: 'material' },
+        { id: 'e5', source: 'materialB', target: 'sinkB', inputSlot: 'material', role: 'material' },
       ],
     };
 
@@ -711,7 +717,12 @@ describe('pillar compiler: materialize-uv fixture', () => {
     expect(pass.dependencies.textures['uv_gradient']).toBe('write');
   });
 
-  it('compute pass emits a TextureStore of vec4<f32> targeting the texture', () => {
+  it('compute pass stores the material-composed color varying into the texture', () => {
+    // The material owns color composition: its computeAst let-binds the color
+    // varying ('color') to a vec4<f32>, and the pass stores it by reference.
+    // Asserting that meaning — a vec4 color let-bound by the material, stored
+    // into the texture — rather than an inline Construct at the store site,
+    // which the material epic deliberately removed. [LAW:behavior-not-structure]
     const result = compilePillarPatch(makeMaterializeUvPatch());
     if (result.kind !== 'ok') throw new Error(result.errors.join('; '));
     const pass = result.payload.roster[0];
@@ -719,11 +730,21 @@ describe('pillar compiler: materialize-uv fixture', () => {
 
     const stores = pass.ast.filter((s) => s.type === 'TextureStore');
     expect(stores).toHaveLength(1);
-    const store = stores[0] as { textureId: string; value: { type: string; dataType?: string; args?: unknown[] } };
+    const store = stores[0] as { textureId: string; value: { type: string; name?: string } };
     expect(store.textureId).toBe('uv_gradient');
-    expect(store.value.type).toBe('Construct');
-    expect(store.value.dataType).toBe('vec4<f32>');
-    expect(store.value.args).toHaveLength(4);
+    // The pass never constructs a color itself — it stores the material's
+    // colorVaryingName by reference.
+    expect(store.value.type).toBe('VarRef');
+    expect(store.value.name).toBe('color');
+
+    // The color varying is let-bound to a vec4<f32> composed from the bundle.
+    const colorLet = pass.ast.find(
+      (s) => s.type === 'Let' && (s as { name: string }).name === 'color',
+    ) as { value: { type: string; dataType?: string; args?: unknown[] } } | undefined;
+    expect(colorLet).toBeDefined();
+    expect(colorLet!.value.type).toBe('Construct');
+    expect(colorLet!.value.dataType).toBe('vec4<f32>');
+    expect(colorLet!.value.args).toHaveLength(4);
   });
 
   it("modifier's tint is visible: color_r let-binding contains LiteralF32(0.8)", () => {

--- a/src/pillars/blocks/texture-grid.ts
+++ b/src/pillars/blocks/texture-grid.ts
@@ -7,9 +7,18 @@
  *
  * Bundle fields:
  *   u, v               — normalized texel coordinates in [0, 1]
+ *   pos_x, pos_y       — = u, v (the texel's normalized position)
  *   color_r, color_g   — initial values = u, v (a uv gradient)
  *   color_b            — constant 0
  *   color_a            — constant 1
+ *
+ * pos_x/pos_y exist so a DotMaterial wired into the paired Materialize sink
+ * finds the pos fields its `requiredFields` declare. Materialize reads only
+ * the material's compute color path (color_r/g/b → vec4); the pos fields feed
+ * DotMaterial's vertex path, which a texture-materialize sink never emits.
+ * They are provided rather than weakening the material's contract.
+ * [LAW:single-enforcer] (A TextureMaterial whose requiredFields omits pos is
+ * the clean split; the Material epic scopes it out, so DotMaterial serves both.)
  *
  * The expressions reference `gid_x` and `gid_y` (let-bound at the top
  * of the Materialize compute pass). Like Clock, TextureGrid has no
@@ -81,6 +90,8 @@ function lower(args: TextureGridLowerArgs, _ctx: LoweringContext): LoweredBlock 
   const output: SourceBundle = {
     u,
     v,
+    pos_x: u,
+    pos_y: v,
     color_r: u,
     color_g: v,
     color_b: litF32(0),

--- a/src/pillars/fixtures/clock-driven-wobble.ts
+++ b/src/pillars/fixtures/clock-driven-wobble.ts
@@ -82,6 +82,13 @@ export function makeClockDrivenWobblePatch(): PillarPatch {
           attachment: clearCanvas([0.05, 0.05, 0.07, 1]),
         },
       },
+      // Material (Pillar 3): the dot color composition for this sink.
+      {
+        id: 'material',
+        kind: 'material',
+        type: 'DotMaterial',
+        config: { domainId: 'dots' },
+      },
     ],
     edges: [
       // ParticlePool → ExpressionModifier (primary)
@@ -107,6 +114,14 @@ export function makeClockDrivenWobblePatch(): PillarPatch {
         target: 'sink',
         inputSlot: 'primary',
         role: 'primary',
+      },
+      // DotMaterial → DrawBundle (material)
+      {
+        id: 'e3',
+        source: 'material',
+        target: 'sink',
+        inputSlot: 'material',
+        role: 'material',
       },
     ],
   };

--- a/src/pillars/fixtures/cross-domain-follow.ts
+++ b/src/pillars/fixtures/cross-domain-follow.ts
@@ -126,6 +126,20 @@ export function makeCrossDomainFollowPatch(): PillarPatch {
           attachment: loadCanvas(),
         },
       },
+      // One Material per sink: each composes color over its own domain's
+      // fields. Two sinks → two DotMaterial blocks (pool_a, pool_b).
+      {
+        id: 'materialA',
+        kind: 'material',
+        type: 'DotMaterial',
+        config: { domainId: 'pool_a' },
+      },
+      {
+        id: 'materialB',
+        kind: 'material',
+        type: 'DotMaterial',
+        config: { domainId: 'pool_b' },
+      },
     ],
     edges: [
       // genA → sinkA (primary)
@@ -162,6 +176,22 @@ export function makeCrossDomainFollowPatch(): PillarPatch {
         target: 'sinkB',
         inputSlot: 'primary',
         role: 'primary',
+      },
+      // materialA → sinkA (material)
+      {
+        id: 'e4',
+        source: 'materialA',
+        target: 'sinkA',
+        inputSlot: 'material',
+        role: 'material',
+      },
+      // materialB → sinkB (material)
+      {
+        id: 'e5',
+        source: 'materialB',
+        target: 'sinkB',
+        inputSlot: 'material',
+        role: 'material',
       },
     ],
   };

--- a/src/pillars/fixtures/materialize-uv.ts
+++ b/src/pillars/fixtures/materialize-uv.ts
@@ -55,10 +55,20 @@ export function makeMaterializeUvPatch(): PillarPatch {
           format: 'rgba8unorm',
         },
       },
+      // Material (Pillar 3): Materialize reads only its computeAst (the
+      // vec4 color path). domainId feeds the vertex path, which a
+      // texture-materialize sink never emits — inert here.
+      {
+        id: 'material',
+        kind: 'material',
+        type: 'DotMaterial',
+        config: { domainId: 'uv_gradient' },
+      },
     ],
     edges: [
       { id: 'e0', source: 'grid', target: 'tint', inputSlot: 'primary', role: 'primary' },
       { id: 'e1', source: 'tint', target: 'sink', inputSlot: 'primary', role: 'primary' },
+      { id: 'e2', source: 'material', target: 'sink', inputSlot: 'material', role: 'material' },
     ],
   };
 }

--- a/src/pillars/fixtures/orbit-ring.ts
+++ b/src/pillars/fixtures/orbit-ring.ts
@@ -65,6 +65,14 @@ export function makeOrbitRingPatch(): PillarPatch {
           attachment: clearCanvas([0.05, 0.05, 0.07, 1]),
         },
       },
+      // Material (Pillar 3): owns the dot's color composition. The sink reads
+      // it from its 'material' slot — color is no longer inlined in the sink.
+      {
+        id: 'material',
+        kind: 'material',
+        type: 'DotMaterial',
+        config: { domainId: 'dots' },
+      },
     ],
     edges: [
       {
@@ -80,6 +88,13 @@ export function makeOrbitRingPatch(): PillarPatch {
         target: 'sink',
         inputSlot: 'primary',
         role: 'primary',
+      },
+      {
+        id: 'e2',
+        source: 'material',
+        target: 'sink',
+        inputSlot: 'material',
+        role: 'material',
       },
     ],
   };


### PR DESCRIPTION
## Ticket
`oscilla-pillars-material-saxf.6` — final slice of the **Materials as Pillar 3 First-Class Blocks** epic.

## What this does
As of `.5`, `DrawBundle` and `Materialize` require a `material` input (via `consumeMaterial`), but no fixture wired one — leaving 36 fixture tests red with the intentional `requires a 'material' input` symptom. This slice satisfies that dependency: every fixture gains a `DotMaterial` block and a `'material'`-role edge into its sink.

- **orbit-ring**, **clock-driven-wobble**: one `DotMaterial` (`domainId: 'dots'`) per sink.
- **cross-domain-follow**: TWO `DotMaterial` blocks (`pool_a`, `pool_b`), one per sink.
- **materialize-uv**: `DotMaterial` wired to `Materialize` (only its `computeAst` path is read).
- **compile.test.ts**: the inline two-`DrawBundle` cardinality patch gets two materials so compilation reaches the cardinality check instead of tripping the missing-material guard; the materialize-uv `TextureStore` assertion is updated to the new behavior — the material let-binds the `color` varying and the pass stores it by reference (no inline `Construct` at the store site). `[LAW:behavior-not-structure]`

## Gotcha resolved (flagged for reviewer)
`DotMaterial.requiredFields` includes `pos_x`/`pos_y`, and `consumeMaterial` validates the **whole** list against the sink's primary bundle — for **both** sinks. The materialize-uv bundle lacked `pos_x`/`pos_y`. The `ExpressionModifier` can only overwrite **existing** fields, so the pos fields must originate in the generator. **`TextureGrid`** (used only by this fixture, purpose-built to pair with `Materialize`) now emits `pos_x`/`pos_y` from the texel coordinates. Materialize reads only the color compute path; the pos fields feed DotMaterial's vertex path, which a texture sink never emits. Provided rather than weakening `requiredFields`. `[LAW:single-enforcer]`

The clean long-term fix — a `TextureMaterial` whose `requiredFields` omits `pos_x`/`pos_y` — is **explicitly scoped out** of this epic (decision log + "What is NOT in this epic").

## Verification
- `npx vitest run src/pillars/` → **108 pass** (37 in compile.test.ts, up from all-red).
- `tsc -b` → clean.
- `depcruise src/pillars/` → only the pre-existing `render/gpu-ir ↔ render/rust` cycle; no new pillar violations.
- Grep gates empty: `makeDotMaterial`, `validateBundleForDotMaterial`, hardcoded color in `pass-builders/`. `dot-material.ts` deleted.
- Visual regression (compiler-tester, real WebGPU): orbit-ring (red-suppressed ring), clock-driven-wobble (full rainbow ring), cross-domain-follow (two pools), materialize-uv (blank canvas) — all render as documented. Screenshots read back and confirmed.

After this: sinks have zero knowledge of how color is composed — they forward the bound material's WGSL fragments. **Epic complete.**