### PR TITLE
feat(pillars-types wzm3.1): Zod schema layer for the pillar type system

### DIFF
--- a/src/pillars/types/__tests__/schemas.test.ts
+++ b/src/pillars/types/__tests__/schemas.test.ts
@@ -1,0 +1,122 @@
+/**
+ * src/pillars/types/__tests__/schemas.test.ts
+ *
+ * The schema layer's load-bearing property is the concrete/inference split:
+ * a fully-instantiated `ZCanonicalType` must be incapable of holding a type
+ * variable, while its inference counterpart must accept one. These tests pin
+ * that boundary at runtime — the compile-time half is enforced by the types
+ * themselves. [LAW:types-are-the-program]
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ZCanonicalTypeSchema,
+  ZInferenceCanonicalTypeSchema,
+  ZBundleTypeSchema,
+  ZInferenceBundleTypeSchema,
+  zFloat,
+  zColor,
+  oneExtent,
+  manyExtent,
+  payloadVar,
+  cardinalityVar,
+  instanceRef,
+  type ZCanonicalType,
+  type ZInferenceCanonicalType,
+} from '../schemas';
+
+describe('ZCanonicalType — concrete types', () => {
+  it('round-trips a scalar float through JSON then re-parses', () => {
+    const value: ZCanonicalType = {
+      payload: { kind: 'float' },
+      unit: { kind: 'none' },
+      extent: oneExtent(),
+    };
+    const reparsed = ZCanonicalTypeSchema.safeParse(JSON.parse(JSON.stringify(value)));
+    expect(reparsed.success).toBe(true);
+    expect(reparsed).toMatchObject({ success: true });
+    expect(reparsed.success && reparsed.data).toEqual(value);
+  });
+
+  it('round-trips a per-instance color through JSON then re-parses', () => {
+    const value: ZCanonicalType = {
+      payload: { kind: 'color' },
+      unit: { kind: 'color', unit: 'rgba01' },
+      extent: manyExtent(instanceRef('particles'), 1024),
+    };
+    const reparsed = ZCanonicalTypeSchema.safeParse(JSON.parse(JSON.stringify(value)));
+    expect(reparsed.success).toBe(true);
+    expect(reparsed.success && reparsed.data).toEqual(value);
+  });
+
+  it('rejects a structured unit with a wrong enum member', () => {
+    const bad = {
+      payload: { kind: 'float' },
+      unit: { kind: 'angle', unit: 'gradians' },
+      extent: oneExtent(),
+    };
+    expect(ZCanonicalTypeSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+describe('concrete vs inference — the variable boundary', () => {
+  it('a payload variable FAILS concrete parse but PASSES inference parse', () => {
+    const withVar = {
+      payload: payloadVar('a'),
+      unit: { kind: 'none' },
+      extent: oneExtent(),
+    };
+    expect(ZCanonicalTypeSchema.safeParse(withVar).success).toBe(false);
+    expect(ZInferenceCanonicalTypeSchema.safeParse(withVar).success).toBe(true);
+  });
+
+  it('a cardinality variable FAILS concrete parse but PASSES inference parse', () => {
+    const withVar: ZInferenceCanonicalType = {
+      payload: { kind: 'float' },
+      unit: { kind: 'none' },
+      extent: { ...oneExtent(), cardinality: cardinalityVar('n') },
+    };
+    expect(ZCanonicalTypeSchema.safeParse(withVar).success).toBe(false);
+    expect(ZInferenceCanonicalTypeSchema.safeParse(withVar).success).toBe(true);
+  });
+
+  it('every concrete type is also a valid inference type', () => {
+    const concrete = zFloat();
+    // zFloat returns an inference type, but its value carries no variables, so
+    // it parses as concrete too — concrete ⊆ inference.
+    expect(ZCanonicalTypeSchema.safeParse(concrete).success).toBe(true);
+    expect(ZInferenceCanonicalTypeSchema.safeParse(concrete).success).toBe(true);
+  });
+});
+
+describe('constructors', () => {
+  it('zColor defaults to the rgba01 color unit', () => {
+    expect(zColor().unit).toEqual({ kind: 'color', unit: 'rgba01' });
+  });
+
+  it('manyExtent omits capacity when not supplied', () => {
+    expect(manyExtent(instanceRef('p')).cardinality).toEqual({
+      kind: 'many',
+      instance: 'p',
+    });
+  });
+
+  it('canonical opts override unit and extent', () => {
+    const t = zFloat({ unit: { kind: 'angle', unit: 'radians' } });
+    expect(t.unit).toEqual({ kind: 'angle', unit: 'radians' });
+  });
+});
+
+describe('ZBundleType', () => {
+  it('round-trips a concrete bundle and rejects a variable-bearing field', () => {
+    const bundle = {
+      position: { payload: { kind: 'vec2' }, unit: { kind: 'none' }, extent: oneExtent() },
+      angle: { payload: { kind: 'float' }, unit: { kind: 'angle', unit: 'radians' }, extent: oneExtent() },
+    };
+    expect(ZBundleTypeSchema.safeParse(JSON.parse(JSON.stringify(bundle))).success).toBe(true);
+
+    const withVar = { ...bundle, free: { payload: payloadVar('a'), unit: { kind: 'none' }, extent: oneExtent() } };
+    expect(ZBundleTypeSchema.safeParse(withVar).success).toBe(false);
+    expect(ZInferenceBundleTypeSchema.safeParse(withVar).success).toBe(true);
+  });
+});

--- a/src/pillars/types/graph.ts
+++ b/src/pillars/types/graph.ts
@@ -1,5 +1,5 @@
 /**
- * src/pillars/types.ts
+ * src/pillars/types/graph.ts
  *
  * The user-authored graph type. PillarPatch is the input to the frontend.
  * Compiler-internal types (NormalizedGraph, LoweringContext, BlockDefinition,

--- a/src/pillars/types/index.ts
+++ b/src/pillars/types/index.ts
@@ -1,0 +1,12 @@
+/**
+ * src/pillars/types/index.ts
+ *
+ * The pillar type module. There is exactly one `@/pillars/types` so a file and
+ * a same-named directory can never shadow each other. [LAW:one-source-of-truth]
+ *
+ *   - `graph`   — the user-authored PillarPatch graph (frontend input).
+ *   - `schemas` — the Zod type-system layer every compiler type is expressed in.
+ */
+
+export * from './graph';
+export * from './schemas';

