### PR TITLE
feat(pillars-types wzm3.4): ZAdapterSpec + findAdapterCandidates pure helper

### DIFF
--- a/src/pillars/block-api.ts
+++ b/src/pillars/block-api.ts
@@ -36,6 +36,7 @@ import type {
   TextureSpec,
 } from '../render/rust/boundary-contract';
 import type {
+  ZAdapterSpec,
   ZBlockContract,
   ZCombineMode,
   ZInferenceBundleType,
@@ -288,6 +289,16 @@ export interface BlockDefinition<TConfig, TLowerArgs> {
   readonly contract?: ZBlockContract;
 
   /**
+   * Present iff this block is an adapter — a one-in/one-out conversion the type
+   * system may auto-insert to bridge an incompatible edge. It is block-role
+   * metadata at the same altitude as `type`, NOT part of the port type surface,
+   * so it lives here rather than inside `contract`. The adapter search reads it
+   * to filter the catalog; a block without it is never an insertion candidate.
+   * [LAW:decomposition]
+   */
+  readonly adapterSpec?: ZAdapterSpec;
+
+  /**
    * FRONTEND-ONLY. Validates and narrows raw user-supplied config.
    *
    * Contract:
@@ -342,6 +353,21 @@ export interface BlockDefinition<TConfig, TLowerArgs> {
    * the walker calls without ever seeing what's inside.
    */
   readonly lower: (args: TLowerArgs, ctx: LoweringContext) => LoweredBlock;
+}
+
+/**
+ * The read-only catalog projection of a block — exactly the slice the type
+ * system's pure passes (adapter search, insert-menu query) consult, and nothing
+ * more. It names only the covariant data fields, never `lower`/`readConfig`, so
+ * a `BlockDefinition<TConfig, TLowerArgs>` for ANY config is structurally
+ * assignable (the existing `ALL_BLOCKS: BlockDefinition<unknown, unknown>[]`
+ * passes straight through) while a pure search depends on no closures it does
+ * not call. [LAW:decomposition]
+ */
+export interface DefinedBlock {
+  readonly type: string;
+  readonly contract?: ZBlockContract;
+  readonly adapterSpec?: ZAdapterSpec;
 }
 
 // ---------------------------------------------------------------------------
@@ -427,6 +453,8 @@ export function defineBlock<
   readonly config: TConfig;
   readonly inputs: TInputs;
   readonly outputs: TOutputs;
+  /** Present iff this block is an adapter; rides through onto the definition. */
+  readonly adapterSpec?: ZAdapterSpec;
   readonly manifest?: (config: z.infer<TConfig>) => ManifestContribution;
   readonly lower: (
     config: z.infer<TConfig>,
@@ -441,6 +469,7 @@ export function defineBlock<
   return {
     type: spec.type,
     contract,
+    ...(spec.adapterSpec !== undefined ? { adapterSpec: spec.adapterSpec } : {}),
     readConfig: (raw, diagnostics) => {
       const parsed = spec.config.safeParse(raw);
       if (parsed.success) return parsed.data;

--- a/src/pillars/types/schemas.ts
+++ b/src/pillars/types/schemas.ts
@@ -284,6 +284,25 @@ export const ZBlockContractSchema = z.object({
 });
 export type ZBlockContract = z.infer<typeof ZBlockContractSchema>;
 
+/**
+ * Marks a block as an adapter — a one-in/one-out conversion the type system may
+ * insert to bridge an otherwise-incompatible edge. There is NO adapter registry
+ * and NO pattern dialect: an adapter is a regular block whose polymorphism is
+ * expressed in its ports' `ZInferenceCanonicalType` variables, and "find an
+ * adapter" is unification over the catalog. So the only data an adapter spec
+ * carries beyond the block's existing contract is human-facing description plus
+ * a tiebreak priority. [LAW:one-type-per-behavior] [LAW:no-mode-explosion]
+ *
+ * `priority` is lower-is-preferred (default 0), the deterministic tiebreak when
+ * several adapters unify the same edge. It is data on the type, never a mode the
+ * search branches on.
+ */
+export const ZAdapterSpecSchema = z.object({
+  description: z.string(),
+  priority: z.number().int().optional(),
+});
+export type ZAdapterSpec = z.infer<typeof ZAdapterSpecSchema>;
+
 // ---------------------------------------------------------------------------
 // Constructors — produce inference types ergonomically
 // ---------------------------------------------------------------------------

--- a/src/pillars/types/solve/__tests__/adapters.test.ts
+++ b/src/pillars/types/solve/__tests__/adapters.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Adapter search is unification over the catalog, not a registry lookup or a
+ * pattern match. These tests pin that: an adapter matches iff the sub-solvers
+ * unify both its endpoints, the binding it required is reported as the
+ * candidate's substitution, and unmarked blocks are invisible to the search.
+ * [LAW:one-type-per-behavior] [LAW:effects-at-boundaries]
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  canonical,
+  zFloat,
+  oneExtent,
+  manyExtent,
+  payloadVar,
+  unitVar,
+  cardinalityVar,
+  payloadVarId,
+  unitVarId,
+  cardinalityVarId,
+  instanceRef,
+  type ZAdapterSpec,
+  type ZInferenceCanonicalType,
+} from '../../schemas';
+import type { DefinedBlock } from '../../../block-api';
+import { findAdapterCandidates } from '../adapters';
+
+// --- catalog builders ------------------------------------------------------
+
+/** A one-in/one-out adapter block over single-field bundles. */
+const adapter = (
+  type: string,
+  inputField: ZInferenceCanonicalType,
+  outputField: ZInferenceCanonicalType,
+  spec: ZAdapterSpec = { description: type },
+): DefinedBlock => ({
+  type,
+  adapterSpec: spec,
+  contract: {
+    inputs: { in: { id: 'in', dir: 'in', type: { value: inputField } } },
+    outputs: { out: { id: 'out', dir: 'out', type: { value: outputField } } },
+  },
+});
+
+/** A structurally-identical block that is NOT marked as an adapter. */
+const plainBlock = (
+  type: string,
+  inputField: ZInferenceCanonicalType,
+  outputField: ZInferenceCanonicalType,
+): DefinedBlock => ({
+  type,
+  contract: {
+    inputs: { in: { id: 'in', dir: 'in', type: { value: inputField } } },
+    outputs: { out: { id: 'out', dir: 'out', type: { value: outputField } } },
+  },
+});
+
+// --- canonical-type helpers ------------------------------------------------
+
+const degrees = (): ZInferenceCanonicalType =>
+  canonical({ kind: 'float' }, { unit: { kind: 'angle', unit: 'degrees' } });
+const radians = (): ZInferenceCanonicalType =>
+  canonical({ kind: 'float' }, { unit: { kind: 'angle', unit: 'radians' } });
+const seconds = (): ZInferenceCanonicalType =>
+  canonical({ kind: 'float' }, { unit: { kind: 'time', unit: 'seconds' } });
+
+describe('findAdapterCandidates', () => {
+  it('matches an exact concrete adapter with an empty substitution', () => {
+    const catalog = [adapter('DegToRad', degrees(), radians())];
+    const result = findAdapterCandidates(degrees(), radians(), catalog);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].blockType).toBe('DegToRad');
+    expect(result[0].inputSlot).toBe('in');
+    expect(result[0].outputSlot).toBe('out');
+    expect(result[0].substitution.payloads.size).toBe(0);
+    expect(result[0].substitution.units.size).toBe(0);
+    expect(result[0].substitution.cardinalities.size).toBe(0);
+  });
+
+  it('binds the variables of a polymorphic UnitCast {P, U_in} → {P, U_out}', () => {
+    const unitCast = adapter(
+      'UnitCast',
+      canonical(payloadVar('P'), { unit: unitVar('U_in') }),
+      canonical(payloadVar('P'), { unit: unitVar('U_out') }),
+    );
+    const result = findAdapterCandidates(radians(), degrees(), [unitCast]);
+
+    expect(result).toHaveLength(1);
+    const { substitution } = result[0];
+    expect(substitution.payloads.get(payloadVarId('P'))).toEqual({ kind: 'float' });
+    expect(substitution.units.get(unitVarId('U_in'))).toEqual({ kind: 'angle', unit: 'radians' });
+    expect(substitution.units.get(unitVarId('U_out'))).toEqual({ kind: 'angle', unit: 'degrees' });
+  });
+
+  describe('unit discriminator sensitivity', () => {
+    // The ticket's "nested var inside a concrete variant" ({kind:'angle', unit:
+    // <var>}) is unrepresentable in the landed schema — `angle.unit` is a closed
+    // enum, and the only unit variable is the top-level one. So these cover the
+    // realizable form of that intent: a TOP-LEVEL unit var adopts a concrete
+    // structured unit, and a differing unit discriminator refuses to match.
+    // (Nested-variant variables await the wzm3.10 axis-representation decision.)
+    it('binds a top-level unit var to the structured unit of a concrete source', () => {
+      const normalize = adapter(
+        'ToRadians',
+        canonical({ kind: 'float' }, { unit: unitVar('U') }),
+        radians(),
+      );
+      const result = findAdapterCandidates(degrees(), radians(), [normalize]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].substitution.units.get(unitVarId('U'))).toEqual({
+        kind: 'angle',
+        unit: 'degrees',
+      });
+    });
+
+    it('does not match when the unit discriminator differs (angle input vs time source)', () => {
+      const catalog = [adapter('DegToRad', degrees(), radians())];
+      expect(findAdapterCandidates(seconds(), radians(), catalog)).toEqual([]);
+    });
+  });
+
+  it('returns nothing when no adapter bridges the edge', () => {
+    const catalog = [adapter('DegToRad', degrees(), radians())];
+    // Source is seconds — incompatible with the degrees input field.
+    expect(findAdapterCandidates(seconds(), radians(), catalog)).toEqual([]);
+  });
+
+  it('sorts matches by priority ascending (default 0), tiebreaking on blockType', () => {
+    const pass = (): ZInferenceCanonicalType => zFloat();
+    const catalog = [
+      adapter('B_high', pass(), pass(), { description: 'b', priority: 10 }),
+      adapter('C_low', pass(), pass(), { description: 'c', priority: 1 }),
+      adapter('A_low', pass(), pass(), { description: 'a', priority: 1 }),
+      adapter('D_default', pass(), pass(), { description: 'd' }), // priority undefined ⇒ 0
+    ];
+    const result = findAdapterCandidates(zFloat(), zFloat(), catalog);
+
+    expect(result.map((c) => c.blockType)).toEqual(['D_default', 'A_low', 'C_low', 'B_high']);
+  });
+
+  it('binds a cardinality var for a one → many broadcast adapter', () => {
+    const broadcast = adapter(
+      'Broadcast',
+      canonical(payloadVar('P'), { unit: unitVar('U') }),
+      canonical(payloadVar('P'), {
+        unit: unitVar('U'),
+        extent: { ...oneExtent(), cardinality: cardinalityVar('C') },
+      }),
+    );
+    const source = zFloat(); // cardinality one
+    const target = canonical({ kind: 'float' }, { extent: manyExtent(instanceRef('dots')) });
+    const result = findAdapterCandidates(source, target, [broadcast]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].substitution.cardinalities.get(cardinalityVarId('C'))).toEqual({
+      kind: 'many',
+      instance: 'dots',
+    });
+  });
+
+  it('never considers a block without an adapterSpec, even if it would unify', () => {
+    const catalog = [
+      plainBlock('PlainPassthrough', zFloat(), zFloat()),
+      adapter('RealAdapter', zFloat(), zFloat()),
+    ];
+    const result = findAdapterCandidates(zFloat(), zFloat(), catalog);
+
+    expect(result.map((c) => c.blockType)).toEqual(['RealAdapter']);
+  });
+
+  it('throws when an adapter-marked block violates the one-in/one-out shape', () => {
+    const malformed: DefinedBlock = {
+      type: 'TwoInputs',
+      adapterSpec: { description: 'malformed' },
+      contract: {
+        inputs: {
+          a: { id: 'a', dir: 'in', type: { value: zFloat() } },
+          b: { id: 'b', dir: 'in', type: { value: zFloat() } },
+        },
+        outputs: { out: { id: 'out', dir: 'out', type: { value: zFloat() } } },
+      },
+    };
+    expect(() => findAdapterCandidates(zFloat(), zFloat(), [malformed])).toThrow(
+      /exactly one input slot/,
+    );
+  });
+});

