### PR TITLE
docs: correct Migration State — Three fork is the live renderer; Rust/GPU-IR frozen

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,56 +20,42 @@ Oscilla Animator v2 is a browser-based animation editor for creating procedural,
 
 ## Migration State
 
-The codebase is mid-migration via **strangler fig pattern**. The renderer (Rust/WASM/WebGPU) is largely feature complete. The TS↔Rust boundary is ~90% done. The C1 compiler backend that produces GPU payloads from user graphs has ~5% of blocks migrated.
+The codebase is mid-migration via **strangler fig pattern**. The **renderer direction is the "Three fork"**: a three.js (`three@0.184`, TSL) `WebGPURenderer` (`ThreeForkRenderer`) behind the `createWebGPURenderer()` seam, fed by the **pillar compiler** (`src/pillars/`) which lowers an authored patch to a backend-neutral **`ScenePlan`** (`compileScenePlan`). The earlier **Rust/WASM/WebGPU + GPU-IR** renderer and the **`PipelineInstallPayload`** path are **frozen legacy** — operational as a replaceable backend, not extended (the code marks them `FROZEN LEGACY`, e.g. `src/pillars/assembly/payload.ts`). **V1** (backend + JS runtime) is still the **default boot**; the Three path is a `?scenePlan=<id>`-selected steel thread, not yet the default.
 
-### Two Pipelines Coexist
+> **Source of truth for this migration** (these win over older GPU-IR text and ambiguous ticket prose):
+> `design-docs/three-migration-backend-canon.md` · `design-docs/three-migration-renderer-seam-inventory.md` (keep/freeze/delete map) · `design-docs/three-fork-integration-proposal.md`. Tracker epic: `oscilla-pillars-cleanup-ulu`. [LAW:one-source-of-truth]
+
+### Three lineages (one live, one default-but-legacy, one frozen)
 
 ```
-                    ┌─────────────────────────────────────────────────────────┐
-                    │                  SHARED FRONTEND                       │
-  Patch ──► Normalize ──► Type Solve ──► TypedPatch / NormalizedPatch        │
-                    └────────────┬────────────────────┬──────────────────────┘
-                                 │                    │
-                    ┌────────────▼────────┐  ┌───────▼──────────────────────┐
-                    │    V1 BACKEND       │  │    C1 BACKEND (NEW)          │
-                    │    (LEGACY)         │  │                              │
-                    │ DepGraph → SCC →    │  │ TopoSort → Harvest →        │
-                    │ Lower → Schedule    │  │ SinkDiscover → Lower+Fuse → │
-                    │         │           │  │ RosterAssembly               │
-                    │         ▼           │  │         │                    │
-                    │ CompiledProgramIR   │  │ PipelineInstallPayload       │
-                    │         │           │  │         │                    │
-                    │         ▼           │  │         ▼                    │
-                    │ JS Runtime          │  │ Rust/WASM Worker             │
-                    │ (ScheduleExecutor)  │  │ (Naga → WGSL → WebGPU)      │
-                    │         │           │  │         │                    │
-                    │         ▼           │  │         ▼                    │
-                    │ (stub renderer)     │  │ WebGPU Canvas                │
-                    └─────────────────────┘  └──────────────────────────────┘
+  authored Patch
+       │
+       ├─► V1 backend (LEGACY, DEFAULT BOOT) ─► JS Runtime (ScheduleExecutor) ─► stub
+       │
+       ├─► Pillar compiler ─► ScenePlan ─► Three fork renderer (LIVE) ─► WebGPU Canvas
+       │     src/pillars/ · compileScenePlan      ScenePlan → TSL scene graph
+       │     (activated by ?scenePlan=<id>)
+       │
+       └─► [FROZEN] Pillar/C1 ─► PipelineInstallPayload ─► Rust/WASM Worker (Naga → WGSL → WebGPU)
 ```
 
-### What Maps to What
+### Status by area
 
