### PR TITLE
feat(pillars-types wzm3.2): port bindings + ZBlockContract + defineBlock (end-to-end TS inference)

### DIFF
--- a/src/pillars/block-api.ts
+++ b/src/pillars/block-api.ts
@@ -15,7 +15,11 @@
  *
  * dependency-cruiser rule: src/pillars/block-api.ts must not import from
  * any phase directory. See `.dependency-cruiser.cjs` for the enforcement.
+ * The schema layer (`./types/schemas`) is the one exception — it is a leaf
+ * the ABI is allowed to build on, one-way. [LAW:one-way-deps]
  */
+
+import { z } from 'zod';
 
 import type {
   ArenaScalarSpec,
@@ -31,6 +35,13 @@ import type {
   StaticGeometrySpec,
   TextureSpec,
 } from '../render/rust/boundary-contract';
+import type {
+  ZBlockContract,
+  ZCombineMode,
+  ZInferenceBundleType,
+  ZInferenceCanonicalType,
+  ZPortBinding,
+} from './types/schemas';
 
 // ---------------------------------------------------------------------------
 // NodeId — opaque brand for nodes in the NormalizedGraph
@@ -267,6 +278,16 @@ export interface BlockDefinition<TConfig, TLowerArgs> {
   readonly type: string;
 
   /**
+   * The block's type surface: input/output ports with their declared bundle
+   * types. Optional in this child because not every block has been migrated to
+   * declare one yet; it becomes mandatory once the block-migration child lands.
+   * Blocks built via `defineBlock` always carry one. The frontend type solver,
+   * the validate gate, and the insert-menu query read this — never the block
+   * body. [LAW:locality-or-seam]
+   */
+  readonly contract?: ZBlockContract;
+
+  /**
    * FRONTEND-ONLY. Validates and narrows raw user-supplied config.
    *
    * Contract:
@@ -321,4 +342,122 @@ export interface BlockDefinition<TConfig, TLowerArgs> {
    * the walker calls without ever seeing what's inside.
    */
   readonly lower: (args: TLowerArgs, ctx: LoweringContext) => LoweredBlock;
+}
+
+// ---------------------------------------------------------------------------
+// defineBlock — the authoring helper with end-to-end TypeScript inference
+// ---------------------------------------------------------------------------
+
+/**
+ * The author-facing shape of one input port: the bundle of fields it carries
+ * and (optionally) how multiple incoming edges combine. Direction and the
+ * port's stable id are NOT written by the author — `defineBlock` derives `dir`
+ * from whether the port sits under `inputs` or `outputs`, and sets `id` to the
+ * slot key. The author states each fact once. [LAW:one-source-of-truth]
+ */
+type InputPortDecl = {
+  readonly type: ZInferenceBundleType;
+  readonly combine?: ZCombineMode;
+};
+
+type OutputPortDecl = {
+  readonly type: ZInferenceBundleType;
+};
+
+/**
+ * Maps a declared input-port set to the precisely-typed `inputBundles` the
+ * block's `lower` sees. Each slot becomes a record whose keys are EXACTLY the
+ * fields that slot's bundle declared (no index signature), so reading a
+ * declared field yields its runtime `ExprIR` and reading an undeclared field is
+ * a compile error. This is what turns the contract into a compile-time spec
+ * rather than a runtime hope. [LAW:types-are-the-program]
+ */
+type InferBundles<TInputs> = {
+  readonly [Slot in keyof TInputs]: TInputs[Slot] extends { readonly type: infer Bundle }
+    ? { readonly [Field in keyof Bundle]: ExprIR }
+    : never;
+};
+
+/**
+ * The `LoweringContext` a `defineBlock` block sees, with the wide
+ * `Record<string, SourceBundle>` inputBundles REPLACED (not intersected) by the
+ * precise per-slot view. Intersecting would re-admit arbitrary keys through the
+ * record's index signature and defeat the field-level checking, so the wide
+ * member is omitted first. [LAW:types-are-the-program]
+ */
+type TypedLoweringContext<TInputs> = Omit<LoweringContext, 'inputBundles'> & {
+  readonly inputBundles: InferBundles<TInputs>;
+};
+
+const toBindings = (
+  decls: Readonly<Record<string, InputPortDecl>>,
+  dir: 'in' | 'out',
+): Record<string, ZPortBinding> => {
+  const out: Record<string, ZPortBinding> = {};
+  for (const [slot, decl] of Object.entries(decls)) {
+    out[slot] =
+      decl.combine === undefined
+        ? { id: slot, dir, type: decl.type }
+        : { id: slot, dir, type: decl.type, combine: decl.combine };
+  }
+  return out;
+};
+
+/**
+ * Builds a fully-typed `BlockDefinition` from Zod schemas, giving block authors
+ * end-to-end inference: `config` validates with a one-line `.safeParse` instead
+ * of a hand-rolled `readConfig`, and `lower` receives both the parsed config and
+ * an `inputBundles` view typed field-by-field from the declared ports.
+ *
+ * The `TConfig`/`TLowerArgs` split collapses here — `lower` receives the parsed
+ * config directly (`buildLowerArgs` is identity). A block that needs to inject
+ * resolved symbol ids into the backend still uses the longhand `BlockDefinition`
+ * literal; `defineBlock` covers the common case where config IS the lower args.
+ *
+ * `const` type parameters preserve the literal slot and field keys through
+ * inference (Zod discussion #670), which is the entire point: without them the
+ * field keys widen to `string` and the compile-time checking evaporates.
+ */
+export function defineBlock<
+  TConfig extends z.ZodType,
+  const TInputs extends Record<string, InputPortDecl>,
+  const TOutputs extends Record<string, OutputPortDecl>,
+>(spec: {
+  readonly type: string;
+  readonly config: TConfig;
+  readonly inputs: TInputs;
+  readonly outputs: TOutputs;
+  readonly manifest?: (config: z.infer<TConfig>) => ManifestContribution;
+  readonly lower: (
+    config: z.infer<TConfig>,
+    ctx: TypedLoweringContext<TInputs>,
+  ) => LoweredBlock;
+}): BlockDefinition<z.infer<TConfig>, z.infer<TConfig>> {
+  const contract: ZBlockContract = {
+    inputs: toBindings(spec.inputs, 'in'),
+    outputs: toBindings(spec.outputs, 'out'),
+  };
+
+  return {
+    type: spec.type,
+    contract,
+    readConfig: (raw, diagnostics) => {
+      const parsed = spec.config.safeParse(raw);
+      if (parsed.success) return parsed.data;
+      for (const issue of parsed.error.issues) {
+        const path = issue.path.length > 0 ? `config.${issue.path.join('.')}: ` : '';
+        diagnostics.push({
+          severity: 'error',
+          message: `[${spec.type}] ${path}${issue.message}`,
+        });
+      }
+      return null;
+    },
+    buildManifestContribution: spec.manifest ?? (() => ({})),
+    buildLowerArgs: (config) => config,
+    // The walker hands us the wide LoweringContext; the contract guarantees the
+    // declared fields are present, so we refine the view to the typed one at
+    // this single seam rather than threading a generic ctx through the walker.
+    lower: (args, ctx) => spec.lower(args, ctx as TypedLoweringContext<TInputs>),
+  };
 }

--- a/src/pillars/types/__tests__/contract.test.ts
+++ b/src/pillars/types/__tests__/contract.test.ts
@@ -1,0 +1,148 @@
+/**
+ * src/pillars/types/__tests__/contract.test.ts
+ *
+ * The contract layer's load-bearing property is end-to-end TypeScript inference:
+ * a block's `lower` sees an `inputBundles` view typed field-by-field from the
+ * ports it declared, so reading a declared field compiles and reading an
+ * undeclared one is a COMPILE error. The decisive assertion in this file is the
+ * `@ts-expect-error` below — it is verified by `tsc --noEmit`, not by the
+ * runtime: if the field-level checking ever regresses (inputBundles widening
+ * back to a string-indexed record), the directive becomes unused and tsc fails.
+ * [LAW:types-are-the-program]
+ *
+ * The runtime `expect`s pin the data side: `defineBlock` derives port ids and
+ * directions, threads `combine`, validates config with one `.safeParse`, and
+ * defaults the manifest contribution to empty.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { z } from 'zod';
+import { defineBlock, type Diagnostic, type LoweredBlock } from '../../block-api';
+import {
+  ZBlockContractSchema,
+  ZPortBindingSchema,
+  ZCombineModeSchema,
+  zFloat,
+  type ZBlockContract,
+} from '../schemas';
+
+// A modifier-style fixture: it reads two declared fields off its `primary`
+// input and emits them. `lower` is where inference is proven.
+const WobbleBlock = defineBlock({
+  type: 'TestWobble',
+  config: z.object({ amount: z.number() }),
+  inputs: {
+    primary: { type: { pos_x: zFloat(), pos_y: zFloat() }, combine: 'last' },
+  },
+  outputs: {
+    out: { type: { pos_x: zFloat(), pos_y: zFloat() } },
+  },
+  lower: (config, ctx): LoweredBlock => {
+    // Declared fields — these compile, and each is typed as ExprIR.
+    const x = ctx.inputBundles.primary.pos_x;
+    const y = ctx.inputBundles.primary.pos_y;
+
+    // The whole point of the contract: an undeclared field does not type-check.
+    // @ts-expect-error reading a field the contract did not declare is a compile error
+    const missing = ctx.inputBundles.primary.nonExistent;
+    void missing;
+    void config.amount;
+
+    return { kind: 'bundle', output: { pos_x: x, pos_y: y } };
+  },
+});
+
+describe('defineBlock — contract derivation', () => {
+  it('derives a contract with port ids equal to slot keys and directions by position', () => {
+    const contract = WobbleBlock.contract;
+    expect(contract).toBeDefined();
+    expect(contract?.inputs.primary).toMatchObject({ id: 'primary', dir: 'in' });
+    expect(contract?.outputs.out).toMatchObject({ id: 'out', dir: 'out' });
+  });
+
+  it('threads combine onto the port and omits it where unset', () => {
+    expect(WobbleBlock.contract?.inputs.primary.combine).toBe('last');
+    expect(WobbleBlock.contract?.outputs.out.combine).toBeUndefined();
+  });
+
+  it('carries the declared bundle fields on the port type', () => {
+    expect(Object.keys(WobbleBlock.contract?.inputs.primary.type ?? {})).toEqual([
+      'pos_x',
+      'pos_y',
+    ]);
+  });
+
+  it('produces a contract that re-parses through the runtime schema', () => {
+    const reparsed = ZBlockContractSchema.safeParse(
+      JSON.parse(JSON.stringify(WobbleBlock.contract)),
+    );
+    expect(reparsed.success).toBe(true);
+  });
+});
+
+describe('defineBlock — config validation', () => {
+  it('returns the parsed config and pushes no diagnostics on valid input', () => {
+    const diagnostics: Diagnostic[] = [];
+    const config = WobbleBlock.readConfig({ amount: 3 }, diagnostics);
+    expect(config).toEqual({ amount: 3 });
+    expect(diagnostics).toHaveLength(0);
+  });
+
+  it('returns null and pushes a block-tagged diagnostic on invalid input', () => {
+    const diagnostics: Diagnostic[] = [];
+    const config = WobbleBlock.readConfig({ amount: 'nope' }, diagnostics);
+    expect(config).toBeNull();
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0].severity).toBe('error');
+    expect(diagnostics[0].message).toContain('[TestWobble]');
+    expect(diagnostics[0].message).toContain('config.amount');
+  });
+
+  it('feeds the parsed config straight through buildLowerArgs (identity)', () => {
+    const config = { amount: 7 };
+    expect(WobbleBlock.buildLowerArgs(config, {})).toBe(config);
+  });
+});
+
+describe('defineBlock — manifest contribution', () => {
+  it('defaults to an empty contribution when no manifest builder is given', () => {
+    expect(WobbleBlock.buildManifestContribution({ amount: 1 })).toEqual({});
+  });
+
+  it('uses a provided manifest builder', () => {
+    const block = defineBlock({
+      type: 'TestGen',
+      config: z.object({ seed: z.number() }),
+      inputs: {},
+      outputs: { out: { type: { pos_x: zFloat() } } },
+      manifest: (config) => ({
+        globals: { 'sys:time': { type: 'f32', isDynamic: true, defaultValue: config.seed } },
+      }),
+      lower: (_config, _ctx): LoweredBlock => ({ kind: 'bundle', output: {} }),
+    });
+    expect(block.buildManifestContribution({ seed: 4 }).globals?.['sys:time'].defaultValue).toBe(4);
+  });
+});
+
+describe('contract schemas — runtime validation', () => {
+  it('accepts the legal combine modes and rejects others', () => {
+    for (const mode of ['first', 'last', 'sum', 'or', 'and']) {
+      expect(ZCombineModeSchema.safeParse(mode).success).toBe(true);
+    }
+    expect(ZCombineModeSchema.safeParse('average').success).toBe(false);
+  });
+
+  it('rejects a port binding with an unknown direction', () => {
+    const bad = { id: 'p', dir: 'sideways', type: {} };
+    expect(ZPortBindingSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('round-trips a hand-built contract through JSON', () => {
+    const contract: ZBlockContract = {
+      inputs: { primary: { id: 'primary', dir: 'in', type: { v: zFloat() } } },
+      outputs: { out: { id: 'out', dir: 'out', type: { v: zFloat() } } },
+    };
+    const reparsed = ZBlockContractSchema.safeParse(JSON.parse(JSON.stringify(contract)));
+    expect(reparsed.success).toBe(true);
+  });
+});

--- a/src/pillars/types/schemas.ts
+++ b/src/pillars/types/schemas.ts
@@ -241,6 +241,50 @@ export const ZInferenceBundleTypeSchema = z.record(z.string(), ZInferenceCanonic
 export type ZInferenceBundleType = z.infer<typeof ZInferenceBundleTypeSchema>;
 
 // ---------------------------------------------------------------------------
+// Ports — where a block declares the types it consumes and emits
+// ---------------------------------------------------------------------------
+
+/**
+ * How a multi-fanout input field reduces when several edges target one port.
+ * `first`/`last` pick a single contributor; `sum` adds numeric fields; `or`/`and`
+ * combine booleans. Which mode is legal for which payload category is a semantic
+ * rule the validate gate enforces in a later child — the schema admits the set,
+ * the gate decides the pairing. [LAW:decomposition]
+ */
+export const ZCombineModeSchema = z.enum(['first', 'last', 'sum', 'or', 'and']);
+export type ZCombineMode = z.infer<typeof ZCombineModeSchema>;
+
+/**
+ * A single port: its stable identity, its direction, and the bundle of typed
+ * fields it carries. The type is a `ZInferenceBundleType` because a port may
+ * declare variables (a modifier ties its output field to its input field by
+ * sharing a variable) that only become concrete after the resolver runs.
+ *
+ * Types live on PORTS, never on edges — an edge is `{source, target}` only.
+ * A catalog block has fully-typed ports with no edges at all, which is what
+ * makes `findInsertableBlocks` answerable without walking a graph. [LAW:one-source-of-truth]
+ */
+export const ZPortBindingSchema = z.object({
+  id: z.string(),
+  dir: z.enum(['in', 'out']),
+  type: ZInferenceBundleTypeSchema,
+  combine: ZCombineModeSchema.optional(),
+});
+export type ZPortBinding = z.infer<typeof ZPortBindingSchema>;
+
+/**
+ * A block's complete type surface: its input and output ports, each keyed by
+ * slot name. This is the block's seam — the rest of the compiler (unifier,
+ * validate gate, insert-menu query) reads the contract, never the block body.
+ * [LAW:locality-or-seam]
+ */
+export const ZBlockContractSchema = z.object({
+  inputs: z.record(z.string(), ZPortBindingSchema),
+  outputs: z.record(z.string(), ZPortBindingSchema),
+});
+export type ZBlockContract = z.infer<typeof ZBlockContractSchema>;
+
+// ---------------------------------------------------------------------------
 // Constructors — produce inference types ergonomically
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

The block author's declaration layer for the pillar type-system epic (`wzm3`), built on wzm3.1's Zod schema foundation (#369).

### `src/pillars/types/schemas.ts`
- **`ZCombineMode`** (`first|last|sum|or|and`) — how a multi-fanout input field reduces.
- **`ZPortBinding`** `{id, dir, type: ZInferenceBundleType, combine?}` — types live on **ports, not edges**; a port may carry variables before unification (a modifier ties output→input by sharing a var). A catalog block has fully-typed ports with no edges, which is what makes `findInsertableBlocks` (wzm3.6) answerable without walking a graph.
- **`ZBlockContract`** `{inputs, outputs}` keyed by slot — the block's type seam; the solver/validate-gate/insert-menu read this, never the block body.

### `src/pillars/block-api.ts`
- `BlockDefinition.contract?: ZBlockContract` — **optional in this child** (becomes mandatory at wzm3.8 once every block declares one). Existing blocks are untouched.
- **`defineBlock`** helper with end-to-end TS inference via `const` type parameters (pattern from [Zod #670](https://github.com/colinhacks/zod/discussions/670)): `lower` receives an `inputBundles` view typed **field-by-field** from the declared ports. Reading a declared field yields `ExprIR`; reading an undeclared one fails `tsc`. `readConfig` becomes a one-line `.safeParse`; `buildLowerArgs` is identity (the `TConfig = TLowerArgs` collapse); an optional `manifest` builder keeps generators adoptable at wzm3.8. `id`/`dir` are derived so the author states each fact once.
- `block-api → ./types/schemas` is the one import allowed past the leaf rule (one-way).

### The inference detail that matters
`TypedLoweringContext` **omits** (does not intersect) the wide `inputBundles: Record<string, SourceBundle>` before substituting the precise per-slot view — intersecting would re-admit arbitrary keys through the record's index signature and defeat field-level checking. `contract.test.ts` pins this with a `@ts-expect-error` that **`tsc` verifies**: if the checking ever regresses, the directive goes unused and the build fails. (Verified adversarially: removing the directive yields `error TS2339: Property 'nonExistent' does not exist on type '{ readonly pos_x: ExprIR; readonly pos_y: ExprIR; }'`.)

## Verification
- `npx tsc --noEmit` — **0 errors**
- `npx vitest run src/pillars/` — **130/130** (12 new in `contract.test.ts`)
- `eslint` on changed files — clean
- depcruise — the only error is a **pre-existing** `src/render/` internal cycle (`ir-node-rules ↔ boundary-contract`, landed in #350), reached transitively via the long-standing `block-api → boundary-contract` import; untouched here.

## Laws
`[LAW:types-are-the-program]` (the contract drives compile-time field checking) · `[LAW:locality-or-seam]` (the contract is the block's seam) · `[LAW:one-source-of-truth]` (id/dir derived, not repeated)

Closes `oscilla-pillars-types-wzm3.2`