--- a/src/pillars/types/solve/adapters.ts
+++ b/src/pillars/types/solve/adapters.ts
@@ -1,0 +1,227 @@
+/**
+ * src/pillars/types/solve/adapters.ts
+ *
+ * Adapter search: "which adapter blocks could bridge a `source` value into a
+ * `target` slot?" An adapter is NOT a registry entry and carries NO pattern
+ * dialect — it is a regular block marked with a `ZAdapterSpec` whose
+ * polymorphism is expressed in its ports' `ZInferenceCanonicalType` variables.
+ * So the search is plain iteration over adapter-marked catalog blocks, each
+ * attempt a unification run through the wzm3.3 sub-solvers. There is no public
+ * `unify(a, b)` API and no separate pattern-matching dialect: the matching
+ * primitive is a flat constraint set fed to the solvers, exactly as graph
+ * edges will be.
+ * [LAW:one-type-per-behavior] [LAW:no-mode-explosion]
+ *
+ * Pure: a function of (source, target, catalog) only — it computes candidates,
+ * it never mutates a graph. Inserting a chosen adapter is the fixpoint child's
+ * job (wzm3.5); ranking many candidates for a menu is the query child's
+ * (wzm3.6). [LAW:effects-at-boundaries]
+ *
+ * One unification, not two passes. The ticket frames matching as "unify source
+ * against the input field, THEN target against the output field starting from
+ * the first substitution." A modifier-style adapter ties its input and output
+ * fields by SHARING a variable (e.g. UnitCast's `{P, U_in} → {P, U_out}` shares
+ * `P`), so both edges belong in ONE solve: the shared variable lands the four
+ * endpoints in one union-find group, and a binding proven on the source side is
+ * automatically in force on the target side. Running them as one symmetric solve
+ * is what correctly REJECTS an identity-payload passthrough asked to convert
+ * float→int — the shared `P` group sees both concretes and conflicts. [LAW:decomposition]
+ *
+ * Unit polymorphism is expressible only at the TOP LEVEL of a unit
+ * (`{kind:'var', var}` = "any unit"), never nested inside a concrete variant
+ * (`{kind:'angle', unit: <var>}` = "any angle unit"). The landed schema makes
+ * `angle.unit` a closed enum, so a nested unit variable is unrepresentable; the
+ * V1 walkthrough §7's nested illustration awaits a schema decision (wzm3.10).
+ * Concrete adapters (radians→degrees) need no variable, and a pure passthrough
+ * uses a top-level unit var, so the first adapters are unaffected.
+ */
+
+import type {
+  ZAdapterSpec,
+  ZInferenceCanonicalType,
+  ZInferenceCardinality,
+  ZPayloadType,
+  ZPortBinding,
+  ZUnitType,
+} from '../schemas';
+import type { DefinedBlock } from '../../block-api';
+import type { Substitution } from './substitution';
+import { solvePayloadUnit, type PortVarInfo, type ZPayloadUnitConstraint } from './payload-unit';
+import { solveCardinality, type ZCardinalityConstraint } from './cardinality';
+import type { ConstraintOrigin, PortKey } from './shared';
+
+/**
+ * One way to bridge `source → target`: the adapter block that does it, the
+ * single slots it reads/writes, and the substitution that makes its polymorphic
+ * ports fit this particular edge. The substitution is the unification's whole
+ * answer — the resolver applies it to instantiate the inserted adapter's ports.
+ */
+export interface AdapterCandidate {
+  readonly blockType: string;
+  readonly inputSlot: string;
+  readonly outputSlot: string;
+  readonly substitution: Substitution;
+  readonly spec: ZAdapterSpec;
+}
+
+// The four endpoints of one unification, as opaque solver port keys.
+const SRC: PortKey = 'src';
+const IN: PortKey = 'in';
+const TGT: PortKey = 'tgt';
+const OUT: PortKey = 'out';
+
+/**
+ * Every adapter-marked block whose input field unifies with `source` and whose
+ * output field unifies with `target`, ranked by `spec.priority` ascending
+ * (lower = preferred) with a lexicographic `blockType` tiebreak for total
+ * determinism. Blocks without an `adapterSpec` are never considered, even if
+ * their ports would structurally unify. [LAW:no-silent-failure]
+ *
+ * Throws if an adapter-marked block violates the adapter shape invariant
+ * (exactly one input slot, one output slot, each carrying exactly one field) —
+ * a malformed adapter is a block-definition bug, surfaced loudly rather than
+ * silently skipped.
+ */
+export function findAdapterCandidates(
+  source: ZInferenceCanonicalType,
+  target: ZInferenceCanonicalType,
+  catalog: readonly DefinedBlock[],
+): readonly AdapterCandidate[] {
+  const candidates: AdapterCandidate[] = [];
+
+  for (const block of catalog) {
+    if (block.adapterSpec === undefined) continue;
+    const ports = lonePorts(block);
+    const substitution = tryUnify(source, ports.inputField, target, ports.outputField, block.type);
+    if (substitution === null) continue;
+    candidates.push({
+      blockType: block.type,
+      inputSlot: ports.inputSlot,
+      outputSlot: ports.outputSlot,
+      substitution,
+      spec: block.adapterSpec,
+    });
+  }
+
+  return candidates.sort(compareCandidates);
+}
+
+/**
+ * The private unification primitive: build one flat constraint set tying the
+ * source to the adapter's input field and the target to its output field, run
+ * both sub-solvers, and return the merged substitution — or `null` if either
+ * solver reports an error (a mismatch the adapter cannot bridge). Deliberately
+ * NOT exported: callers want "find adapters", never a general `unify(a, b)`.
+ */
+function tryUnify(
+  source: ZInferenceCanonicalType,
+  inputField: ZInferenceCanonicalType,
+  target: ZInferenceCanonicalType,
+  outputField: ZInferenceCanonicalType,
+  blockType: string,
+): Substitution | null {
+  const origin: ConstraintOrigin = { kind: 'blockRule', blockId: blockType, rule: 'adapter-unify' };
+
+  // --- payload + unit ---
+  const puPorts = new Map<PortKey, PortVarInfo>();
+  const puConstraints: ZPayloadUnitConstraint[] = [];
+  const register = (port: PortKey, t: ZInferenceCanonicalType): void => {
+    puPorts.set(port, varInfo(t));
+    if (t.payload.kind !== 'var') {
+      const value: ZPayloadType = t.payload;
+      puConstraints.push({ kind: 'concretePayload', port, value, origin });
+    }
+    if (t.unit.kind !== 'var') {
+      const value: ZUnitType = t.unit;
+      puConstraints.push({ kind: 'concreteUnit', port, value, origin });
+    }
+  };
+  register(SRC, source);
+  register(IN, inputField);
+  register(TGT, target);
+  register(OUT, outputField);
+  puConstraints.push(
+    { kind: 'payloadEq', a: SRC, b: IN, origin },
+    { kind: 'unitEq', a: SRC, b: IN, origin },
+    { kind: 'payloadEq', a: TGT, b: OUT, origin },
+    { kind: 'unitEq', a: TGT, b: OUT, origin },
+  );
+  const pu = solvePayloadUnit({ ports: puPorts, constraints: puConstraints });
+  if (pu.errors.length > 0) return null;
+
+  // --- cardinality ---
+  const cardPorts = new Map<PortKey, ZInferenceCardinality>([
+    [SRC, source.extent.cardinality],
+    [IN, inputField.extent.cardinality],
+    [TGT, target.extent.cardinality],
+    [OUT, outputField.extent.cardinality],
+  ]);
+  const cardConstraints: ZCardinalityConstraint[] = [
+    { kind: 'equal', a: SRC, b: IN, origin },
+    { kind: 'equal', a: TGT, b: OUT, origin },
+  ];
+  const card = solveCardinality({ ports: cardPorts, constraints: cardConstraints });
+  if (card.errors.length > 0) return null;
+
+  return { payloads: pu.payloads, units: pu.units, cardinalities: card.cardinalities };
+}
+
+/**
+ * A port's variable identities for the payload/unit solver, built so an absent
+ * variable is an absent key (never `{ payloadVar: undefined }`) to satisfy
+ * exact-optional typing. A non-variable axis contributes no key here; its
+ * concrete value is pinned by a separate `concrete*` constraint.
+ */
+const varInfo = (t: ZInferenceCanonicalType): PortVarInfo => ({
+  ...(t.payload.kind === 'var' ? { payloadVar: t.payload.var } : {}),
+  ...(t.unit.kind === 'var' ? { unitVar: t.unit.var } : {}),
+});
+
+interface LonePorts {
+  readonly inputSlot: string;
+  readonly inputField: ZInferenceCanonicalType;
+  readonly outputSlot: string;
+  readonly outputField: ZInferenceCanonicalType;
+}
+
+/** Enforce + extract the one-in/one-out, one-field-each adapter shape. */
+function lonePorts(block: DefinedBlock): LonePorts {
+  const contract = block.contract;
+  if (contract === undefined) {
+    throw new Error(
+      `Adapter block '${block.type}' has an adapterSpec but no contract; an adapter must declare typed ports.`,
+    );
+  }
+  const [inputSlot, inputField] = loneSlotField(block.type, contract.inputs, 'input');
+  const [outputSlot, outputField] = loneSlotField(block.type, contract.outputs, 'output');
+  return { inputSlot, inputField, outputSlot, outputField };
+}
+
+function loneSlotField(
+  blockType: string,
+  slots: Readonly<Record<string, ZPortBinding>>,
+  dir: 'input' | 'output',
+): [string, ZInferenceCanonicalType] {
+  const entries = Object.entries(slots);
+  if (entries.length !== 1) {
+    throw new Error(
+      `Adapter block '${blockType}' must have exactly one ${dir} slot, found ${entries.length}.`,
+    );
+  }
+  const [slot, binding] = entries[0];
+  const fields = Object.entries(binding.type);
+  if (fields.length !== 1) {
+    throw new Error(
+      `Adapter block '${blockType}' ${dir} slot '${slot}' must carry exactly one field, found ${fields.length}.`,
+    );
+  }
+  return [slot, fields[0][1]];
+}
+
+const priorityOf = (spec: ZAdapterSpec): number => spec.priority ?? 0;
+
+const compareCandidates = (a: AdapterCandidate, b: AdapterCandidate): number => {
+  const byPriority = priorityOf(a.spec) - priorityOf(b.spec);
+  if (byPriority !== 0) return byPriority;
+  return a.blockType < b.blockType ? -1 : a.blockType > b.blockType ? 1 : 0;
+};