-| Legacy (V1) | New (C1) | Status |
-|---|---|---|
-| `src/compiler/backend/` | `src/compiler/backend-v2/` | C1 has 5-phase pipeline working |
-| `src/blocks/` + `defineBlock()` | `src/blocks-v2/` + `registerC1Block()` | 10 of ~200 blocks migrated |
-| `src/runtime/` (JS frame executor) | Rust renderer (GPU compute+render) | Renderer feature complete |
-| `src/render/Canvas2DRenderer.ts` | Deleted | Canvas2D/SVG removed |
-| `src/render/SVGRenderer.ts` | Deleted | |
-| `src/render/webgpu/` (old facade) | Stub — scorched earth, being rebuilt | |
-| `src/compiler/passes-v2/` | Deleted (excluded from build) | Was an earlier false start |
-| `CompileOrchestrator.ts` (V1 backend) | `compileC1()` / `compileC1FromNormalized()` | C1 entry point standalone |
-
-### Migrated C1 Blocks (`src/blocks-v2/`)
-
-`Const`, `Add`, `Subtract`, `Multiply`, `Divide`, `Sin`, `Cos`, `InfiniteTimeRoot` (Time), `InstanceIndex`, `RenderInstances2D` (sink)
+| Area | Status |
+|---|---|
+| `src/render/webgpu/three/` — ThreeForkRenderer, ScenePlan realizer, TSL | **LIVE — current renderer** |
+| `src/pillars/` + `src/pillars/scene/` (`compileScenePlan`) | **ACTIVE — authored patch → ScenePlan; the open backlog is `pillars-*`** |
+| `compiler/backend/` + `src/blocks/` + `src/runtime/` (V1) | **LEGACY — still the default boot path** |
+| `compiler/backend-v2/` + `src/blocks-v2/`; `src/pillars/compile.ts` + `src/pillars/assembly/` (`PipelineInstallPayload`) | **FROZEN LEGACY** |
+| `src/render/wasm/rust/`, `src/render/rust/`, `src/render/gpu-ir/` (Rust renderer + GPU-IR / Boundary DSL) | **FROZEN LEGACY** |
+| `src/render/Canvas2DRenderer.ts`, `src/render/SVGRenderer.ts`, `src/compiler/passes-v2/` | **DELETED** |
 
 ### Migration Discipline
 
-- **No feature flags** — tests control which pipeline runs, not runtime toggles
-- **Never fix V1 bugs** — energy goes to C1 migration only
-- **Shared frontend stays** — `compiler/frontend/` serves both pipelines
+- **Never fix V1 bugs** — V1 (backend/blocks/runtime) is legacy.
+- **Do not extend the frozen stack** — the Rust/WASM/GPU-IR renderer and the `PipelineInstallPayload` path are frozen. New renderer/compiler work follows **pillar → `ScenePlan` → Three**.
+- **No feature flags** — path selection is `?scenePlan=<id>` (steel thread) vs default V1 boot, plus tests; never runtime toggles.
+- When ticket text or older docs conflict with the canon docs above, the canon docs win. [LAW:one-source-of-truth]
 
 ## Development Commands
 
