### PR TITLE
feat(pillars-types wzm3.3): pure sub-solvers (payload/unit + 5-phase cardinality) + substitution

### DIFF
--- a/src/pillars/types/index.ts
+++ b/src/pillars/types/index.ts
@@ -6,7 +6,9 @@
  *
  *   - `graph`   — the user-authored PillarPatch graph (frontend input).
  *   - `schemas` — the Zod type-system layer every compiler type is expressed in.
+ *   - `solve`   — the pure sub-solvers + substitution that resolve type variables.
  */
 
 export * from './graph';
 export * from './schemas';
+export * from './solve';

--- a/src/pillars/types/solve/__tests__/solve-cardinality.test.ts
+++ b/src/pillars/types/solve/__tests__/solve-cardinality.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The 5-phase cardinality sub-solver, exercised with hand-rolled constraints.
+ * Covers the resolution rules, the structural/terminal error split, and the
+ * promoteToMany inner fixpoint including the clampOne exemption that makes a
+ * "clampOne inside a zip set" deliberately NOT a conflict. [LAW:behavior-not-structure]
+ */
+
+import { describe, it, expect } from 'vitest';
+import { cardinalityVarId, instanceRef, type ZInferenceCardinality } from '../../schemas';
+import {
+  solveCardinality,
+  isStructuralCardinalityConflict,
+  UNBOUND_INSTANCE,
+  type ZCardinalityConstraint,
+} from '../cardinality';
+import type { ConstraintOrigin, PortKey } from '../shared';
+
+const o: ConstraintOrigin = { kind: 'blockRule', blockId: 'b', rule: 'test' };
+const varAxis = (name: string): ZInferenceCardinality => ({ kind: 'var', var: cardinalityVarId(name) });
+const dots = instanceRef('dots');
+const stars = instanceRef('stars');
+
+const run = (
+  ports: Record<string, ZInferenceCardinality>,
+  constraints: readonly ZCardinalityConstraint[],
+  inheritInstanceVars?: ReadonlySet<ReturnType<typeof cardinalityVarId>>,
+) => solveCardinality({ ports: new Map<PortKey, ZInferenceCardinality>(Object.entries(ports)), constraints, inheritInstanceVars });
+
+describe('solveCardinality — base resolution', () => {
+  it('resolves a concrete one (propagated through equal) to one without a many', () => {
+    const r = run(
+      { A: { kind: 'one' }, B: varAxis('n') },
+      [{ kind: 'equal', a: 'A', b: 'B', origin: o }],
+    );
+    expect(r.cardinalities.get(cardinalityVarId('n'))).toEqual({ kind: 'one' });
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('resolves forceMany to many(instance)', () => {
+    const r = run({ A: varAxis('n') }, [{ kind: 'forceMany', port: 'A', instance: { kind: 'inst', ref: dots }, origin: o }]);
+    expect(r.cardinalities.get(cardinalityVarId('n'))).toEqual({ kind: 'many', instance: 'dots' });
+  });
+
+  it('resolves two matching forceMany across an equal group to one many', () => {
+    const r = run(
+      { A: varAxis('n'), B: varAxis('m') },
+      [
+        { kind: 'equal', a: 'A', b: 'B', origin: o },
+        { kind: 'forceMany', port: 'A', instance: { kind: 'inst', ref: dots }, origin: o },
+        { kind: 'forceMany', port: 'B', instance: { kind: 'inst', ref: dots }, origin: o },
+      ],
+    );
+    expect(r.cardinalities.get(cardinalityVarId('n'))).toEqual({ kind: 'many', instance: 'dots' });
+    expect(r.cardinalities.get(cardinalityVarId('m'))).toEqual({ kind: 'many', instance: 'dots' });
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('reports InstanceConflict for two different concrete instances', () => {
+    const r = run({ A: varAxis('n') }, [
+      { kind: 'forceMany', port: 'A', instance: { kind: 'inst', ref: dots }, origin: o },
+      { kind: 'forceMany', port: 'A', instance: { kind: 'inst', ref: stars }, origin: o },
+    ]);
+    const conflict = r.errors.find((e) => e.kind === 'InstanceConflict');
+    expect(conflict).toBeDefined();
+    expect(isStructuralCardinalityConflict(conflict!)).toBe(false); // terminal, not structural
+  });
+
+  it('propagates facts through equal (clampOne reaches the joined var)', () => {
+    const r = run(
+      { A: { kind: 'one' }, B: varAxis('n') },
+      [
+        { kind: 'clampOne', port: 'A', origin: o },
+        { kind: 'equal', a: 'A', b: 'B', origin: o },
+      ],
+    );
+    expect(r.cardinalities.get(cardinalityVarId('n'))).toEqual({ kind: 'one' });
+    expect(r.diagnostics).toHaveLength(0); // forcedOne, not a default
+  });
+});
+
+describe('solveCardinality — structural conflict', () => {
+  it('reports ClampManyConflict (structural) for clampOne + forceMany on one group', () => {
+    const r = run({ A: varAxis('n') }, [
+      { kind: 'clampOne', port: 'A', origin: o },
+      { kind: 'forceMany', port: 'A', instance: { kind: 'inst', ref: dots }, origin: o },
+    ]);
+    const conflict = r.errors.find((e) => e.kind === 'ClampManyConflict');
+    expect(conflict).toBeDefined();
+    expect(isStructuralCardinalityConflict(conflict!)).toBe(true);
+    expect(r.cardinalities.has(cardinalityVarId('n'))).toBe(false); // left unresolved for the driver
+  });
+});
+
+describe('solveCardinality — promoteToMany inner fixpoint', () => {
+  it('promotes every zip member to many from a single forceMany', () => {
+    const r = run(
+      { a: varAxis('na'), b: varAxis('nb'), c: varAxis('nc') },
+      [
+        { kind: 'promoteToMany', ports: ['a', 'b', 'c'], origin: o },
+        { kind: 'forceMany', port: 'a', instance: { kind: 'inst', ref: dots }, origin: o },
+      ],
+    );
+    for (const v of ['na', 'nb', 'nc']) {
+      expect(r.cardinalities.get(cardinalityVarId(v))).toEqual({ kind: 'many', instance: 'dots' });
+    }
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('keeps a clampOne zip member at one while others go many — no conflict', () => {
+    const r = run(
+      { a: varAxis('na'), b: varAxis('nb'), c: varAxis('nc') },
+      [
+        { kind: 'promoteToMany', ports: ['a', 'b', 'c'], origin: o },
+        { kind: 'forceMany', port: 'a', instance: { kind: 'inst', ref: dots }, origin: o },
+        { kind: 'clampOne', port: 'b', origin: o },
+      ],
+    );
+    expect(r.cardinalities.get(cardinalityVarId('na'))).toEqual({ kind: 'many', instance: 'dots' });
+    expect(r.cardinalities.get(cardinalityVarId('nb'))).toEqual({ kind: 'one' });
+    expect(r.cardinalities.get(cardinalityVarId('nc'))).toEqual({ kind: 'many', instance: 'dots' });
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('reports InstanceConflict when two zip members are many with different instances', () => {
+    const r = run(
+      { a: varAxis('na'), b: varAxis('nb') },
+      [
+        { kind: 'promoteToMany', ports: ['a', 'b'], origin: o },
+        { kind: 'forceMany', port: 'a', instance: { kind: 'inst', ref: dots }, origin: o },
+        { kind: 'forceMany', port: 'b', instance: { kind: 'inst', ref: stars }, origin: o },
+      ],
+    );
+    const conflicts = r.errors.filter((e) => e.kind === 'InstanceConflict');
+    expect(conflicts).toHaveLength(1); // emitted once, not once per fixpoint pass
+  });
+
+  it('cascades many across overlapping zip sets in one solve', () => {
+    const r = run(
+      { a: varAxis('na'), b: varAxis('nb'), c: varAxis('nc'), d: varAxis('nd') },
+      [
+        { kind: 'promoteToMany', ports: ['a', 'b'], origin: o },
+        { kind: 'promoteToMany', ports: ['b', 'c'], origin: o },
+        { kind: 'promoteToMany', ports: ['c', 'd'], origin: o },
+        { kind: 'forceMany', port: 'a', instance: { kind: 'inst', ref: dots }, origin: o },
+      ],
+    );
+    for (const v of ['na', 'nb', 'nc', 'nd']) {
+      expect(r.cardinalities.get(cardinalityVarId(v))).toEqual({ kind: 'many', instance: 'dots' });
+    }
+  });
+});
+
+describe('solveCardinality — deferred instance binding', () => {
+  it('keeps an unresolved instance var as UNBOUND_INSTANCE under inherit policy', () => {
+    const iv = cardinalityVarId('iv');
+    const r = run(
+      { A: varAxis('n') },
+      [{ kind: 'forceMany', port: 'A', instance: { kind: 'var', var: iv }, origin: o }],
+      new Set([iv]),
+    );
+    expect(r.cardinalities.get(cardinalityVarId('n'))).toEqual({ kind: 'many', instance: UNBOUND_INSTANCE });
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('reports UnresolvedInstanceVar with no inherit policy', () => {
+    const iv = cardinalityVarId('iv');
+    const r = run(
+      { A: varAxis('n') },
+      [{ kind: 'forceMany', port: 'A', instance: { kind: 'var', var: iv }, origin: o }],
+    );
+    expect(r.errors.map((e) => e.kind)).toContain('UnresolvedInstanceVar');
+    expect(r.cardinalities.has(cardinalityVarId('n'))).toBe(false);
+  });
+});
+
+describe('solveCardinality — purity', () => {
+  it('returns equal results across repeated calls on the same input', () => {
+    const ports = { a: varAxis('na'), b: varAxis('nb'), c: varAxis('nc') };
+    const constraints: readonly ZCardinalityConstraint[] = [
+      { kind: 'promoteToMany', ports: ['a', 'b', 'c'], origin: o },
+      { kind: 'forceMany', port: 'a', instance: { kind: 'inst', ref: dots }, origin: o },
+      { kind: 'clampOne', port: 'b', origin: o },
+    ];
+    const first = run({ ...ports }, constraints);
+    const second = run({ ...ports }, constraints);
+    expect([...second.cardinalities]).toEqual([...first.cardinalities]);
+    expect(second.errors).toEqual(first.errors);
+  });
+});

--- a/src/pillars/types/solve/__tests__/solve-payload-unit.test.ts
+++ b/src/pillars/types/solve/__tests__/solve-payload-unit.test.ts
@@ -1,0 +1,157 @@
+/**
+ * The payload/unit sub-solver, exercised with hand-rolled constraints — no
+ * graph, no fixpoint. Each test pins one resolution rule or one failure mode,
+ * so a regression names itself. [LAW:behavior-not-structure]
+ */
+
+import { describe, it, expect } from 'vitest';
+import { payloadVarId, unitVarId, type ZPayloadType } from '../../schemas';
+import {
+  solvePayloadUnit,
+  type PortVarInfo,
+  type ZPayloadUnitConstraint,
+} from '../payload-unit';
+import type { ConstraintOrigin, PortKey } from '../shared';
+
+const rule: ConstraintOrigin = { kind: 'blockRule', blockId: 'b', rule: 'test' };
+const edge = (edgeId: string): ConstraintOrigin => ({ kind: 'edge', edgeId });
+
+const ports = (entries: Record<string, PortVarInfo>): ReadonlyMap<PortKey, PortVarInfo> =>
+  new Map(Object.entries(entries));
+
+const run = (
+  portMap: Record<string, PortVarInfo>,
+  constraints: readonly ZPayloadUnitConstraint[],
+  edgeVerifications?: readonly { edgeId: string; from: PortKey; to: PortKey }[],
+) => solvePayloadUnit({ ports: ports(portMap), constraints, edgeVerifications });
+
+describe('solvePayloadUnit — payload', () => {
+  it('resolves a single concrete payload', () => {
+    const r = run(
+      { A: { payloadVar: payloadVarId('a') } },
+      [{ kind: 'concretePayload', port: 'A', value: { kind: 'vec3' }, origin: rule }],
+    );
+    expect(r.payloads.get(payloadVarId('a'))).toEqual({ kind: 'vec3' });
+    expect(r.portPayloads.get('A')).toEqual({ kind: 'vec3' });
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('resolves a variable from a concrete neighbour via payloadEq transitivity', () => {
+    const r = run(
+      { A: {}, B: { payloadVar: payloadVarId('b') } },
+      [
+        { kind: 'concretePayload', port: 'A', value: { kind: 'float' }, origin: rule },
+        { kind: 'payloadEq', a: 'A', b: 'B', origin: edge('e1') },
+      ],
+    );
+    expect(r.payloads.get(payloadVarId('b'))).toEqual({ kind: 'float' });
+  });
+
+  it('reports ConflictingPayloads for two incompatible concretes on one group', () => {
+    const r = run(
+      { A: {}, B: {} },
+      [
+        { kind: 'concretePayload', port: 'A', value: { kind: 'float' }, origin: rule },
+        { kind: 'concretePayload', port: 'B', value: { kind: 'vec2' }, origin: rule },
+        { kind: 'payloadEq', a: 'A', b: 'B', origin: edge('e1') },
+      ],
+    );
+    expect(r.errors.map((e) => e.kind)).toContain('ConflictingPayloads');
+    // edge origin on the unifying constraint → the user's patch is at fault.
+    expect(r.errors.find((e) => e.kind === 'ConflictingPayloads')?.errorClass).toBe('UserPatchTypeError');
+  });
+
+  it('defaults a single-element allowed set to that payload', () => {
+    const r = run(
+      { A: { payloadVar: payloadVarId('a') } },
+      [{ kind: 'requirePayloadIn', port: 'A', allowed: [{ kind: 'int' }], origin: rule }],
+    );
+    expect(r.payloads.get(payloadVarId('a'))).toEqual({ kind: 'int' });
+  });
+
+  it('intersects allowed sets to a single non-empty choice', () => {
+    const r = run(
+      { A: { payloadVar: payloadVarId('a') } },
+      [
+        { kind: 'requirePayloadIn', port: 'A', allowed: [{ kind: 'float' }, { kind: 'int' }], origin: rule },
+        { kind: 'requirePayloadIn', port: 'A', allowed: [{ kind: 'int' }], origin: rule },
+      ],
+    );
+    expect(r.payloads.get(payloadVarId('a'))).toEqual({ kind: 'int' });
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('reports EmptyAllowedSet when the intersection is empty', () => {
+    const r = run(
+      { A: { payloadVar: payloadVarId('a') } },
+      [
+        { kind: 'requirePayloadIn', port: 'A', allowed: [{ kind: 'float' }], origin: rule },
+        { kind: 'requirePayloadIn', port: 'A', allowed: [{ kind: 'int' }], origin: rule },
+      ],
+    );
+    expect(r.errors.map((e) => e.kind)).toContain('EmptyAllowedSet');
+  });
+});
+
+describe('solvePayloadUnit — unit', () => {
+  it('reports UnitlessMismatch for a concrete non-none unit where unitless is required', () => {
+    const r = run(
+      { A: {} },
+      [
+        { kind: 'concreteUnit', port: 'A', value: { kind: 'angle', unit: 'radians' }, origin: rule },
+        { kind: 'requireUnitless', port: 'A', origin: rule },
+      ],
+    );
+    expect(r.errors.map((e) => e.kind)).toContain('UnitlessMismatch');
+  });
+
+  it('defaults an unresolved required-unitless port to none with no diagnostic', () => {
+    const r = run(
+      { A: { unitVar: unitVarId('u') } },
+      [{ kind: 'requireUnitless', port: 'A', origin: rule }],
+    );
+    expect(r.units.get(unitVarId('u'))).toEqual({ kind: 'none' });
+    expect(r.diagnostics).toHaveLength(0);
+  });
+
+  it('defaults an unconstrained unit variable to none and announces it', () => {
+    const r = run({ A: { unitVar: unitVarId('u') } }, []);
+    expect(r.units.get(unitVarId('u'))).toEqual({ kind: 'none' });
+    expect(r.diagnostics.map((d) => d.code)).toContain('UnitDefaultedToNone');
+  });
+});
+
+describe('solvePayloadUnit — purity', () => {
+  it('returns equal results across repeated calls on the same input', () => {
+    const portMap = { A: {}, B: { payloadVar: payloadVarId('b') }, C: { unitVar: unitVarId('u') } };
+    const constraints: readonly ZPayloadUnitConstraint[] = [
+      { kind: 'concretePayload', port: 'A', value: { kind: 'float' }, origin: rule },
+      { kind: 'payloadEq', a: 'A', b: 'B', origin: edge('e1') },
+    ];
+    const first = run({ ...portMap }, constraints);
+    const second = run({ ...portMap }, constraints);
+    expect([...second.payloads]).toEqual([...first.payloads]);
+    expect([...second.portPayloads]).toEqual([...first.portPayloads]);
+    expect(second.diagnostics).toEqual(first.diagnostics);
+  });
+});
+
+describe('solvePayloadUnit — edge verification safety net', () => {
+  it('catches a dropped constraint via a post-solve edge mismatch', () => {
+    // A=float, B=int are never linked by a payloadEq — the "dropped" constraint.
+    // Only the edge verification catches that they disagree. Both carry a
+    // concrete unit, as every extracted port does. [LAW:no-silent-failure]
+    const incompatible: ZPayloadType[] = [{ kind: 'float' }, { kind: 'int' }];
+    const r = run(
+      { A: {}, B: {} },
+      [
+        { kind: 'concretePayload', port: 'A', value: incompatible[0], origin: rule },
+        { kind: 'concretePayload', port: 'B', value: incompatible[1], origin: rule },
+        { kind: 'concreteUnit', port: 'A', value: { kind: 'none' }, origin: rule },
+        { kind: 'concreteUnit', port: 'B', value: { kind: 'none' }, origin: rule },
+      ],
+      [{ edgeId: 'e1', from: 'A', to: 'B' }],
+    );
+    expect(r.diagnostics.map((d) => d.code)).toContain('PostSolveEdgeTypeMismatch');
+  });
+});

--- a/src/pillars/types/solve/__tests__/substitution.test.ts
+++ b/src/pillars/types/solve/__tests__/substitution.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Substitution is the inference→concrete boundary's working surface: applying a
+ * total substitution must yield a value that parses as `ZCanonicalType`, and a
+ * partial one must yield a value that does NOT. That parse — not a scattered
+ * `kind === 'inst'` check — is the single enforcer of the boundary, so these
+ * tests pin both directions of it. [LAW:single-enforcer]
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  ZCanonicalTypeSchema,
+  canonical,
+  oneExtent,
+  payloadVar,
+  unitVar,
+  cardinalityVar,
+  payloadVarId,
+  unitVarId,
+  cardinalityVarId,
+  instanceRef,
+  type ZInferenceCanonicalType,
+} from '../../schemas';
+import { applySubstitution, EMPTY_SUBSTITUTION, type Substitution } from '../substitution';
+
+describe('applySubstitution', () => {
+  it('returns the input unchanged under the empty substitution', () => {
+    const type = canonical(payloadVar('p'), { unit: unitVar('u') });
+    expect(applySubstitution(type, EMPTY_SUBSTITUTION)).toEqual(type);
+  });
+
+  it('replaces a bound payload variable', () => {
+    const subst: Substitution = {
+      payloads: new Map([[payloadVarId('p'), { kind: 'vec3' }]]),
+      units: new Map(),
+      cardinalities: new Map(),
+    };
+    const result = applySubstitution(canonical(payloadVar('p')), subst);
+    expect(result.payload).toEqual({ kind: 'vec3' });
+  });
+
+  it('replaces a bound unit variable (resolving to a structured angle unit)', () => {
+    // The landed schema makes `angle.unit` a closed enum, so the only unit
+    // variable is the top-level one; this covers a unit var resolving to an
+    // angle, which is the realizable form of "incl. nested in angle".
+    const subst: Substitution = {
+      payloads: new Map(),
+      units: new Map([[unitVarId('u'), { kind: 'angle', unit: 'radians' }]]),
+      cardinalities: new Map(),
+    };
+    const result = applySubstitution(canonical({ kind: 'float' }, { unit: unitVar('u') }), subst);
+    expect(result.unit).toEqual({ kind: 'angle', unit: 'radians' });
+  });
+
+  it('replaces a bound cardinality variable', () => {
+    const subst: Substitution = {
+      payloads: new Map(),
+      units: new Map(),
+      cardinalities: new Map([[cardinalityVarId('n'), { kind: 'many', instance: instanceRef('dots') }]]),
+    };
+    const type = canonical({ kind: 'float' }, { extent: { ...oneExtent(), cardinality: cardinalityVar('n') } });
+    const result = applySubstitution(type, subst);
+    expect(result.extent.cardinality).toEqual({ kind: 'many', instance: 'dots' });
+  });
+
+  it('produces a value that parses as concrete once every variable is bound', () => {
+    const subst: Substitution = {
+      payloads: new Map([[payloadVarId('p'), { kind: 'float' }]]),
+      units: new Map([[unitVarId('u'), { kind: 'none' }]]),
+      cardinalities: new Map([[cardinalityVarId('n'), { kind: 'one' }]]),
+    };
+    const type: ZInferenceCanonicalType = {
+      payload: payloadVar('p'),
+      unit: unitVar('u'),
+      extent: { ...oneExtent(), cardinality: cardinalityVar('n') },
+    };
+    expect(ZCanonicalTypeSchema.safeParse(applySubstitution(type, subst)).success).toBe(true);
+  });
+
+  it('leaves a surviving variable that FAILS the concrete parse (partial substitution)', () => {
+    // Only the payload is bound; the unit variable survives, so the result is
+    // still an inference type and the concrete parse must reject it.
+    const subst: Substitution = {
+      payloads: new Map([[payloadVarId('p'), { kind: 'float' }]]),
+      units: new Map(),
+      cardinalities: new Map(),
+    };
+    const type = canonical(payloadVar('p'), { unit: unitVar('u') });
+    const result = applySubstitution(type, subst);
+    expect(result.unit).toEqual(unitVar('u'));
+    expect(ZCanonicalTypeSchema.safeParse(result).success).toBe(false);
+  });
+});

--- a/src/pillars/types/solve/cardinality.ts
+++ b/src/pillars/types/solve/cardinality.ts
@@ -1,0 +1,560 @@
+/**
+ * src/pillars/types/solve/cardinality.ts
+ *
+ * The cardinality sub-solver: resolves every port's lane count (one / many) and,
+ * for many, its lane-set identity. A distinct domain from payload/unit with a
+ * distinct mechanism, so a distinct solver. [LAW:decomposition]
+ *
+ * Two union-finds: `CardinalityUF` groups ports that must share a cardinality
+ * (so a fact proven for one is proven for all), and `InstanceUF` unifies the
+ * instance *terms* a `many` can carry — a concrete lane set or a variable
+ * standing for one. Five phases turn a flat constraint set into resolved
+ * cardinalities; a sixth concern, propagating `many` across zip sets, is a
+ * bounded inner fixpoint inside phase 4 — it converges within this call, before
+ * the outer graph fixpoint (wzm3.5) ever sees the result. [LAW:no-ambient-temporal-coupling]
+ *
+ * Pure: no input mutated, deterministic output. [LAW:effects-at-boundaries]
+ *
+ * Two deliberate departures from V1, both because the pillar schema is tighter:
+ *   - No subdomain escape hatch in instance unification — the pillar has no
+ *     subdomain relation, so two distinct concrete instances simply conflict.
+ *   - A `many` whose instance is still a variable is its own `GroupResolution`
+ *     state, not a concrete cardinality smuggling a `__var__` sentinel string.
+ *     The intermediate is honestly typed; only phase 5 produces `ZCardinality`.
+ *     [LAW:types-are-the-program]
+ */
+
+import { instanceRef } from '../schemas';
+import type {
+  CardinalityVarId,
+  InstanceRef,
+  ZCardinality,
+  ZInferenceCardinality,
+} from '../schemas';
+import type { ConstraintOrigin, PortKey, SolveDiagnostic } from './shared';
+
+/**
+ * The lane-set identity a `many` aligns by: a concrete reference, or a variable
+ * standing for one until evidence resolves it. The variable reuses
+ * `CardinalityVarId` — the pillar mints no separate instance-variable space, so
+ * a cardinality variable doubles as the identity of the lane set it resolves to.
+ * Kept a solver-internal term (never a schema type) so this reuse stays local.
+ */
+export type InstanceTerm =
+  | { readonly kind: 'inst'; readonly ref: InstanceRef }
+  | { readonly kind: 'var'; readonly var: CardinalityVarId };
+
+export type ZCardinalityConstraint =
+  | { readonly kind: 'equal'; readonly a: PortKey; readonly b: PortKey; readonly origin: ConstraintOrigin }
+  | { readonly kind: 'clampOne'; readonly port: PortKey; readonly origin: ConstraintOrigin }
+  | { readonly kind: 'forceMany'; readonly port: PortKey; readonly instance: InstanceTerm; readonly origin: ConstraintOrigin }
+  | { readonly kind: 'promoteToMany'; readonly ports: readonly PortKey[]; readonly origin: ConstraintOrigin };
+
+export interface CardinalitySolveInput {
+  /** Each port's declared base cardinality axis. A concrete `many` is many-evidence; a `var` is what phase 5 writes a substitution for. */
+  readonly ports: ReadonlyMap<PortKey, ZInferenceCardinality>;
+  readonly constraints: readonly ZCardinalityConstraint[];
+  /**
+   * Cardinality variables whose group may keep an unbound lane set rather than
+   * failing when no concrete instance is found — the `inherit` binding policy,
+   * supplied as data by the extraction layer (the schema carries no policy
+   * field, so the solver receives it, never reads it off the type).
+   */
+  readonly inheritInstanceVars?: ReadonlySet<CardinalityVarId>;
+}
+
+/**
+ * The deferred-binding sentinel: a `many` whose lane set is legitimately not yet
+ * known (an `inherit`-binding group with no concrete evidence). A later backend
+ * repass binds it; until then it is a concrete-but-sentinel `InstanceRef` so it
+ * satisfies `ZCardinality` while remaining recognizable.
+ */
+export const UNBOUND_INSTANCE: InstanceRef = instanceRef('__unbound__');
+
+export type CardinalitySolveError =
+  | {
+      readonly kind: 'ClampManyConflict';
+      readonly ports: readonly PortKey[];
+      readonly clampOneMembers: readonly PortKey[];
+      readonly forceManyMembers: readonly PortKey[];
+      readonly clampOneOrigins: readonly ConstraintOrigin[];
+      readonly forceManyOrigins: readonly ConstraintOrigin[];
+      readonly message: string;
+    }
+  | { readonly kind: 'InstanceConflict'; readonly ports: readonly PortKey[]; readonly origins: readonly ConstraintOrigin[]; readonly message: string }
+  | { readonly kind: 'UnresolvedInstanceVar'; readonly ports: readonly PortKey[]; readonly origins: readonly ConstraintOrigin[]; readonly message: string };
+
+/**
+ * The structural / terminal split is how the solver tells the fixpoint driver
+ * which conflicts an adapter can fix (structural → an obligation) versus which
+ * are dead ends (terminal → a diagnostic). Defining it as one predicate keeps
+ * the taxonomy in a single place rather than re-derived at every callsite.
+ * [LAW:single-enforcer]
+ *
+ * Only `ClampManyConflict` is structural *and* emitted: a clampOne port caught
+ * inside a promoteToMany zip is exempt by design (it stays `one`, the runtime
+ * zip-promotes it), so the would-be `PromoteToManyClampOneConflict` is never
+ * constructed — an unrepresentable state earns no error kind. [LAW:types-are-the-program]
+ */
+export const isStructuralCardinalityConflict = (e: CardinalitySolveError): boolean =>
+  e.kind === 'ClampManyConflict';
+
+export interface CardinalitySolveResult {
+  readonly cardinalities: ReadonlyMap<CardinalityVarId, ZCardinality>;
+  readonly errors: readonly CardinalitySolveError[];
+  readonly diagnostics: readonly SolveDiagnostic[];
+}
+
+/** A group's resolution, with `many(var)` an explicit state rather than a sentinel concrete. */
+type GroupResolution =
+  | { readonly kind: 'one' }
+  | { readonly kind: 'manyConcrete'; readonly instance: InstanceRef }
+  | { readonly kind: 'manyVar'; readonly var: CardinalityVarId };
+
+interface GroupFacts {
+  forcedOne: boolean;
+  forcedManyTerms: InstanceTerm[];
+  resolved: GroupResolution | null;
+  clampOneOrigins: ConstraintOrigin[];
+  forceManyOrigins: ConstraintOrigin[];
+}
+
+const newGroupFacts = (): GroupFacts => ({
+  forcedOne: false,
+  forcedManyTerms: [],
+  resolved: null,
+  clampOneOrigins: [],
+  forceManyOrigins: [],
+});
+
+// ---------------------------------------------------------------------------
+// CardinalityUF — port equality groups, rank + lexicographic, facts on the root
+// ---------------------------------------------------------------------------
+
+class CardinalityUF {
+  private readonly parent = new Map<PortKey, PortKey>();
+  private readonly rank = new Map<PortKey, number>();
+  private readonly facts = new Map<PortKey, GroupFacts>();
+
+  ensure(id: PortKey): void {
+    if (!this.parent.has(id)) {
+      this.parent.set(id, id);
+      this.rank.set(id, 0);
+    }
+  }
+
+  find(id: PortKey): PortKey {
+    this.ensure(id);
+    let root = id;
+    while (this.parent.get(root)! !== root) root = this.parent.get(root)!;
+    let cur = id;
+    while (this.parent.get(cur)! !== root) {
+      const next = this.parent.get(cur)!;
+      this.parent.set(cur, root);
+      cur = next;
+    }
+    return root;
+  }
+
+  union(a: PortKey, b: PortKey): void {
+    const ra = this.find(a);
+    const rb = this.find(b);
+    if (ra === rb) return;
+    const rankA = this.rank.get(ra)!;
+    const rankB = this.rank.get(rb)!;
+    // Rank-balanced, with a lexicographic tiebreak so equal-rank merges are deterministic.
+    let winner: PortKey;
+    let loser: PortKey;
+    if (rankA > rankB) [winner, loser] = [ra, rb];
+    else if (rankB > rankA) [winner, loser] = [rb, ra];
+    else {
+      [winner, loser] = ra < rb ? [ra, rb] : [rb, ra];
+      this.rank.set(winner, rankA + 1);
+    }
+    this.parent.set(loser, winner);
+    this.mergeFacts(winner, loser);
+  }
+
+  private mergeFacts(winner: PortKey, loser: PortKey): void {
+    const loserFacts = this.facts.get(loser);
+    if (!loserFacts) return;
+    const winnerFacts = this.getOrCreateFacts(winner);
+    winnerFacts.forcedOne = winnerFacts.forcedOne || loserFacts.forcedOne;
+    winnerFacts.forcedManyTerms.push(...loserFacts.forcedManyTerms);
+    winnerFacts.clampOneOrigins.push(...loserFacts.clampOneOrigins);
+    winnerFacts.forceManyOrigins.push(...loserFacts.forceManyOrigins);
+    this.facts.delete(loser);
+  }
+
+  getOrCreateFacts(id: PortKey): GroupFacts {
+    const root = this.find(id);
+    let f = this.facts.get(root);
+    if (!f) {
+      f = newGroupFacts();
+      this.facts.set(root, f);
+    }
+    return f;
+  }
+
+  getFacts(id: PortKey): GroupFacts | undefined {
+    return this.facts.get(this.find(id));
+  }
+
+  roots(): PortKey[] {
+    const set = new Set<PortKey>();
+    for (const id of this.parent.keys()) set.add(this.find(id));
+    return [...set].sort();
+  }
+
+  members(root: PortKey): PortKey[] {
+    const out: PortKey[] = [];
+    for (const id of this.parent.keys()) if (this.find(id) === root) out.push(id);
+    return out.sort();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// InstanceUF — unifies instance terms; concrete beats variable
+// ---------------------------------------------------------------------------
+
+const instanceTermKey = (t: InstanceTerm): string => (t.kind === 'inst' ? `inst:${t.ref}` : `var:${t.var}`);
+
+class InstanceUF {
+  private readonly parent = new Map<string, string>();
+  private readonly rank = new Map<string, number>();
+  private readonly value = new Map<string, InstanceTerm>();
+
+  ensure(t: InstanceTerm): string {
+    const key = instanceTermKey(t);
+    if (!this.parent.has(key)) {
+      this.parent.set(key, key);
+      this.rank.set(key, 0);
+      this.value.set(key, t);
+    }
+    return key;
+  }
+
+  private find(key: string): string {
+    let root = key;
+    while (this.parent.get(root)! !== root) root = this.parent.get(root)!;
+    let cur = key;
+    while (this.parent.get(cur)! !== root) {
+      const next = this.parent.get(cur)!;
+      this.parent.set(cur, root);
+      cur = next;
+    }
+    return root;
+  }
+
+  /** Unify two terms. Returns a conflict message when two distinct concrete instances meet. */
+  unify(a: InstanceTerm, b: InstanceTerm): { conflict: string } | null {
+    const ka = this.find(this.ensure(a));
+    const kb = this.find(this.ensure(b));
+    if (ka === kb) return null;
+    const va = this.value.get(ka)!;
+    const vb = this.value.get(kb)!;
+    if (va.kind === 'inst' && vb.kind === 'inst') {
+      // Distinct concrete lane sets cannot be the same — no subdomain rescue in the pillar.
+      return { conflict: `Instance conflict: ${va.ref} vs ${vb.ref}` };
+    }
+    // Prefer a concrete instance as the winner so the variable resolves to it.
+    let winner: string;
+    let loser: string;
+    if (va.kind === 'inst') [winner, loser] = [ka, kb];
+    else if (vb.kind === 'inst') [winner, loser] = [kb, ka];
+    else {
+      const rankA = this.rank.get(ka)!;
+      const rankB = this.rank.get(kb)!;
+      if (rankA > rankB) [winner, loser] = [ka, kb];
+      else if (rankB > rankA) [winner, loser] = [kb, ka];
+      else {
+        [winner, loser] = ka < kb ? [ka, kb] : [kb, ka];
+        this.rank.set(winner, rankA + 1);
+      }
+    }
+    this.parent.set(loser, winner);
+    return null;
+  }
+
+  resolve(t: InstanceTerm): InstanceTerm {
+    return this.value.get(this.find(this.ensure(t)))!;
+  }
+
+  /** Every variable term that unified with a concrete instance, mapped to that instance. */
+  resolvedVars(): Map<CardinalityVarId, InstanceRef> {
+    const out = new Map<CardinalityVarId, InstanceRef>();
+    for (const term of this.value.values()) {
+      if (term.kind !== 'var') continue;
+      const root = this.value.get(this.find(instanceTermKey(term)))!;
+      if (root.kind === 'inst') out.set(term.var, root.ref);
+    }
+    return out;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The solve
+// ---------------------------------------------------------------------------
+
+export function solveCardinality(input: CardinalitySolveInput): CardinalitySolveResult {
+  const { ports, constraints, inheritInstanceVars } = input;
+  const uf = new CardinalityUF();
+  const instanceUF = new InstanceUF();
+  const errors: CardinalitySolveError[] = [];
+  const diagnostics: SolveDiagnostic[] = [];
+
+  for (const port of ports.keys()) uf.ensure(port);
+
+  // --- Phase 1: equality UF ------------------------------------------------
+  for (const c of constraints) if (c.kind === 'equal') uf.union(c.a, c.b);
+
+  // --- Phase 2: collect group facts ----------------------------------------
+  for (const c of constraints) {
+    if (c.kind === 'clampOne') {
+      const f = uf.getOrCreateFacts(c.port);
+      f.forcedOne = true;
+      f.clampOneOrigins.push(c.origin);
+    } else if (c.kind === 'forceMany') {
+      const f = uf.getOrCreateFacts(c.port);
+      instanceUF.ensure(c.instance);
+      f.forcedManyTerms.push(c.instance);
+      f.forceManyOrigins.push(c.origin);
+    }
+  }
+  // A concrete `many` in a port's base axis is many-evidence; a concrete `one`
+  // there is NOT clampOne — only an explicit clampOne constraint forces one.
+  for (const [port, axis] of ports) {
+    if (axis.kind === 'many') {
+      const term: InstanceTerm = { kind: 'inst', ref: axis.instance };
+      const f = uf.getOrCreateFacts(port);
+      instanceUF.ensure(term);
+      f.forcedManyTerms.push(term);
+    }
+  }
+
+  // --- Phase 3: local group resolution -------------------------------------
+  for (const root of uf.roots()) {
+    const facts = uf.getOrCreateFacts(root);
+    const hasForcedMany = facts.forcedManyTerms.length > 0;
+
+    if (facts.forcedOne && hasForcedMany) {
+      const members = uf.members(root);
+      const clampOneMembers = members.filter((p) => directlyClampOne(p, constraints, uf, root));
+      const forceManyMembers = members.filter((p) => directlyForceMany(p, constraints, ports, uf, root));
+      errors.push({
+        kind: 'ClampManyConflict',
+        ports: members,
+        clampOneMembers: clampOneMembers.length > 0 ? clampOneMembers : members,
+        forceManyMembers: forceManyMembers.length > 0 ? forceManyMembers : members,
+        clampOneOrigins: facts.clampOneOrigins,
+        forceManyOrigins: facts.forceManyOrigins,
+        message: 'A port is constrained to both one and many',
+      });
+      continue; // leaves resolved === null; phase 5 skips it
+    }
+
+    if (facts.forcedOne) {
+      facts.resolved = { kind: 'one' };
+      continue;
+    }
+
+    if (hasForcedMany) {
+      facts.resolved = resolveManyTerms(facts.forcedManyTerms, instanceUF, uf.members(root), errors);
+      continue;
+    }
+
+    // No evidence → default one. Announce it only when a variable was in play —
+    // a deliberately concrete-one port is not news. [LAW:no-silent-failure]
+    facts.resolved = { kind: 'one' };
+    if (uf.members(root).some((p) => ports.get(p)?.kind === 'var')) {
+      diagnostics.push({
+        code: 'CardinalityDefaultedToOne',
+        message: 'Cardinality variable defaulted to one (no many evidence)',
+        ports: uf.members(root),
+        origins: [],
+        stableKey: `CardinalityDefaultedToOne:${root}`,
+      });
+    }
+  }
+
+  // --- Phase 4: promoteToMany inner fixpoint -------------------------------
+  const zipSets = constraints
+    .filter((c): c is Extract<ZCardinalityConstraint, { kind: 'promoteToMany' }> => c.kind === 'promoteToMany')
+    .map((c) => [...new Set(c.ports)].sort())
+    .filter((ports2) => ports2.length > 0);
+
+  const isMany = (r: PortKey): boolean => {
+    const res = uf.getFacts(r)?.resolved;
+    return res?.kind === 'manyConcrete' || res?.kind === 'manyVar';
+  };
+  const emittedZipConflicts = new Set<string>();
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const zip of zipSets) {
+      const groupRoots = [...new Set(zip.map((p) => uf.find(p)))];
+      const manyRoots = groupRoots.filter(isMany);
+      if (manyRoots.length === 0) continue;
+
+      // Every many group in a zip must align on one lane set. Unifying their
+      // terms lets a variable adopt a concrete instance; two differing concretes
+      // are a real conflict, reported once per zip. [LAW:no-silent-failure]
+      const lead = uf.getFacts(manyRoots[0])!;
+      let conflicted = false;
+      for (let i = 1; i < manyRoots.length; i++) {
+        const conflict = instanceUF.unify(resolutionToTerm(lead.resolved!), resolutionToTerm(uf.getFacts(manyRoots[i])!.resolved!));
+        if (conflict) {
+          conflicted = true;
+          const key = zip.join(',');
+          if (!emittedZipConflicts.has(key)) {
+            emittedZipConflicts.add(key);
+            errors.push({ kind: 'InstanceConflict', ports: zip, origins: [], message: conflict.conflict });
+          }
+        }
+      }
+      if (conflicted) continue;
+
+      for (const r of groupRoots) {
+        if (isMany(r)) continue;
+        const facts = uf.getFacts(r) ?? uf.getOrCreateFacts(r);
+        // clampOne groups are exempt — they stay one and the runtime zip-promotes
+        // them lane-by-lane; this is the reason no clampOne-in-zip conflict exists.
+        if (facts.forcedOne) continue;
+        if (facts.resolved === null || facts.resolved.kind === 'one') {
+          facts.resolved = cloneManyResolution(lead.resolved!);
+          facts.forcedManyTerms.push(resolutionToTerm(lead.resolved!));
+          changed = true;
+        }
+      }
+    }
+  }
+
+  // --- Phase 5: finalize ---------------------------------------------------
+  const cardinalities = new Map<CardinalityVarId, ZCardinality>();
+  const resolvedVars = instanceUF.resolvedVars();
+
+  for (const root of uf.roots()) {
+    const facts = uf.getFacts(root);
+    if (!facts || facts.resolved === null) continue; // phase-3 conflict groups, already reported
+    const members = uf.members(root);
+
+    const final = finalizeResolution(facts.resolved, members, resolvedVars, inheritInstanceVars, errors);
+    if (final === null) continue;
+
+    for (const port of members) {
+      const axis = ports.get(port);
+      if (axis?.kind !== 'var') continue;
+      mergeSubstitution(cardinalities, axis.var, final);
+    }
+  }
+
+  return { cardinalities, errors, diagnostics };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const directlyClampOne = (
+  port: PortKey,
+  constraints: readonly ZCardinalityConstraint[],
+  uf: CardinalityUF,
+  root: PortKey,
+): boolean =>
+  constraints.some((c) => c.kind === 'clampOne' && c.port === port && uf.find(port) === root);
+
+const directlyForceMany = (
+  port: PortKey,
+  constraints: readonly ZCardinalityConstraint[],
+  ports: ReadonlyMap<PortKey, ZInferenceCardinality>,
+  uf: CardinalityUF,
+  root: PortKey,
+): boolean => {
+  if (uf.find(port) !== root) return false;
+  if (constraints.some((c) => c.kind === 'forceMany' && c.port === port)) return true;
+  return ports.get(port)?.kind === 'many';
+};
+
+/** Unify every many-evidence term, then read the lane set: concrete, or a still-variable group. */
+function resolveManyTerms(
+  terms: readonly InstanceTerm[],
+  instanceUF: InstanceUF,
+  members: readonly PortKey[],
+  errors: CardinalitySolveError[],
+): GroupResolution {
+  const first = terms[0];
+  for (let i = 1; i < terms.length; i++) {
+    const conflict = instanceUF.unify(first, terms[i]);
+    if (conflict) {
+      errors.push({ kind: 'InstanceConflict', ports: members, origins: [], message: conflict.conflict });
+    }
+  }
+  const resolved = instanceUF.resolve(first);
+  return resolved.kind === 'inst'
+    ? { kind: 'manyConcrete', instance: resolved.ref }
+    : { kind: 'manyVar', var: resolved.var };
+}
+
+const resolutionToTerm = (r: GroupResolution): InstanceTerm => {
+  if (r.kind === 'manyConcrete') return { kind: 'inst', ref: r.instance };
+  if (r.kind === 'manyVar') return { kind: 'var', var: r.var };
+  throw new Error('resolutionToTerm called on a one resolution'); // unreachable: callers guard kind
+};
+
+const cloneManyResolution = (r: GroupResolution): GroupResolution => {
+  switch (r.kind) {
+    case 'manyConcrete':
+      return { kind: 'manyConcrete', instance: r.instance };
+    case 'manyVar':
+      return { kind: 'manyVar', var: r.var };
+    case 'one':
+      return { kind: 'one' };
+  }
+};
+
+/** Turn a group resolution into a concrete cardinality, resolving or deferring a variable lane set. */
+function finalizeResolution(
+  resolution: GroupResolution,
+  members: readonly PortKey[],
+  resolvedVars: ReadonlyMap<CardinalityVarId, InstanceRef>,
+  inheritInstanceVars: ReadonlySet<CardinalityVarId> | undefined,
+  errors: CardinalitySolveError[],
+): ZCardinality | null {
+  if (resolution.kind === 'one') return { kind: 'one' };
+  if (resolution.kind === 'manyConcrete') return { kind: 'many', instance: resolution.instance };
+
+  const concrete = resolvedVars.get(resolution.var);
+  if (concrete !== undefined) return { kind: 'many', instance: concrete };
+  if (inheritInstanceVars?.has(resolution.var)) return { kind: 'many', instance: UNBOUND_INSTANCE };
+
+  errors.push({
+    kind: 'UnresolvedInstanceVar',
+    ports: members,
+    origins: [],
+    message: `Cardinality variable ${resolution.var} resolved to many with no instance and no inherit policy`,
+  });
+  return null;
+}
+
+/**
+ * A cardinality variable can surface in more than one group via promoteToMany,
+ * so resolve write conflicts deterministically: many beats one; a concrete lane
+ * set beats the unbound sentinel. [LAW:one-source-of-truth]
+ */
+function mergeSubstitution(
+  out: Map<CardinalityVarId, ZCardinality>,
+  varId: CardinalityVarId,
+  incoming: ZCardinality,
+): void {
+  const existing = out.get(varId);
+  if (existing === undefined) {
+    out.set(varId, incoming);
+    return;
+  }
+  if (existing.kind === 'many' && incoming.kind === 'many') {
+    if (existing.instance === UNBOUND_INSTANCE && incoming.instance !== UNBOUND_INSTANCE) out.set(varId, incoming);
+    return;
+  }
+  if (incoming.kind === 'many') out.set(varId, incoming);
+}

--- a/src/pillars/types/solve/index.ts
+++ b/src/pillars/types/solve/index.ts
@@ -1,0 +1,13 @@
+/**
+ * src/pillars/types/solve/index.ts
+ *
+ * The pure variable-resolution layer: the two sub-solvers, the substitution they
+ * contribute to, and the vocabulary they share. Everything here is a pure
+ * function of its input — the fixpoint driver (wzm3.5) composes these, owning
+ * all graph mutation itself. [LAW:effects-at-boundaries]
+ */
+
+export * from './shared';
+export * from './substitution';
+export * from './payload-unit';
+export * from './cardinality';

--- a/src/pillars/types/solve/payload-unit.ts
+++ b/src/pillars/types/solve/payload-unit.ts
@@ -1,0 +1,613 @@
+/**
+ * src/pillars/types/solve/payload-unit.ts
+ *
+ * The payload + unit sub-solver. Two independent union-finds — one over
+ * payloads, one over units — resolve every port's payload and unit from a flat
+ * constraint set. The primitive is `constraint set → resolution`, never a
+ * pairwise `unify(a, b)`: union-find IS the matching mechanism, so ports that
+ * share a variable land in one group without any explicit equality between them.
+ * [LAW:decomposition]
+ *
+ * Payload and unit differ in exactly one rule, captured as the per-UF `merge`
+ * callback: two distinct concrete payloads conflict (strict), but `none` is a
+ * unit bottom that merges with anything (an unannotated port adopts its
+ * neighbour's unit). That single difference is why one generic `UnionFind<T>`
+ * serves both. [LAW:one-type-per-behavior]
+ *
+ * Pure: same constraints in, same result out, no input mutated. [LAW:effects-at-boundaries]
+ */
+
+import type {
+  PayloadVarId,
+  UnitVarId,
+  ZPayloadType,
+  ZUnitType,
+} from '../schemas';
+import type { ConstraintOrigin, PortKey, SolveDiagnostic } from './shared';
+
+// ---------------------------------------------------------------------------
+// Constraints — the flat input vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * Z-prefixed to keep `grep ZPayloadUnitConstraint` finding only this system and
+ * `grep PayloadUnitConstraint` finding only V1 — the two solvers' constraint
+ * vocabularies must never be confused at a callsite. Six kinds: two equalities
+ * (share a group), two concretes (pin a value), and two requirements (narrow a
+ * group's legal set). [LAW:types-are-the-program]
+ */
+export type ZPayloadUnitConstraint =
+  | { readonly kind: 'payloadEq'; readonly a: PortKey; readonly b: PortKey; readonly origin: ConstraintOrigin }
+  | { readonly kind: 'unitEq'; readonly a: PortKey; readonly b: PortKey; readonly origin: ConstraintOrigin }
+  | { readonly kind: 'concretePayload'; readonly port: PortKey; readonly value: ZPayloadType; readonly origin: ConstraintOrigin }
+  | { readonly kind: 'concreteUnit'; readonly port: PortKey; readonly value: ZUnitType; readonly origin: ConstraintOrigin }
+  | { readonly kind: 'requirePayloadIn'; readonly port: PortKey; readonly allowed: readonly ZPayloadType[]; readonly origin: ConstraintOrigin }
+  | { readonly kind: 'requireUnitless'; readonly port: PortKey; readonly origin: ConstraintOrigin };
+
+/**
+ * The per-port variable identities the solver groups by. A port with a payload
+ * variable shares its payload node with every other port carrying that variable;
+ * a port without one gets a private node. Every port the solver should resolve
+ * must appear here, variable or not — finalization iterates these keys.
+ */
+export interface PortVarInfo {
+  readonly payloadVar?: PayloadVarId;
+  readonly unitVar?: UnitVarId;
+}
+
+/**
+ * A post-solve safety net: after union-find settles, re-check that the two ends
+ * of an edge actually agree. Catches a constraint that was dropped or never
+ * emitted — a mismatch surfaces as a diagnostic rather than silently shipping an
+ * ill-typed edge. The pillar has no `collect` ports, so an edge verification is
+ * one shape: source must agree with target. [LAW:no-silent-failure]
+ */
+export interface EdgeVerification {
+  readonly edgeId: string;
+  readonly from: PortKey;
+  readonly to: PortKey;
+}
+
+export interface PayloadUnitSolveInput {
+  readonly ports: ReadonlyMap<PortKey, PortVarInfo>;
+  readonly constraints: readonly ZPayloadUnitConstraint[];
+  readonly edgeVerifications?: readonly EdgeVerification[];
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export type PayloadUnitErrorKind =
+  | 'ConflictingPayloads'
+  | 'ConflictingUnits'
+  | 'PayloadNotInAllowedSet'
+  | 'UnitlessMismatch'
+  | 'EmptyAllowedSet'
+  | 'UnresolvedPayload'
+  | 'UnresolvedUnit';
+
+/**
+ * Who is at fault, derived solely from the origins that fed the failing group.
+ * The classification is the seam to diagnostics: `UserPatchTypeError` is shown
+ * to the user as "you wired this wrong", `BlockDefTooSpecific` as "this block's
+ * declaration is over-constrained". [FRAMING:representation]
+ */
+export type PayloadUnitErrorClass = 'UserPatchTypeError' | 'BlockDefTooSpecific' | 'Unresolved';
+
+export interface PayloadUnitSolveError {
+  readonly kind: PayloadUnitErrorKind;
+  readonly errorClass: PayloadUnitErrorClass;
+  readonly message: string;
+  readonly ports: readonly PortKey[];
+  readonly origins: readonly ConstraintOrigin[];
+}
+
+export interface PayloadUnitSolveResult {
+  /** var id → resolved payload (shared across every port carrying the var). */
+  readonly payloads: ReadonlyMap<PayloadVarId, ZPayloadType>;
+  readonly units: ReadonlyMap<UnitVarId, ZUnitType>;
+  /** per-port resolution, present for concrete ports too (they carry no var). */
+  readonly portPayloads: ReadonlyMap<PortKey, ZPayloadType>;
+  readonly portUnits: ReadonlyMap<PortKey, ZUnitType>;
+  readonly errors: readonly PayloadUnitSolveError[];
+  readonly diagnostics: readonly SolveDiagnostic[];
+}
+
+// ---------------------------------------------------------------------------
+// UnionFind<T> — tagged parent/value nodes with path compression
+// ---------------------------------------------------------------------------
+
+/**
+ * A node is either a link toward its parent (the self-link is an unresolved
+ * root) or a resolved value (a root holding a concrete payload/unit). The value
+ * lives in the node entry itself rather than a side table, so a value root is
+ * terminal. `merge` decides what happens when two values meet: `null` means
+ * conflict, any value means "these are compatible, here is the combined one".
+ * Keeping the domain rule in a callback is what lets one structure serve both
+ * payload (strict) and unit (none-as-bottom). [LAW:decomposition]
+ */
+type UFEntry<T> = { readonly tag: 'link'; readonly to: string } | { readonly tag: 'value'; readonly value: T };
+
+export type UnionConflict<T> = { readonly conflict: readonly [T, T] };
+export type UnionOk = { readonly winner: string; readonly loser: string | null };
+
+export class UnionFind<T> {
+  private readonly entries = new Map<string, UFEntry<T>>();
+
+  constructor(private readonly merge: (a: T, b: T) => T | null) {}
+
+  private ensure(id: string): void {
+    if (!this.entries.has(id)) this.entries.set(id, { tag: 'link', to: id });
+  }
+
+  /**
+   * The canonical node id for `id`'s group: the node physically holding the
+   * value, or the self-linked root. Path-compresses every link walked so repeat
+   * lookups stay flat. Returns a node id (not the value) because per-group
+   * metadata is keyed by this id outside the structure.
+   */
+  findRoot(id: string): string {
+    this.ensure(id);
+    const walked: string[] = [];
+    let cur = id;
+    for (;;) {
+      const entry = this.entries.get(cur)!;
+      if (entry.tag === 'value' || entry.to === cur) break;
+      walked.push(cur);
+      cur = entry.to;
+    }
+    for (const node of walked) this.entries.set(node, { tag: 'link', to: cur });
+    return cur;
+  }
+
+  resolved(id: string): T | null {
+    const entry = this.entries.get(this.findRoot(id))!;
+    return entry.tag === 'value' ? entry.value : null;
+  }
+
+  /** Pin `id`'s group to a concrete value, merging with any existing one. */
+  assign(id: string, value: T): UnionConflict<T> | null {
+    const root = this.findRoot(id);
+    const entry = this.entries.get(root)!;
+    if (entry.tag === 'value') {
+      const merged = this.merge(entry.value, value);
+      if (merged === null) return { conflict: [entry.value, value] };
+      this.entries.set(root, { tag: 'value', value: merged });
+      return null;
+    }
+    this.entries.set(root, { tag: 'value', value });
+    return null;
+  }
+
+  /**
+   * Unite two groups. A value-bearing root wins so the value survives; when both
+   * carry values they are merged (or conflict). When neither does, the
+   * lexicographically smaller id wins, making output order deterministic. The
+   * loser id is returned so the caller can re-home its per-group metadata onto
+   * the winner. [LAW:no-ambient-temporal-coupling]
+   */
+  union(a: string, b: string): UnionOk | UnionConflict<T> {
+    const rootA = this.findRoot(a);
+    const rootB = this.findRoot(b);
+    if (rootA === rootB) return { winner: rootA, loser: null };
+
+    const entryA = this.entries.get(rootA)!;
+    const entryB = this.entries.get(rootB)!;
+
+    if (entryA.tag === 'value' && entryB.tag === 'value') {
+      const merged = this.merge(entryA.value, entryB.value);
+      if (merged === null) return { conflict: [entryA.value, entryB.value] };
+      this.entries.set(rootB, { tag: 'link', to: rootA });
+      this.entries.set(rootA, { tag: 'value', value: merged });
+      return { winner: rootA, loser: rootB };
+    }
+    if (entryA.tag === 'value') {
+      this.entries.set(rootB, { tag: 'link', to: rootA });
+      return { winner: rootA, loser: rootB };
+    }
+    if (entryB.tag === 'value') {
+      this.entries.set(rootA, { tag: 'link', to: rootB });
+      return { winner: rootB, loser: rootA };
+    }
+    const [winner, loser] = rootA < rootB ? [rootA, rootB] : [rootB, rootA];
+    this.entries.set(loser, { tag: 'link', to: winner });
+    return { winner, loser };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Value equality / merge rules — the one place payload and unit differ
+// ---------------------------------------------------------------------------
+
+/** Every payload member is discriminated solely by `kind`, so kind equality is full equality. */
+const payloadEquals = (a: ZPayloadType, b: ZPayloadType): boolean => a.kind === b.kind;
+
+const unitEquals = (a: ZUnitType, b: ZUnitType): boolean => {
+  if (a.kind !== b.kind) return false;
+  switch (a.kind) {
+    case 'angle':
+      return a.unit === (b as Extract<ZUnitType, { kind: 'angle' }>).unit;
+    case 'time':
+      return a.unit === (b as Extract<ZUnitType, { kind: 'time' }>).unit;
+    case 'color':
+      return a.unit === (b as Extract<ZUnitType, { kind: 'color' }>).unit;
+    case 'space': {
+      const other = b as Extract<ZUnitType, { kind: 'space' }>;
+      return a.space === other.space && a.dims === other.dims;
+    }
+    default:
+      return true; // none | count — discriminated by kind alone
+  }
+};
+
+const payloadMerge = (a: ZPayloadType, b: ZPayloadType): ZPayloadType | null =>
+  payloadEquals(a, b) ? a : null;
+
+/** `none` is the unit bottom: it merges into any concrete unit. Two distinct concretes conflict. */
+const unitMerge = (a: ZUnitType, b: ZUnitType): ZUnitType | null => {
+  if (unitEquals(a, b)) return a;
+  if (a.kind === 'none') return b;
+  if (b.kind === 'none') return a;
+  return null;
+};
+
+const intersectAllowed = (
+  current: readonly ZPayloadType[],
+  incoming: readonly ZPayloadType[],
+): ZPayloadType[] => current.filter((c) => incoming.some((i) => payloadEquals(c, i)));
+
+// ---------------------------------------------------------------------------
+// Per-group metadata
+// ---------------------------------------------------------------------------
+
+interface PayloadGroupMeta {
+  /** null = unconstrained; otherwise the running intersection of allowed sets. */
+  allowedPayloads: readonly ZPayloadType[] | null;
+  allowedOrigins: ConstraintOrigin[];
+}
+
+interface UnitGroupMeta {
+  mustBeUnitless: boolean;
+  unitlessOrigins: ConstraintOrigin[];
+}
+
+// ---------------------------------------------------------------------------
+// Node id scheme — a port's payload/unit node is shared iff it carries that var
+// ---------------------------------------------------------------------------
+
+const payloadNode = (port: PortKey, info: PortVarInfo): string =>
+  info.payloadVar !== undefined ? `pv:${info.payloadVar}` : `pp:${port}`;
+
+const unitNode = (port: PortKey, info: PortVarInfo): string =>
+  info.unitVar !== undefined ? `uv:${info.unitVar}` : `up:${port}`;
+
+const classifyError = (origins: readonly ConstraintOrigin[]): PayloadUnitErrorClass => {
+  if (origins.some((o) => o.kind === 'edge')) return 'UserPatchTypeError';
+  if (origins.some((o) => o.kind === 'payloadMetadata')) return 'BlockDefTooSpecific';
+  return 'Unresolved';
+};
+
+// ---------------------------------------------------------------------------
+// The solve
+// ---------------------------------------------------------------------------
+
+export function solvePayloadUnit(input: PayloadUnitSolveInput): PayloadUnitSolveResult {
+  const { ports, constraints, edgeVerifications = [] } = input;
+
+  const payloadUF = new UnionFind<ZPayloadType>(payloadMerge);
+  const unitUF = new UnionFind<ZUnitType>(unitMerge);
+  const payloadMeta = new Map<string, PayloadGroupMeta>();
+  const unitMeta = new Map<string, UnitGroupMeta>();
+
+  const errors: PayloadUnitSolveError[] = [];
+  const diagnostics: SolveDiagnostic[] = [];
+
+  // Every port becomes a node so finalization can visit it even with no constraint.
+  for (const [port, info] of ports) {
+    payloadUF.findRoot(payloadNode(port, info));
+    unitUF.findRoot(unitNode(port, info));
+  }
+
+  const nodeOfPayload = (port: PortKey): string | null => {
+    const info = ports.get(port);
+    return info ? payloadNode(port, info) : null;
+  };
+  const nodeOfUnit = (port: PortKey): string | null => {
+    const info = ports.get(port);
+    return info ? unitNode(port, info) : null;
+  };
+
+  const payloadMetaFor = (node: string): PayloadGroupMeta => {
+    const root = payloadUF.findRoot(node);
+    let meta = payloadMeta.get(root);
+    if (!meta) {
+      meta = { allowedPayloads: null, allowedOrigins: [] };
+      payloadMeta.set(root, meta);
+    }
+    return meta;
+  };
+  const unitMetaFor = (node: string): UnitGroupMeta => {
+    const root = unitUF.findRoot(node);
+    let meta = unitMeta.get(root);
+    if (!meta) {
+      meta = { mustBeUnitless: false, unitlessOrigins: [] };
+      unitMeta.set(root, meta);
+    }
+    return meta;
+  };
+
+  const pushUnresolvedPort = (kind: 'UnresolvedPayload' | 'UnresolvedUnit', port: PortKey, origin: ConstraintOrigin): void => {
+    errors.push({
+      kind,
+      errorClass: classifyError([origin]),
+      message: `Port ${port} referenced by a constraint is not registered`,
+      ports: [port],
+      origins: [origin],
+    });
+  };
+
+  // --- Phase 1: process constraints in order -------------------------------
+  for (const c of constraints) {
+    switch (c.kind) {
+      case 'concretePayload': {
+        const node = nodeOfPayload(c.port);
+        if (node === null) { pushUnresolvedPort('UnresolvedPayload', c.port, c.origin); break; }
+        const conflict = payloadUF.assign(node, c.value);
+        if (conflict) {
+          errors.push({
+            kind: 'ConflictingPayloads',
+            errorClass: classifyError([c.origin]),
+            message: `Conflicting payloads: ${conflict.conflict[0].kind} vs ${conflict.conflict[1].kind}`,
+            ports: [c.port],
+            origins: [c.origin],
+          });
+        }
+        break;
+      }
+      case 'concreteUnit': {
+        const node = nodeOfUnit(c.port);
+        if (node === null) { pushUnresolvedPort('UnresolvedUnit', c.port, c.origin); break; }
+        const conflict = unitUF.assign(node, c.value);
+        if (conflict) {
+          errors.push({
+            kind: 'ConflictingUnits',
+            errorClass: classifyError([c.origin]),
+            message: `Conflicting units: ${conflict.conflict[0].kind} vs ${conflict.conflict[1].kind}`,
+            ports: [c.port],
+            origins: [c.origin],
+          });
+        }
+        break;
+      }
+      case 'payloadEq': {
+        const a = nodeOfPayload(c.a);
+        const b = nodeOfPayload(c.b);
+        if (a === null) { pushUnresolvedPort('UnresolvedPayload', c.a, c.origin); break; }
+        if (b === null) { pushUnresolvedPort('UnresolvedPayload', c.b, c.origin); break; }
+        mergePayloadGroups(payloadUF, payloadMeta, payloadMetaFor, a, b, c.origin, errors, [c.a, c.b]);
+        break;
+      }
+      case 'unitEq': {
+        const a = nodeOfUnit(c.a);
+        const b = nodeOfUnit(c.b);
+        if (a === null) { pushUnresolvedPort('UnresolvedUnit', c.a, c.origin); break; }
+        if (b === null) { pushUnresolvedPort('UnresolvedUnit', c.b, c.origin); break; }
+        mergeUnitGroups(unitUF, unitMeta, unitMetaFor, a, b, c.origin, errors, [c.a, c.b]);
+        break;
+      }
+      case 'requirePayloadIn': {
+        const node = nodeOfPayload(c.port);
+        if (node === null) { pushUnresolvedPort('UnresolvedPayload', c.port, c.origin); break; }
+        const meta = payloadMetaFor(node);
+        meta.allowedPayloads =
+          meta.allowedPayloads === null ? [...c.allowed] : intersectAllowed(meta.allowedPayloads, c.allowed);
+        meta.allowedOrigins.push(c.origin);
+        break;
+      }
+      case 'requireUnitless': {
+        const node = nodeOfUnit(c.port);
+        if (node === null) { pushUnresolvedPort('UnresolvedUnit', c.port, c.origin); break; }
+        const meta = unitMetaFor(node);
+        meta.mustBeUnitless = true;
+        meta.unitlessOrigins.push(c.origin);
+        break;
+      }
+    }
+  }
+
+  // --- Phase 2: finalization + validation ----------------------------------
+  const payloads = new Map<PayloadVarId, ZPayloadType>();
+  const units = new Map<UnitVarId, ZUnitType>();
+  const portPayloads = new Map<PortKey, ZPayloadType>();
+  const portUnits = new Map<PortKey, ZUnitType>();
+  const validatedPayloadRoots = new Set<string>();
+  const validatedUnitRoots = new Set<string>();
+
+  for (const [port, info] of ports) {
+    // -- Payload --
+    const pNode = payloadNode(port, info);
+    const pRoot = payloadUF.findRoot(pNode);
+    let payload = payloadUF.resolved(pNode);
+    const pMeta = payloadMeta.get(pRoot);
+
+    if (payload === null && pMeta?.allowedPayloads) {
+      if (pMeta.allowedPayloads.length === 1) {
+        payload = pMeta.allowedPayloads[0];
+        payloadUF.assign(pNode, payload);
+      } else if (pMeta.allowedPayloads.length === 0 && !validatedPayloadRoots.has(pRoot)) {
+        validatedPayloadRoots.add(pRoot);
+        errors.push({
+          kind: 'EmptyAllowedSet',
+          errorClass: classifyError(pMeta.allowedOrigins),
+          message: 'No payload type satisfies every constraint on this group',
+          ports: [port],
+          origins: pMeta.allowedOrigins,
+        });
+      }
+    }
+
+    if (payload !== null) {
+      if (!validatedPayloadRoots.has(pRoot)) {
+        validatedPayloadRoots.add(pRoot);
+        if (pMeta?.allowedPayloads && pMeta.allowedPayloads.length > 0 && !pMeta.allowedPayloads.some((a) => payloadEquals(a, payload!))) {
+          errors.push({
+            kind: 'PayloadNotInAllowedSet',
+            errorClass: classifyError(pMeta.allowedOrigins),
+            message: `Resolved payload ${payload.kind} is outside the allowed set {${pMeta.allowedPayloads.map((a) => a.kind).join(', ')}}`,
+            ports: [port],
+            origins: pMeta.allowedOrigins,
+          });
+        }
+      }
+      portPayloads.set(port, payload);
+      if (info.payloadVar !== undefined) payloads.set(info.payloadVar, payload);
+    }
+
+    // -- Unit --
+    const uNode = unitNode(port, info);
+    const uRoot = unitUF.findRoot(uNode);
+    let unit = unitUF.resolved(uNode);
+    const uMeta = unitMeta.get(uRoot);
+
+    if (unit === null && uMeta?.mustBeUnitless) {
+      unit = { kind: 'none' };
+      unitUF.assign(uNode, unit);
+    }
+    if (unit === null && info.unitVar !== undefined) {
+      // A unit variable with no concrete evidence is treated as unitless — the
+      // common case of a polymorphic numeric chain. The decision is announced,
+      // never silent. [LAW:no-silent-failure]
+      unit = { kind: 'none' };
+      unitUF.assign(uNode, unit);
+      if (!validatedUnitRoots.has(uRoot)) {
+        validatedUnitRoots.add(uRoot);
+        diagnostics.push({
+          code: 'UnitDefaultedToNone',
+          message: 'Unit variable defaulted to unitless (no concrete unit evidence)',
+          ports: [port],
+          origins: [],
+          stableKey: `UnitDefaultedToNone:${uRoot}`,
+        });
+      }
+    }
+    if (unit !== null) {
+      if (!validatedUnitRoots.has(uRoot)) {
+        validatedUnitRoots.add(uRoot);
+        if (uMeta?.mustBeUnitless && unit.kind !== 'none') {
+          errors.push({
+            kind: 'UnitlessMismatch',
+            errorClass: classifyError(uMeta.unitlessOrigins),
+            message: `Unit ${unit.kind} where a unitless value is required`,
+            ports: [port],
+            origins: uMeta.unitlessOrigins,
+          });
+        }
+      }
+      portUnits.set(port, unit);
+      if (info.unitVar !== undefined) units.set(info.unitVar, unit);
+    }
+  }
+
+  // --- Phase 3: post-solve edge verification (safety net) ------------------
+  for (const ev of edgeVerifications) {
+    const fromPayload = portPayloads.get(ev.from);
+    const fromUnit = portUnits.get(ev.from);
+    const toPayload = portPayloads.get(ev.to);
+    const toUnit = portUnits.get(ev.to);
+    if (fromPayload === undefined || fromUnit === undefined || toPayload === undefined || toUnit === undefined) continue;
+
+    const payloadOk = payloadEquals(fromPayload, toPayload);
+    const unitOk = unitMerge(fromUnit, toUnit) !== null;
+    if (payloadOk && unitOk) continue;
+
+    diagnostics.push({
+      code: 'PostSolveEdgeTypeMismatch',
+      message: `Edge ${ev.edgeId}: ${fromPayload.kind}/${fromUnit.kind} is incompatible with ${toPayload.kind}/${toUnit.kind}`,
+      ports: [ev.from, ev.to],
+      origins: [{ kind: 'edge', edgeId: ev.edgeId }],
+      stableKey: `PostSolveEdgeTypeMismatch:${ev.edgeId}`,
+    });
+  }
+
+  return { payloads, units, portPayloads, portUnits, errors, diagnostics };
+}
+
+/**
+ * Capture both groups' metadata before the union, then re-home the loser's meta
+ * onto the winner: allowed sets intersect, unitless flags OR, origins concat.
+ * Metadata is keyed by root, and union changes the root, so the merge must
+ * happen here — the moment we know winner and loser. [LAW:one-source-of-truth]
+ */
+function mergePayloadGroups(
+  uf: UnionFind<ZPayloadType>,
+  metaMap: Map<string, PayloadGroupMeta>,
+  metaFor: (node: string) => PayloadGroupMeta,
+  a: string,
+  b: string,
+  origin: ConstraintOrigin,
+  errors: PayloadUnitSolveError[],
+  ports: readonly PortKey[],
+): void {
+  const rootABefore = uf.findRoot(a);
+  const metaA = metaFor(a);
+  const metaB = metaFor(b);
+  const result = uf.union(a, b);
+  if ('conflict' in result) {
+    errors.push({
+      kind: 'ConflictingPayloads',
+      errorClass: classifyError([origin]),
+      message: `Conflicting payloads: ${result.conflict[0].kind} vs ${result.conflict[1].kind}`,
+      ports,
+      origins: [origin],
+    });
+    return;
+  }
+  if (result.loser === null) return;
+  // The value-bearing side wins regardless of id order, so the winner may be b's
+  // group; compare against the root captured before the union, not after.
+  const winnerMeta = result.winner === rootABefore ? metaA : metaB;
+  const loserMeta = winnerMeta === metaA ? metaB : metaA;
+  metaMap.delete(result.loser);
+  if (loserMeta.allowedPayloads) {
+    winnerMeta.allowedPayloads =
+      winnerMeta.allowedPayloads === null
+        ? [...loserMeta.allowedPayloads]
+        : intersectAllowed(winnerMeta.allowedPayloads, loserMeta.allowedPayloads);
+  }
+  winnerMeta.allowedOrigins.push(...loserMeta.allowedOrigins);
+  metaMap.set(result.winner, winnerMeta);
+}
+
+function mergeUnitGroups(
+  uf: UnionFind<ZUnitType>,
+  metaMap: Map<string, UnitGroupMeta>,
+  metaFor: (node: string) => UnitGroupMeta,
+  a: string,
+  b: string,
+  origin: ConstraintOrigin,
+  errors: PayloadUnitSolveError[],
+  ports: readonly PortKey[],
+): void {
+  const rootABefore = uf.findRoot(a);
+  const metaA = metaFor(a);
+  const metaB = metaFor(b);
+  const result = uf.union(a, b);
+  if ('conflict' in result) {
+    errors.push({
+      kind: 'ConflictingUnits',
+      errorClass: classifyError([origin]),
+      message: `Conflicting units: ${result.conflict[0].kind} vs ${result.conflict[1].kind}`,
+      ports,
+      origins: [origin],
+    });
+    return;
+  }
+  if (result.loser === null) return;
+  const winnerMeta = result.winner === rootABefore ? metaA : metaB;
+  const loserMeta = winnerMeta === metaA ? metaB : metaA;
+  metaMap.delete(result.loser);
+  winnerMeta.mustBeUnitless = winnerMeta.mustBeUnitless || loserMeta.mustBeUnitless;
+  winnerMeta.unitlessOrigins.push(...loserMeta.unitlessOrigins);
+  metaMap.set(result.winner, winnerMeta);
+}

--- a/src/pillars/types/solve/shared.ts
+++ b/src/pillars/types/solve/shared.ts
@@ -1,0 +1,58 @@
+/**
+ * src/pillars/types/solve/shared.ts
+ *
+ * Cross-cutting vocabulary the two pure sub-solvers share but neither owns:
+ * the opaque port identity, the provenance an emitted error/diagnostic points
+ * back to, and the diagnostic record itself. Defined once here so payload/unit
+ * and cardinality reference one `ConstraintOrigin` rather than two that drift.
+ * [LAW:one-source-of-truth]
+ *
+ * This module imports nothing from the schema layer — these are solver-machinery
+ * types, not type-algebra. The solvers compose: each consumes a constraint set
+ * (carrying these origins) and returns a substitution fragment plus errors and
+ * diagnostics shaped uniformly here. [LAW:decomposition]
+ */
+
+/**
+ * A port's identity, opaque to the solvers. They only compare it for equality
+ * and use it as a map key; they never parse structure out of it. The concrete
+ * key format (`${nodeId}:${portId}:${dir}` or similar) is owned by the graph /
+ * constraint-extraction layer (wzm3.5) — a value branded there stays assignable
+ * here, so keeping this a bare alias couples nothing. [LAW:decomposition]
+ */
+export type PortKey = string;
+
+/**
+ * Where a constraint came from. Carried on every constraint so an error can be
+ * attributed and classified: an edge origin means the user wired incompatible
+ * types (their patch is wrong); a payloadMetadata origin means a block declared
+ * a polymorphism its concrete value contradicts (the block def is too specific);
+ * anything else is an internal unresolved. The kind is the only field the
+ * classifier reads — the rest is for human-facing diagnostic attribution.
+ * [FRAMING:representation]
+ */
+export type ConstraintOrigin =
+  | { readonly kind: 'edge'; readonly edgeId: string }
+  | { readonly kind: 'blockRule'; readonly blockId: string; readonly rule: string }
+  | { readonly kind: 'portDef'; readonly blockId: string; readonly port: string; readonly dir: 'in' | 'out' }
+  | { readonly kind: 'payloadMetadata'; readonly blockId: string; readonly port: string };
+
+/**
+ * The non-fatal signals a solver emits unconditionally — a defaulting decision
+ * the user might want to know about, or a post-solve edge mismatch the safety
+ * net caught. Severity is NOT decided here; the fixpoint driver (wzm3.5) owns
+ * that. `stableKey` lets the driver dedupe the same signal re-emitted across
+ * iterations without bookkeeping. [LAW:no-silent-failure]
+ */
+export type SolveDiagnosticCode =
+  | 'UnitDefaultedToNone'
+  | 'PostSolveEdgeTypeMismatch'
+  | 'CardinalityDefaultedToOne';
+
+export interface SolveDiagnostic {
+  readonly code: SolveDiagnosticCode;
+  readonly message: string;
+  readonly ports: readonly PortKey[];
+  readonly origins: readonly ConstraintOrigin[];
+  readonly stableKey: string;
+}

--- a/src/pillars/types/solve/substitution.ts
+++ b/src/pillars/types/solve/substitution.ts
@@ -1,0 +1,103 @@
+/**
+ * src/pillars/types/solve/substitution.ts
+ *
+ * The substitution: the accumulated answer both sub-solvers contribute to —
+ * one resolved value per bound variable, in the three (and only three) spaces
+ * the schema mints variables for. `applySubstitution` is the pure walk that
+ * pushes those answers into an inference type.
+ *
+ * The single inference→concrete bridge is NOT here: it is one
+ * `ZCanonicalTypeSchema.safeParse` at the resolver's commit step (wzm3.5). This
+ * file's contract with that bridge is exactly testable — apply a *total*
+ * substitution and the result parses as concrete; apply a *partial* one and a
+ * surviving variable makes the same parse fail. The parse, not a scattered
+ * `kind === 'inst'` check, is the boundary. [LAW:single-enforcer]
+ * [LAW:types-are-the-program]
+ */
+
+import type {
+  CardinalityVarId,
+  PayloadVarId,
+  UnitVarId,
+  ZCardinality,
+  ZInferenceCanonicalType,
+  ZInferenceCardinality,
+  ZInferenceExtent,
+  ZInferencePayloadType,
+  ZInferenceUnitType,
+  ZPayloadType,
+  ZUnitType,
+} from '../schemas';
+
+/**
+ * Per-variable, not per-port: ports that share a variable (a modifier tying its
+ * output field to its input field) resolve through one binding, recorded once.
+ * The three maps mirror the three variable spaces — payload, unit, cardinality.
+ * No fourth space exists because the schema mints no other variables: binding,
+ * perspective, branch, and temporality are default-only or derived.
+ * [LAW:one-source-of-truth]
+ */
+export interface Substitution {
+  readonly payloads: ReadonlyMap<PayloadVarId, ZPayloadType>;
+  readonly units: ReadonlyMap<UnitVarId, ZUnitType>;
+  readonly cardinalities: ReadonlyMap<CardinalityVarId, ZCardinality>;
+}
+
+export const EMPTY_SUBSTITUTION: Substitution = {
+  payloads: new Map(),
+  units: new Map(),
+  cardinalities: new Map(),
+};
+
+/**
+ * Replace every bound variable in `type` with its substitution value. Unbound
+ * variables (absent from the substitution — a partial solve) pass through
+ * unchanged, so the result is still an inference type and may still carry
+ * variables. Totality is the resolver's concern, observed by parsing the output
+ * as `ZCanonicalType`; this function makes no totality claim. [LAW:effects-at-boundaries]
+ *
+ * Variables live at exactly one place per axis: the top level of payload, of
+ * unit, and of the cardinality axis. `angle.unit` is a closed enum in the
+ * landed schema, not a variable slot, so there is no nested-variable recursion
+ * to perform — a nested unit variable is unrepresentable, and code to substitute
+ * one would be unreachable. (Should a later schema child make unit variants
+ * carry variables, the substitution extends there, at the type that gains them.)
+ */
+export function applySubstitution(
+  type: ZInferenceCanonicalType,
+  subst: Substitution,
+): ZInferenceCanonicalType {
+  return {
+    payload: substPayload(type.payload, subst),
+    unit: substUnit(type.unit, subst),
+    extent: substExtent(type.extent, subst),
+  };
+}
+
+const substPayload = (
+  payload: ZInferencePayloadType,
+  subst: Substitution,
+): ZInferencePayloadType =>
+  payload.kind === 'var' ? subst.payloads.get(payload.var) ?? payload : payload;
+
+const substUnit = (unit: ZInferenceUnitType, subst: Substitution): ZInferenceUnitType =>
+  unit.kind === 'var' ? subst.units.get(unit.var) ?? unit : unit;
+
+const substCardinality = (
+  cardinality: ZInferenceCardinality,
+  subst: Substitution,
+): ZInferenceCardinality =>
+  cardinality.kind === 'var'
+    ? subst.cardinalities.get(cardinality.var) ?? cardinality
+    : cardinality;
+
+/**
+ * Cardinality is the only extent axis with a variable form, so it is the only
+ * one substitution touches; the other four pass through structurally. The
+ * spread preserves them without enumerating, so adding a future axis needs no
+ * edit here. [LAW:dataflow-not-control-flow]
+ */
+const substExtent = (extent: ZInferenceExtent, subst: Substitution): ZInferenceExtent => ({
+  ...extent,
+  cardinality: substCardinality(extent.cardinality, subst),
+});


### PR DESCRIPTION
Third link in the wzm3 pillar type-system epic. The two pure variable-resolution engines plus their substitution companion, consuming the wzm3.1 schema layer. No graph mutation — the fixpoint driver (wzm3.5) composes these. `[LAW:effects-at-boundaries]`

## What landed
- **`solve/shared.ts`** — `PortKey` (opaque), `ConstraintOrigin`, `SolveDiagnostic`. The vocabulary both solvers share, defined once. `[LAW:one-source-of-truth]`
- **`solve/substitution.ts`** — `Substitution {payloads,units,cardinalities}`, `EMPTY_SUBSTITUTION`, `applySubstitution`. The inference→concrete bridge is **not** here; it stays the single `ZCanonicalTypeSchema.safeParse` (wzm3.5). The substitution test pins both directions of that boundary. `[LAW:single-enforcer]`
- **`solve/payload-unit.ts`** — generic tagged-node `UnionFind<T>` with a merge callback (one structure serves payload-strict and unit-none-as-bottom); 6-kind `ZPayloadUnitConstraint`; per-group allowed-set/unitless metadata; 3 phases incl. post-solve edge verification.
- **`solve/cardinality.ts`** — `CardinalityUF` + `InstanceUF`; 4-kind `ZCardinalityConstraint`; 5 phases with the promoteToMany inner fixpoint and the clampOne-in-zip exemption; structural (`ClampManyConflict`) vs terminal (`InstanceConflict`/`UnresolvedInstanceVar`) split via one predicate; `UNBOUND_INSTANCE` sentinel.

## Two divergences from the V1 walkthrough (the landed wzm3.1 schema is tighter)
1. **`applySubstitution` replaces only top-level unit vars.** `angle.unit` is a closed enum, not var-capable, per wzm3.1's explicit design — a nested-in-angle unit var is unrepresentable, so code for it would be dead. **Note for wzm3.4:** if a unit-polymorphic adapter needs "any *angle* unit" (vs "any unit" via a top-level var), it requires a schema change to make unit variants carry vars. The concrete UnitCast (radians→degrees) needs no var, so this is likely not a blocker.
2. **`inherit` instance-binding is solver input data** (`inheritInstanceVars`), not a policy field read off the type — the schema carries none. Instance vars reuse `CardinalityVarId`; no separate instance-var space is minted.

Also: no subdomain escape hatch in instance unification (pillar has no subdomain relation); a `many(var)` intermediate is an honest `GroupResolution` state, not a `__var__` magic string smuggled through a concrete `InstanceRef`. `[LAW:types-are-the-program]`

## Verification
- `npx tsc --noEmit | grep src/pillars` — 0 errors
- `npx vitest run src/pillars/types/solve/` — 30/30 (incl. purity); full `src/pillars/` suite 157+ green
- `eslint src/pillars/types/solve/` — clean
- No imports from `src/compiler/frontend/`
- Only depcruise error is the pre-existing render cycle (`ir-node-rules ↔ boundary-contract`, PR #350) — not pillar work