--- a/src/pillars/types/schemas.ts
+++ b/src/pillars/types/schemas.ts
@@ -1,0 +1,313 @@
+/**
+ * src/pillars/types/schemas.ts
+ *
+ * The data-model foundation of the pillar compiler's type system: every type a
+ * port can declare, expressed as a Zod schema so the runtime validator, the
+ * JSON round-trip, and the TypeScript type are one artifact rather than three
+ * that drift. [LAW:one-source-of-truth]
+ *
+ * This file imports ONLY zod. Semantics — unification, substitution, the
+ * fixpoint resolver, validateAxes — are deliberately absent; they live in
+ * sibling children that import these schemas. The schema layer knows the
+ * *shape* of a type, never how to solve one. [LAW:decomposition]
+ *
+ * Two separations the schemas enforce mechanically, not by convention:
+ *
+ *   1. Z-prefix. Every exported type is `Z…`, so a search for the Z-prefixed
+ *      name finds only this system and the bare V1 name finds only V1. The two
+ *      type systems cannot be confused at a callsite, and a forbidden-pattern
+ *      test can police the boundary.
+ *
+ *   2. Concrete vs inference. `ZCanonicalType` cannot hold a type variable —
+ *      its schema has no `{kind:'var'}` member, so a variable-bearing value
+ *      fails `ZCanonicalTypeSchema.parse` at runtime AND is unassignable to a
+ *      `ZCanonicalType` parameter at compile time. A consumer needing a
+ *      fully-resolved type declares `ZCanonicalType` and is structurally
+ *      incapable of receiving a variable. The only inference→concrete bridge
+ *      is one `ZCanonicalTypeSchema.safeParse` (landed by the resolver child),
+ *      never a `kind === 'inst'` check scattered across callsites.
+ *      [LAW:types-are-the-program]
+ */
+
+import { z } from 'zod';
+
+/**
+ * Retains the precise tuple type of its arguments. `z.discriminatedUnion`
+ * requires a non-empty tuple `[A, ...A[]]`, but a bare array literal infers as
+ * `A[]` and loses that shape. Routing shared member lists through this identity
+ * lets the concrete and inference unions be built from one list while still
+ * satisfying Zod's tuple constraint. [LAW:one-source-of-truth]
+ */
+const members = <T extends readonly [unknown, ...unknown[]]>(...m: T): T => m;
+
+// ---------------------------------------------------------------------------
+// Branded variable identities
+// ---------------------------------------------------------------------------
+
+/**
+ * A type variable's identity is a string at runtime, but a PayloadVarId must
+ * never be accepted where a UnitVarId is expected. Branding makes the three
+ * variable spaces — and InstanceRef, the identity of a `many` cardinality's
+ * lane set — mutually unassignable with zero runtime cost. [LAW:types-are-the-program]
+ */
+export const PayloadVarIdSchema = z.string().brand<'PayloadVarId'>();
+export type PayloadVarId = z.infer<typeof PayloadVarIdSchema>;
+export const payloadVarId = (s: string): PayloadVarId => PayloadVarIdSchema.parse(s);
+
+export const UnitVarIdSchema = z.string().brand<'UnitVarId'>();
+export type UnitVarId = z.infer<typeof UnitVarIdSchema>;
+export const unitVarId = (s: string): UnitVarId => UnitVarIdSchema.parse(s);
+
+export const CardinalityVarIdSchema = z.string().brand<'CardinalityVarId'>();
+export type CardinalityVarId = z.infer<typeof CardinalityVarIdSchema>;
+export const cardinalityVarId = (s: string): CardinalityVarId => CardinalityVarIdSchema.parse(s);
+
+export const InstanceRefSchema = z.string().brand<'InstanceRef'>();
+export type InstanceRef = z.infer<typeof InstanceRefSchema>;
+export const instanceRef = (s: string): InstanceRef => InstanceRefSchema.parse(s);
+
+// ---------------------------------------------------------------------------
+// Payload — what a value IS
+// ---------------------------------------------------------------------------
+
+/**
+ * The concrete payload members. `material` already exists in the pillar block
+ * ABI from the materials work; `cameraProjection | shape2d | shape3d` are
+ * added by a later child. The members are a shared constant so the concrete
+ * and inference unions are built from one list — adding a payload kind touches
+ * exactly one place. [LAW:one-source-of-truth]
+ */
+const PAYLOAD_MEMBERS = members(
+  z.object({ kind: z.literal('float') }),
+  z.object({ kind: z.literal('int') }),
+  z.object({ kind: z.literal('bool') }),
+  z.object({ kind: z.literal('vec2') }),
+  z.object({ kind: z.literal('vec3') }),
+  z.object({ kind: z.literal('color') }),
+  z.object({ kind: z.literal('material') }),
+);
+
+export const ZPayloadTypeSchema = z.discriminatedUnion('kind', PAYLOAD_MEMBERS);
+export type ZPayloadType = z.infer<typeof ZPayloadTypeSchema>;
+
+export const ZInferencePayloadTypeSchema = z.discriminatedUnion('kind', [
+  ...PAYLOAD_MEMBERS,
+  z.object({ kind: z.literal('var'), var: PayloadVarIdSchema }),
+]);
+export type ZInferencePayloadType = z.infer<typeof ZInferencePayloadTypeSchema>;
+
+// ---------------------------------------------------------------------------
+// Unit — what a value MEANS dimensionally
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured units. `color` carries `rgba01` today; the OKLab epic adds
+ * `oklch`. Unit and payload both have a `color` kind — they are independent
+ * unions, so a `color` payload and a `color` unit never collide.
+ */
+const UNIT_MEMBERS = members(
+  z.object({ kind: z.literal('none') }),
+  z.object({ kind: z.literal('count') }),
+  z.object({ kind: z.literal('angle'), unit: z.enum(['radians', 'degrees', 'phase01']) }),
+  z.object({ kind: z.literal('time'), unit: z.enum(['ms', 'seconds']) }),
+  z.object({
+    kind: z.literal('space'),
+    space: z.enum(['ndc', 'world', 'view']),
+    dims: z.union([z.literal(2), z.literal(3)]),
+  }),
+  z.object({ kind: z.literal('color'), unit: z.enum(['rgba01']) }),
+);
+
+export const ZUnitTypeSchema = z.discriminatedUnion('kind', UNIT_MEMBERS);
+export type ZUnitType = z.infer<typeof ZUnitTypeSchema>;
+
+export const ZInferenceUnitTypeSchema = z.discriminatedUnion('kind', [
+  ...UNIT_MEMBERS,
+  z.object({ kind: z.literal('var'), var: UnitVarIdSchema }),
+]);
+export type ZInferenceUnitType = z.infer<typeof ZInferenceUnitTypeSchema>;
+
+// ---------------------------------------------------------------------------
+// Extent — the five axes describing a value's shape in space, time, and branch
+// ---------------------------------------------------------------------------
+
+/**
+ * Cardinality: how many lanes. `zero` is compile-time-only (no runtime lanes,
+ * NOT a synonym for scalar — scalar is `one`); `many` aligns its lanes by an
+ * InstanceRef and may declare a pool `capacity`. It is the one extent axis the
+ * solver unifies, so it is the one axis with a variable form.
+ */
+const CARDINALITY_MEMBERS = members(
+  z.object({ kind: z.literal('zero') }),
+  z.object({ kind: z.literal('one') }),
+  z.object({
+    kind: z.literal('many'),
+    instance: InstanceRefSchema,
+    capacity: z.number().int().positive().optional(),
+  }),
+);
+
+export const ZCardinalitySchema = z.discriminatedUnion('kind', CARDINALITY_MEMBERS);
+export type ZCardinality = z.infer<typeof ZCardinalitySchema>;
+
+export const ZInferenceCardinalitySchema = z.discriminatedUnion('kind', [
+  ...CARDINALITY_MEMBERS,
+  z.object({ kind: z.literal('var'), var: CardinalityVarIdSchema }),
+]);
+export type ZInferenceCardinality = z.infer<typeof ZInferenceCardinalitySchema>;
+
+/**
+ * Temporality: when a value exists. `discrete` carries event semantics whose
+ * hard invariants (payload=bool, unit=none) are enforced by `validateAxes` in
+ * a later child, not encoded here — the schema layer admits the shape; the
+ * gate decides legality. There is no temporality variable: the solver derives
+ * temporality, it does not unify it.
+ */
+export const ZTemporalitySchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('continuous') }),
+  z.object({ kind: z.literal('discrete') }),
+]);
+export type ZTemporality = z.infer<typeof ZTemporalitySchema>;
+
+/**
+ * Binding, perspective, and branch are default-only for now: each admits
+ * exactly its default value and nothing else. There is no variable form and no
+ * second value to represent — adding either is a deliberate future change with
+ * a consumer, not speculative surface. [LAW:no-mode-explosion]
+ */
+export const ZBindingSchema = z.object({ kind: z.literal('unbound') });
+export type ZBinding = z.infer<typeof ZBindingSchema>;
+
+export const ZPerspectiveSchema = z.object({ kind: z.literal('default') });
+export type ZPerspective = z.infer<typeof ZPerspectiveSchema>;
+
+export const ZBranchSchema = z.object({ kind: z.literal('default') });
+export type ZBranch = z.infer<typeof ZBranchSchema>;
+
+export const ZExtentSchema = z.object({
+  cardinality: ZCardinalitySchema,
+  temporality: ZTemporalitySchema,
+  binding: ZBindingSchema,
+  perspective: ZPerspectiveSchema,
+  branch: ZBranchSchema,
+});
+export type ZExtent = z.infer<typeof ZExtentSchema>;
+
+/**
+ * The inference extent differs from the concrete one in exactly one axis —
+ * cardinality may be a variable. The other four axes are identical, so a
+ * concrete `ZExtent` is structurally assignable to a `ZInferenceExtent`.
+ */
+export const ZInferenceExtentSchema = z.object({
+  cardinality: ZInferenceCardinalitySchema,
+  temporality: ZTemporalitySchema,
+  binding: ZBindingSchema,
+  perspective: ZPerspectiveSchema,
+  branch: ZBranchSchema,
+});
+export type ZInferenceExtent = z.infer<typeof ZInferenceExtentSchema>;
+
+// ---------------------------------------------------------------------------
+// ZCanonicalType — payload + unit + extent
+// ---------------------------------------------------------------------------
+
+/**
+ * The single type authority. A `ZCanonicalType` is fully instantiated: because
+ * none of its three components admit a `{kind:'var'}` member, a variable-bearing
+ * value cannot be parsed into one and cannot be assigned to one. [LAW:one-source-of-truth]
+ */
+export const ZCanonicalTypeSchema = z.object({
+  payload: ZPayloadTypeSchema,
+  unit: ZUnitTypeSchema,
+  extent: ZExtentSchema,
+});
+export type ZCanonicalType = z.infer<typeof ZCanonicalTypeSchema>;
+
+export const ZInferenceCanonicalTypeSchema = z.object({
+  payload: ZInferencePayloadTypeSchema,
+  unit: ZInferenceUnitTypeSchema,
+  extent: ZInferenceExtentSchema,
+});
+export type ZInferenceCanonicalType = z.infer<typeof ZInferenceCanonicalTypeSchema>;
+
+// ---------------------------------------------------------------------------
+// Bundle — a named collection of typed values (a port's or block's field set)
+// ---------------------------------------------------------------------------
+
+export const ZBundleTypeSchema = z.record(z.string(), ZCanonicalTypeSchema);
+export type ZBundleType = z.infer<typeof ZBundleTypeSchema>;
+
+export const ZInferenceBundleTypeSchema = z.record(z.string(), ZInferenceCanonicalTypeSchema);
+export type ZInferenceBundleType = z.infer<typeof ZInferenceBundleTypeSchema>;
+
+// ---------------------------------------------------------------------------
+// Constructors — produce inference types ergonomically
+// ---------------------------------------------------------------------------
+
+export interface CanonicalOpts {
+  readonly unit?: ZInferenceUnitType;
+  readonly extent?: ZInferenceExtent;
+}
+
+/**
+ * The single canonical-type constructor. Payload is the value that varies;
+ * unit and extent default to dimensionless and scalar. `zFloat`/`zVec2`/etc.
+ * are sugar over this one function — same behavior, different payload — rather
+ * than separate implementations. [LAW:one-type-per-behavior]
+ */
+export const canonical = (
+  payload: ZInferencePayloadType,
+  opts: CanonicalOpts = {},
+): ZInferenceCanonicalType => ({
+  payload,
+  unit: opts.unit ?? { kind: 'none' },
+  extent: opts.extent ?? oneExtent(),
+});
+
+export const zFloat = (opts?: CanonicalOpts): ZInferenceCanonicalType =>
+  canonical({ kind: 'float' }, opts);
+
+export const zVec2 = (opts?: CanonicalOpts): ZInferenceCanonicalType =>
+  canonical({ kind: 'vec2' }, opts);
+
+export const zVec3 = (opts?: CanonicalOpts): ZInferenceCanonicalType =>
+  canonical({ kind: 'vec3' }, opts);
+
+/** A color value's natural unit is rgba01; callers may override via opts. */
+export const zColor = (opts?: CanonicalOpts): ZInferenceCanonicalType =>
+  canonical({ kind: 'color' }, { unit: { kind: 'color', unit: 'rgba01' }, ...opts });
+
+// --- Extent constructors ---------------------------------------------------
+
+export const oneExtent = (): ZExtent => ({
+  cardinality: { kind: 'one' },
+  temporality: { kind: 'continuous' },
+  binding: { kind: 'unbound' },
+  perspective: { kind: 'default' },
+  branch: { kind: 'default' },
+});
+
+export const manyExtent = (instance: InstanceRef, capacity?: number): ZExtent => ({
+  ...oneExtent(),
+  cardinality:
+    capacity === undefined
+      ? { kind: 'many', instance }
+      : { kind: 'many', instance, capacity },
+});
+
+// --- Variable constructors -------------------------------------------------
+
+export const payloadVar = (name: string): ZInferencePayloadType => ({
+  kind: 'var',
+  var: payloadVarId(name),
+});
+
+export const unitVar = (name: string): ZInferenceUnitType => ({
+  kind: 'var',
+  var: unitVarId(name),
+});
+
+export const cardinalityVar = (name: string): ZInferenceCardinality => ({
+  kind: 'var',
+  var: cardinalityVarId(name),
+});