@@ -264,19 +250,21 @@ See `.claude/rules/spec/invariants.md` for the full list and `.claude/rules/TYPE
 
 ## Common Tasks
 
-### Adding a New C1 Block
+> **Frozen-path warning**: the "Adding a New C1 Block / C1 Sink Block / GPU-IR Fixture" guides below describe the **frozen** Rust/WASM/GPU-IR stack (see Migration State). Do not extend it for new work — current block/renderer work lives in the pillar → `ScenePlan` → Three direction (`src/pillars/`). These remain only as reference for the legacy path.
+
+### Adding a New C1 Block (FROZEN — legacy reference only)
 1. Create `src/blocks-v2/my-block.ts`
 2. Call `registerC1Block('MyBlock', { lower: (ctx) => ... })` — returns `{ kind: 'proxy', outputs: { ... } }` for math blocks
 3. Import in `src/blocks-v2/all.ts`
 4. Add to a compiler-tester fixture to validate visually
 5. Run: `npx vitest run src/compiler/backend-v2/__tests__/`
 
-### Adding a New C1 Sink Block
+### Adding a New C1 Sink Block (FROZEN — legacy reference only)
 1. Create `src/blocks-v2/my-sink.ts`
 2. Register with `isSink: true`, implement `manifestRequirements()` for GPU resources, `lower()` returns `{ kind: 'sink', injectedPasses: [...] }`
 3. Passes can be `ComputePassSpec`, `SystemPassSpec`, or `RenderPassSpec`
 
-### Adding a GPU-IR Fixture (Boundary DSL)
+### Adding a GPU-IR Fixture (Boundary DSL) (FROZEN — legacy reference only)
 1. Create `src/render/rust/fixtures/my-fixture.ts`
 2. Use `gpu({ manifest, roster })` with `compute()` / `render()` helpers
 3. Export from `src/render/rust/fixtures/index.ts`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,25 +4,27 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 > **Full architectural guide**: `.claude/CLAUDE.md` — comprehensive layer-by-layer breakdown, design patterns, invariants, and common task guides. Read that before making significant changes.
 >
-> **DSL reference**: `docs/DSLs.md` — the five DSLs (Boundary IR, Boundary DSL, Naga DSL, Block DSL, Patch DSL) with entry points and key files.
+> **DSL reference**: `docs/DSLs.md` — the five DSLs (Boundary IR, Boundary DSL, Naga DSL, Block DSL, Patch DSL). Note: Boundary IR/DSL and Naga DSL describe the **frozen** GPU-IR renderer (see Migration State); Block DSL and Patch DSL remain current.
 
 ## Migration State (READ THIS FIRST)
 
-The codebase is mid-migration via strangler fig pattern. Two compilation pipelines coexist:
+The codebase is mid-migration via strangler fig. The **renderer direction is the "Three fork"**: a three.js (`three@0.184`, TSL) `WebGPURenderer` (`ThreeForkRenderer`) lives behind the `createWebGPURenderer()` seam in `src/render/webgpu/`, fed by the **pillar compiler** (`src/pillars/`), which lowers an authored patch into a backend-neutral **`ScenePlan`** (`compileScenePlan`). The earlier **Rust/WASM/WebGPU + GPU-IR** renderer and the **`PipelineInstallPayload`** path are now **frozen legacy** — operational as a replaceable backend, not extended (the code itself marks them `FROZEN LEGACY`, e.g. `src/pillars/assembly/payload.ts`; the Rust install call in `RuntimeService` is commented out).
 
-| System | Status | Path |
-|--------|--------|------|
-| **V1 backend** (`compiler/backend/`) | **LEGACY — being replaced** | Frontend → Backend → JS Runtime → (stub renderer) |
-| **C1 backend** (`compiler/backend-v2/`) | **NEW — ~5% block coverage** | Frontend → C1 Backend → PipelineInstallPayload → Rust/WASM → WebGPU |
-| **Compiler frontend** (`compiler/frontend/`) | **SHARED** — used by both pipelines | |
-| **V1 blocks** (`src/blocks/`) | **LEGACY** — only for V1 backend lowering | |
-| **C1 blocks** (`src/blocks-v2/`) | **NEW** — 10 blocks migrated so far | |
-| **V1 runtime** (`src/runtime/`) | **LEGACY** — JS frame executor | |
-| **Rust renderer** (`src/render/wasm/rust/`) | **NEW — feature complete** | WebGPU render worker |
-| **WebGPU facade** (`src/render/webgpu/`) | **STUB** — deleted during scorched earth, being rebuilt | |
+> **Source of truth for this migration** (these win over older GPU-IR docs and ambiguous ticket prose):
+> `design-docs/three-migration-backend-canon.md` · `design-docs/three-migration-renderer-seam-inventory.md` (keep/freeze/delete map) · `design-docs/three-fork-integration-proposal.md`. Tracker: epic `oscilla-pillars-cleanup-ulu`.
+
+| System | Status | Notes |
+|--------|--------|-------|
+| **Three fork renderer** (`src/render/webgpu/three/`) | **LIVE — the direction** | three.js `WebGPURenderer`; pure `ScenePlan` → TSL scene-graph realizer; constructed at the `createWebGPURenderer` seam, driven from `RuntimeService` |
+| **Pillar compiler → ScenePlan** (`src/pillars/`, `src/pillars/scene/`) | **ACTIVE** | authored patch → `ScenePlan` (`compileScenePlan`); the active backlog lives in the `pillars-*` epics |
+| **V1 backend / blocks / runtime** (`compiler/backend/`, `src/blocks/`, `src/runtime/`) | **LEGACY — still the default boot** | JS frame executor; the app boots this unless `?scenePlan=<id>` selects the Three steel thread |
+| **C1 backend / blocks-v2 + pillar `PipelineInstallPayload`** (`compiler/backend-v2/`, `src/blocks-v2/`, `src/pillars/compile.ts`, `src/pillars/assembly/`) | **FROZEN LEGACY** | targeted the Rust renderer; superseded by the ScenePlan path |
+| **Rust renderer + GPU-IR / Boundary DSL** (`src/render/wasm/rust/`, `src/render/rust/`, `src/render/gpu-ir/`) | **FROZEN LEGACY** | operational, not extended — do not add to it |
 | **Canvas2D / SVG renderers** | **DELETED** | |
 
-**Rules for legacy code**: Never fix bugs in V1 backend, V1 blocks, or V1 runtime. They are dead code being replaced. New work goes in `backend-v2/` and `blocks-v2/`.
+**Default boot is still V1.** The Three path activates via `?scenePlan=<id>` (a steel thread proven for two demos: Grid of Squares, Textured Tiles); promoting it to the default is remaining migration work (`oscilla-pillars-cleanup-ulu`).
+
+**Rules for legacy code**: Never fix bugs in V1 (backend/blocks/runtime). Treat the Rust/WASM/GPU-IR stack and the `PipelineInstallPayload` path (incl. C1 `backend-v2` and `src/pillars/compile.ts` / `src/pillars/assembly/`) as **frozen** — do not extend them. New renderer/compiler work follows **pillar → `ScenePlan` → Three** (see the canon docs above).
 
 ## Development Commands
 


### PR DESCRIPTION
## Why
Both `CLAUDE.md` and `.claude/CLAUDE.md` described the **Rust/WASM/WebGPU + C1 GPU-IR** stack as the *"NEW, feature-complete"* renderer direction, and `src/render/webgpu/` as a *"deleted stub being rebuilt."* That is stale and actively misleading — it points every reading agent (and human) at the **abandoned** backend. `[LAW:one-source-of-truth]`: the authoritative onboarding doc was contradicting the migration canon and the code.

## Reality (per `design-docs/three-migration-*` canon + confirmed in code)
- The **"Three fork"** — a three.js (`three@0.184`, TSL) `WebGPURenderer` (`ThreeForkRenderer`) behind the `createWebGPURenderer()` seam — is the **LIVE** renderer, fed by the **pillar compiler** (`src/pillars/`, `compileScenePlan`) which lowers an authored patch to a backend-neutral **`ScenePlan`**. Wired in `RuntimeService` (`RuntimeService.ts:412`), activated via `?scenePlan=<id>`.
- The **Rust/WASM/WebGPU renderer + GPU-IR/Boundary DSL** and the **`PipelineInstallPayload`** path are **FROZEN LEGACY** — the code itself says so (`src/pillars/assembly/payload.ts`), and the Rust install call in `RuntimeService` is commented out (`TODO: Rebuild...`).
- **V1** (backend + JS runtime) is still the **default boot**; the Three path is a steel thread proven for two demos (Grid of Squares, Textured Tiles), not yet the default.

## Changes (docs only)
- Rewrote both Migration State sections: new intro, status table, three-lineage diagram (live / default-but-legacy / frozen), discipline rules.
- Both now cite the canon docs + epic `oscilla-pillars-cleanup-ulu` as the source of truth.
- Flagged the C1-block / GPU-IR-fixture "Common Tasks" guides as **FROZEN — legacy reference** so they don't lure new work onto the dead path.
- Noted in the DSL reference that Boundary IR/DSL + Naga DSL describe the frozen renderer.

Surfaced while answering "where is the three.js migration work?" — independent of the wzm3.3 solver PR (#371).