--- a/src/pillars/types/solve/index.ts
+++ b/src/pillars/types/solve/index.ts
@@ -11,3 +11,4 @@ export * from './shared';
 export * from './substitution';
 export * from './payload-unit';
 export * from './cardinality';
+export * from './adapters';


### PR DESCRIPTION
## What

Fourth link in the **wzm3** pillar type-system epic (`oscilla-pillars-types-wzm3.4`), building on the wzm3.3 sub-solvers. Adapters are **regular blocks marked with a `ZAdapterSpec`** — no registry, no pattern dialect. `findAdapterCandidates` is the pure search: iterate adapter-marked catalog blocks, unify `source → input-field` and `target → output-field` through the wzm3.3 sub-solvers, return priority-sorted candidates each carrying the merged `Substitution`.

## Changes

- **`types/schemas.ts`** — `ZAdapterSpecSchema` (`description` + optional `priority`; lower = preferred).
- **`block-api.ts`** — `adapterSpec?` on `BlockDefinition` (block-role metadata, *not* the port type-surface), a minimal read-only `DefinedBlock` catalog projection (`{type, contract?, adapterSpec?}`), and `defineBlock` threading `adapterSpec` through.
- **`types/solve/adapters.ts`** — `findAdapterCandidates` + private `tryUnify` + adapter-shape-invariant enforcement (throws loudly on malformed adapters).
- **`types/solve/__tests__/adapters.test.ts`** — 9 tests covering exact match, polymorphic `UnitCast`, unit-discriminator sensitivity, no-match, priority sort + lexicographic tiebreak, `one→many` broadcast, unmarked-block exclusion, and the shape-invariant throw.