### PR DESCRIPTION
## What

First child of epic **oscilla-pillars-types-wzm3** (Foundation: Pillar Compiler Type System). The data-model foundation every other child builds on — all Zod schemas, branded variable IDs, and ergonomic constructors. No behavioral code (unification, resolver, validateAxes land in later children).

New leaf module `src/pillars/types/` (imports only `zod`):

- **Branded var IDs**: `PayloadVarId`, `UnitVarId`, `CardinalityVarId`, `InstanceRef` + constructors
- **`ZPayloadType`**: `float | int | bool | vec2 | vec3 | color | material`
- **`ZUnitType`**: `none | count | angle | time | space | color`
- **`ZExtent`**: `cardinality | temporality | binding | perspective | branch` (binding/perspective/branch default-only for now)
- **`ZCanonicalType`** (no variables representable) + **`ZInferenceCanonicalType`** (payload/unit/cardinality may be `{kind:'var'}`)
- **`ZBundleType`** / **`ZInferenceBundleType`**
- **Constructors**: `canonical`, `zFloat`/`zVec2`/`zVec3`/`zColor`, `oneExtent`/`manyExtent`, `payloadVar`/`unitVar`/`cardinalityVar`

## Key design points

- **Concrete vs inference split is mechanical** — `ZCanonicalTypeSchema` has no `{kind:'var'}` member, so a variable-bearing value fails `parse` at runtime *and* is unassignable to a `ZCanonicalType` parameter at compile time. The only inference→concrete bridge is a single `safeParse`. [LAW:types-are-the-program]
- **One `@/pillars/types`** — the existing `src/pillars/types.ts` (PillarPatch graph types) is folded into the directory as `graph.ts` and re-exported from the barrel, so a `.ts` file can never shadow the same-named directory. All existing `../types` importers keep resolving. [LAW:one-source-of-truth]
- **One canonical constructor** — `zFloat`/`zVec2`/etc. are sugar over `canonical(payload, opts)`; payload is the value that varies. [LAW:one-type-per-behavior]
- **Shared member lists** — concrete and inference unions are built from one member array (via a tuple-preserving helper), so adding a payload/unit kind touches one place.

## Verification

- `npx tsc --noEmit` — clean (whole project)
- `npx eslint src/pillars/types/` — clean
- `depcruise src/pillars/types/` — no violations (clean leaf)
- `npx vitest run src/pillars/` — 118/118 pass (10 new schema tests)
- Grep gates: `ZCanonicalType`/`ZBundleType` populated; only Z-prefixed `CanonicalType` uses; no imports from `compiler/frontend`
- Test proves: concrete type round-trips JSON→safeParse; a `{kind:'var'}` value FAILS concrete parse but PASSES inference parse