## Design notes

- **One combined solve, not two passes.** Field-preserving adapters share a port variable (`{P, U_in} → {P, U_out}`), so all four endpoints (`src`/`in`/`tgt`/`out`) land in one union-find group — a source-side binding is automatically in force on the target side, and an identity-payload passthrough asked to convert `float→int` is correctly *rejected*. No public `unify(a,b)`; the matching primitive is a flat constraint set, as graph edges will be.
- **`DefinedBlock` is a structural projection.** The real `ALL_BLOCKS: BlockDefinition<unknown,unknown>[]` is assignable to `readonly DefinedBlock[]`, while the pure search depends on no `lower`/`readConfig` closures it never calls.

## Divergence (documented on the ticket + in code)

Per the wzm3.3 heads-up: the landed wzm3.1 schema makes `angle.unit` a **closed enum**, so the ticket's "nested var inside a concrete variant" (`{kind:'angle', unit:<var>}`) is **unrepresentable**. Test #3 is realized in its expressible form (top-level unit var adopts a structured unit; a differing discriminator refuses to match). The nested-variant-var capability decision belongs to **wzm3.10**; no hack was added to the adapter layer.

## Verification

- `npx vitest run src/pillars/` — 169 passed (incl. 9 new adapter tests)
- `npx tsc --noEmit | grep src/pillars` — clean
- `grep -rn "TypePattern\|matchesPattern\|AdapterRegistry" src/pillars/types/` — empty
- no imports from `src/compiler/frontend/`
- `eslint` — clean on touched files
- (pre-existing `depcruise` cycle lives in the frozen `render/gpu-ir` stack, untouched)

Ticket: `oscilla-pillars-types-wzm3.4`