### PR TITLE
feat(scene): add native block contract metadata

### DIFF
--- a/src/pillars/scene/__tests__/compile.test.ts
+++ b/src/pillars/scene/__tests__/compile.test.ts
@@ -14,7 +14,8 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it, expect } from 'vitest';
 
-import { compileScenePlan } from '../index';
+import { buildSceneRegistry, compileScenePlan } from '../index';
+import { ALL_SCENE_BLOCKS } from '../blocks';
 import { makeGridOfSquaresPatch } from '../../fixtures/grid-of-squares';
 import { makeTexturedTilesPatch, TEXTURED_TILES_ASSETS } from '../../fixtures/textured-tiles';
 import { sceneObjectRef } from '../../../render/scene-plan';
@@ -195,6 +196,7 @@ describe('compileScenePlan — loud failures', () => {
     expect(message).toContain("'cols'");
     expect(message).toContain("'spacing'");
     expect(message).toContain("'rotationPerIndex'");
+    expect(message).toContain('(InstanceGrid)');
   });
 
   it('reports a patch with no draw block', () => {
@@ -209,6 +211,56 @@ describe('compileScenePlan — loud failures', () => {
     expect(result.kind).toBe('error');
     if (result.kind !== 'error') return;
     expect(result.errors.join('\n')).toMatch(/renders nothing/);
+  });
+});
+
+describe('scene block contract — catalog and registration', () => {
+  it('publishes catalog metadata for palette ports and config fields', () => {
+    const registry = buildSceneRegistry(ALL_SCENE_BLOCKS);
+    const catalog = registry.catalog;
+
+    expect(catalog.map((block) => block.displayName)).toEqual([
+      'Instance Grid',
+      'Draw Instances',
+    ]);
+    expect(catalog.flatMap((block) => block.ports.map((port) => port.value))).toEqual([
+      'instanceBundle',
+      'instanceBundle',
+      'materialShell',
+    ]);
+    expect(catalog.flatMap((block) => block.configFields.map((field) => field.key))).toEqual([
+      'rows',
+      'cols',
+      'spacing',
+      'rotationPerIndex',
+      'rotationPerTime',
+      'huePerTime',
+      'saturation',
+      'lightness',
+      'size',
+      'cameraHalfExtentX',
+      'cameraHalfExtentY',
+      'textureAssetId',
+    ]);
+  });
+
+  it('rejects registration without the required scene block contract metadata', () => {
+    const malformed = {
+      type: 'MalformedSceneBlock',
+      role: 'draw',
+      catalog: {
+        displayName: '',
+        category: 'draw',
+        ports: [],
+      },
+      configSchema: undefined,
+      readConfig: () => null,
+      contribute: () => ({ role: 'draw', shell: {} }),
+    };
+
+    expect(() =>
+      buildSceneRegistry([malformed as unknown as (typeof ALL_SCENE_BLOCKS)[number]]),
+    ).toThrow(/catalog\.displayName.*catalog\.ports.*configSchema/);
   });
 });
 
@@ -231,6 +283,8 @@ describe('compileScenePlan — backend neutrality (source-level)', () => {
       // concepts ([LAW:behavior-not-structure] — test the dependency, not prose).
       // [LAW:one-source-of-truth] No dependency on the frozen Rust payload.
       expect(src).not.toMatch(/from ['"][^'"]*boundary-contract/);
+      expect(src).not.toMatch(/from ['"][^'"]*block-api/);
+      expect(src).not.toMatch(/import\s+[^;]*(ExprIR|SourceBundle|RosterEntry)[^;]*from/);
       // [LAW:locality-or-seam] No Three / WASM coupling in the compiler output.
       expect(src).not.toMatch(/from ['"]three/);
       expect(src).not.toMatch(/from ['"][^'"]*render\/wasm/);

--- a/src/pillars/scene/blocks/draw-instances.ts
+++ b/src/pillars/scene/blocks/draw-instances.ts
@@ -1,63 +1,37 @@
-/**
- * src/pillars/scene/blocks/draw-instances.ts
- *
- * Draw (sink) block: wraps an upstream instance bundle in a rendering shell —
- * a rectangle geometry, an unlit color material, an orthographic camera — and
- * draws it to the preview canvas.
- *
- * The optional `textureAssetId` selects the material: present → a `texturedUnlit`
- * material that samples that texture asset; absent → an `unlitColor` material
- * that takes its per-instance color from the upstream bundle. The texture
- * presence is config *data*; the lowering mints the texture handle.
- *
- * [LAW:decomposition] This block owns *how the instances are drawn* (geometry,
- *   material kind, framing, target); the instance-source block owns *what
- *   varies per instance*. The lowering joins the two at the primary edge.
- * [LAW:locality-or-seam] The shell names a geometry/material by shape only; the
- *   handles that turn it into resource-table entries are minted by the lowering,
- *   and the Three classes that realize them live behind the renderer seam.
- */
-
 import { assetId as makeAssetId } from '../../../core/ids';
-import type { MaterialShell, SceneBlockDefinition, SceneContribution } from '../scene-block';
-import { readOptionalString, readPositiveNumber } from '../scene-block';
+import { defineSceneBlock, sceneConfig, type MaterialShell } from '../scene-block';
 
-interface DrawInstancesConfig {
-  readonly size: number;
-  readonly cameraHalfExtentX: number;
-  readonly cameraHalfExtentY: number;
-  /** When set, the draw samples this texture asset instead of bundle color. */
-  readonly textureAssetId: string | undefined;
-}
+const config = {
+  size: sceneConfig.positiveNumber({ label: 'Size', control: 'number' }),
+  cameraHalfExtentX: sceneConfig.positiveNumber({
+    label: 'Camera half extent X',
+    control: 'number',
+  }),
+  cameraHalfExtentY: sceneConfig.positiveNumber({
+    label: 'Camera half extent Y',
+    control: 'number',
+  }),
+  textureAssetId: sceneConfig.optionalAssetId({ label: 'Texture asset', control: 'asset' }),
+} as const;
 
-export const DrawInstancesBlock: SceneBlockDefinition<DrawInstancesConfig> = {
+export const DrawInstancesBlock = defineSceneBlock({
   type: 'DrawInstances',
   role: 'draw',
-
-  readConfig: (raw, blockId, diagnostics) => {
-    const size = readPositiveNumber(raw, 'size', blockId, diagnostics);
-    const cameraHalfExtentX = readPositiveNumber(raw, 'cameraHalfExtentX', blockId, diagnostics);
-    const cameraHalfExtentY = readPositiveNumber(raw, 'cameraHalfExtentY', blockId, diagnostics);
-    const textureAssetId = readOptionalString(raw, 'textureAssetId', blockId, diagnostics);
-
-    if (
-      size === null ||
-      cameraHalfExtentX === null ||
-      cameraHalfExtentY === null ||
-      textureAssetId === null
-    ) {
-      return null;
-    }
-    return { size, cameraHalfExtentX, cameraHalfExtentY, textureAssetId };
+  catalog: {
+    displayName: 'Draw Instances',
+    category: 'draw',
+    ports: [
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'draw', label: 'Draw', direction: 'output', value: 'materialShell' },
+    ],
   },
-
-  contribute: (config): SceneContribution => {
-    // [LAW:dataflow-not-control-flow] The material shell is selected from the
-    //   texture-asset value, not from a mode flag on the block.
+  config,
+  contribute: (config) => {
     const material: MaterialShell =
       config.textureAssetId === undefined
         ? { kind: 'unlitColor' }
         : { kind: 'texturedUnlit', assetId: makeAssetId(config.textureAssetId) };
+
     return {
       role: 'draw',
       shell: {
@@ -68,9 +42,8 @@ export const DrawInstancesBlock: SceneBlockDefinition<DrawInstancesConfig> = {
           halfExtentX: config.cameraHalfExtentX,
           halfExtentY: config.cameraHalfExtentY,
         },
-        // One render target exists today; the type pins it as a value, not a flag.
         target: 'previewCanvas',
       },
     };
   },
-};
+});

--- a/src/pillars/scene/blocks/instance-grid.ts
+++ b/src/pillars/scene/blocks/instance-grid.ts
@@ -1,22 +1,3 @@
-/**
- * src/pillars/scene/blocks/instance-grid.ts
- *
- * Instance-source block: lays a `rows × cols` grid of animated instances and
- * emits the per-instance field bundle (position, rotation, color) as PlanExprs.
- *
- * This is where authored *parameters* become backend-neutral *expressions* —
- * the "Oscilla fields/expressions → TSL expressions" mapping of the migration
- * (design-docs/three-fork-integration-proposal.md §3). The block stores scalar
- * grid/animation parameters; the lowering synthesizes the index/rank math.
- *
- * [LAW:one-source-of-truth] `rows`/`cols`/`spacing`/animation coefficients are
- *   the canonical authored intent; the `PlanExpr` trees below are derived from
- *   them, never stored alongside them.
- * [LAW:dataflow-not-control-flow] Per-instance variation lives in the *values*
- *   (the `index`/`rank` intrinsics flowing through the expressions), not in any
- *   per-instance branch.
- */
-
 import {
   add,
   div,
@@ -27,60 +8,34 @@ import {
   mod,
   mul,
 } from '../../../render/scene-plan';
-import {
-  readFiniteNumber,
-  readPositiveInt,
-  readPositiveNumber,
-  type SceneBlockDefinition,
-  type SceneContribution,
-} from '../scene-block';
+import { defineSceneBlock, sceneConfig } from '../scene-block';
 
-interface InstanceGridConfig {
-  readonly rows: number;
-  readonly cols: number;
-  readonly spacing: number;
-  readonly rotationPerIndex: number;
-  readonly rotationPerTime: number;
-  readonly huePerTime: number;
-  readonly saturation: number;
-  readonly lightness: number;
-}
+const config = {
+  rows: sceneConfig.positiveInt({ label: 'Rows', control: 'integer' }),
+  cols: sceneConfig.positiveInt({ label: 'Columns', control: 'integer' }),
+  spacing: sceneConfig.positiveNumber({ label: 'Spacing', control: 'number' }),
+  rotationPerIndex: sceneConfig.finiteNumber({ label: 'Rotation per index', control: 'number' }),
+  rotationPerTime: sceneConfig.finiteNumber({ label: 'Rotation per time', control: 'number' }),
+  huePerTime: sceneConfig.finiteNumber({ label: 'Hue per time', control: 'number' }),
+  saturation: sceneConfig.finiteNumber({ label: 'Saturation', control: 'number' }),
+  lightness: sceneConfig.finiteNumber({ label: 'Lightness', control: 'number' }),
+} as const;
 
-export const InstanceGridBlock: SceneBlockDefinition<InstanceGridConfig> = {
+export const InstanceGridBlock = defineSceneBlock({
   type: 'InstanceGrid',
   role: 'instanceSource',
-
-  readConfig: (raw, blockId, diagnostics) => {
-    const rows = readPositiveInt(raw, 'rows', blockId, diagnostics);
-    const cols = readPositiveInt(raw, 'cols', blockId, diagnostics);
-    const spacing = readPositiveNumber(raw, 'spacing', blockId, diagnostics);
-    const rotationPerIndex = readFiniteNumber(raw, 'rotationPerIndex', blockId, diagnostics);
-    const rotationPerTime = readFiniteNumber(raw, 'rotationPerTime', blockId, diagnostics);
-    const huePerTime = readFiniteNumber(raw, 'huePerTime', blockId, diagnostics);
-    const saturation = readFiniteNumber(raw, 'saturation', blockId, diagnostics);
-    const lightness = readFiniteNumber(raw, 'lightness', blockId, diagnostics);
-
-    if (
-      rows === null ||
-      cols === null ||
-      spacing === null ||
-      rotationPerIndex === null ||
-      rotationPerTime === null ||
-      huePerTime === null ||
-      saturation === null ||
-      lightness === null
-    ) {
-      return null;
-    }
-    return { rows, cols, spacing, rotationPerIndex, rotationPerTime, huePerTime, saturation, lightness };
+  catalog: {
+    displayName: 'Instance Grid',
+    category: 'instance',
+    ports: [
+      { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
+    ],
   },
-
-  contribute: (config): SceneContribution => {
+  config,
+  contribute: (config) => {
     const index = intrinsic('index');
     const rank = intrinsic('rank');
     const time = input('time');
-
-    // Grid placement: row-major. col = index % cols; row = floor(index / cols).
     const col = mod(index, konst(config.cols));
     const row = floor(div(index, konst(config.cols)));
 
@@ -91,7 +46,6 @@ export const InstanceGridBlock: SceneBlockDefinition<InstanceGridConfig> = {
         transform: {
           positionX: mul(col, konst(config.spacing)),
           positionY: mul(row, konst(config.spacing)),
-          // rotation = index * rotationPerIndex + time * rotationPerTime
           rotation: add(
             mul(index, konst(config.rotationPerIndex)),
             mul(time, konst(config.rotationPerTime)),
@@ -99,7 +53,6 @@ export const InstanceGridBlock: SceneBlockDefinition<InstanceGridConfig> = {
         },
         color: {
           space: 'hsl',
-          // hue spreads across the grid by normalized rank and cycles over time.
           h: add(rank, mul(time, konst(config.huePerTime))),
           s: konst(config.saturation),
           l: konst(config.lightness),
@@ -107,4 +60,4 @@ export const InstanceGridBlock: SceneBlockDefinition<InstanceGridConfig> = {
       },
     };
   },
-};
+});

--- a/src/pillars/scene/index.ts
+++ b/src/pillars/scene/index.ts
@@ -15,9 +15,14 @@ export type { SceneCompileResult } from './assemble';
 export { ALL_SCENE_BLOCKS } from './blocks';
 export {
   buildSceneRegistry,
+  defineSceneBlock,
+  sceneConfig,
   type SceneBlockDefinition,
   type SceneContribution,
   type SceneDiagnostic,
+  type SceneCatalogMetadata,
+  type ScenePortDeclaration,
+  type SceneValueKind,
   type InstanceBundle,
   type DrawShell,
   type MaterialShell,

--- a/src/pillars/scene/scene-block.ts
+++ b/src/pillars/scene/scene-block.ts
@@ -1,30 +1,4 @@
-/**
- * src/pillars/scene/scene-block.ts
- *
- * The ABI between scene-block authors and the ScenePlan lowering.
- *
- * Scope source: design-docs/three-fork-integration-proposal.md §2.1, §2.2, §3.
- * Ownership/seam canon: design-docs/three-migration-backend-canon.md
- *   (Oscilla owns "compile/lower stages from authored graph to backend-neutral
- *   execution data"; ScenePlan is that data).
- * Replacement narrative: design-docs/three-migration-scene-plan.md §"Concept
- *   Mapping".
- *
- * This is the NEW lowering ABI for the Three migration. It is deliberately NOT
- * the GPU-IR `BlockDefinition` (src/pillars/block-api.ts): that ABI's `lower`
- * produces `ExprIR`/`RosterEntry` for the frozen Rust-boundary payload (canon
- * §"Dead Concepts"). A scene block instead `contribute`s backend-neutral
- * ScenePlan fragments.
- *
- * [LAW:decomposition] A scene block is a genuinely different part from a GPU-IR
- *   block — different target representation, different seam — so it gets its own
- *   ABI rather than being forced through the GPU-IR contract.
- * [LAW:effects-at-boundaries] `contribute` is pure: declarative config in,
- *   ScenePlan-fragment description out. Nothing here touches a renderer.
- * [LAW:types-are-the-program] The contribution is a discriminated union on
- *   `role`; the lowering joins the parts by role without re-deriving block kind.
- */
-
+import { z } from 'zod';
 import type { AssetId } from '../../core/ids';
 import type {
   CameraPlan,
@@ -34,61 +8,21 @@ import type {
   TransformBinding,
 } from '../../render/scene-plan';
 
-// ---------------------------------------------------------------------------
-// Diagnostics — the loud-failure channel for config validation.
-// ---------------------------------------------------------------------------
-
-/**
- * A config-validation failure. There is no `warning`/`info` severity here: a
- * scene block either has a usable config or it does not.
- *
- * [LAW:no-silent-failure] An invalid config is a collected, surfaced error, not
- *   a silently-defaulted value that renders the wrong scene.
- */
 export interface SceneDiagnostic {
   readonly message: string;
   readonly blockId: string;
 }
 
-// ---------------------------------------------------------------------------
-// Contributions — what a block hands the lowering, before parts are joined.
-// ---------------------------------------------------------------------------
-
-/**
- * The per-instance field bundle an instance-source block emits: how many
- * instances exist and the fields that vary across them. Each field is a
- * `PlanExpr` (carried inside `TransformBinding` / `ColorBinding`), so it may
- * reference `index`/`rank` intrinsics and runtime inputs.
- *
- * [LAW:one-source-of-truth] The bundle is the canonical per-instance data; the
- *   draw block wraps it (geometry, material shell, camera) without re-deriving
- *   any of these fields.
- */
 export interface InstanceBundle {
   readonly count: number;
   readonly transform: TransformBinding;
   readonly color: ColorBinding;
 }
 
-/**
- * The surface a draw block wraps around its instance bundle.
- *
- * - `unlitColor` takes its per-instance color from the upstream `InstanceBundle`;
- *   the shell carries no color of its own.
- * - `texturedUnlit` samples a texture asset (named by {@link AssetId}); the
- *   lowering mints the plan's `TextureRef` and the textures-table entry from it.
- *
- * [LAW:no-mode-explosion] Material kinds are variants of this union; the
- *   lowering's join stays a total switch as kinds are added.
- */
 export type MaterialShell =
   | { readonly kind: 'unlitColor' }
   | { readonly kind: 'texturedUnlit'; readonly assetId: AssetId };
 
-/**
- * What a draw (sink) block contributes before it is joined to its instance
- * bundle: the rendering shell around the per-instance data.
- */
 export interface DrawShell {
   readonly geometry: GeometryDef;
   readonly material: MaterialShell;
@@ -96,42 +30,161 @@ export interface DrawShell {
   readonly target: RenderTarget;
 }
 
-/**
- * The discriminated contribution every scene block produces. The lowering
- * joins an `instanceSource` to the `draw` that reads it (via the primary edge).
- */
 export type SceneContribution =
   | { readonly role: 'instanceSource'; readonly bundle: InstanceBundle }
   | { readonly role: 'draw'; readonly shell: DrawShell };
 
-// ---------------------------------------------------------------------------
-// Block definition — the contract every scene block file exports.
-// ---------------------------------------------------------------------------
+export type SceneContributionRole = SceneContribution['role'];
 
-/**
- * The shape every scene-block file exports as a named constant.
- *
- * `readConfig` validates/narrows raw authored config (loud diagnostics on bad
- * input, never throws on user input). `contribute` is the pure mapping from the
- * narrowed config to a backend-neutral ScenePlan fragment.
- */
-export interface SceneBlockDefinition<TConfig> {
+export type SceneValueKind =
+  | 'instanceBundle'
+  | 'geometry'
+  | 'materialShell'
+  | 'texture'
+  | 'camera'
+  | 'color'
+  | 'scalar'
+  | 'mask';
+
+export type ScenePortDirection = 'input' | 'output';
+
+export interface ScenePortDeclaration {
+  readonly id: string;
+  readonly label: string;
+  readonly direction: ScenePortDirection;
+  readonly value: SceneValueKind;
+}
+
+export type SceneBlockCategory =
+  | 'instance'
+  | 'modifier'
+  | 'draw'
+  | 'material'
+  | 'asset'
+  | 'color';
+
+export type SceneConfigControl =
+  | 'number'
+  | 'integer'
+  | 'asset'
+  | 'color'
+  | 'toggle'
+  | 'select';
+
+export interface SceneConfigFieldCatalog {
+  readonly label: string;
+  readonly control: SceneConfigControl;
+}
+
+export interface SceneConfigField<TValue> {
+  readonly schema: z.ZodType<TValue>;
+  readonly catalog: SceneConfigFieldCatalog;
+}
+
+export type SceneConfigFields = Readonly<Record<string, SceneConfigField<unknown>>>;
+
+export type SceneConfigFor<TFields extends SceneConfigFields> = {
+  readonly [K in keyof TFields]: z.infer<TFields[K]['schema']>;
+};
+
+export interface SceneCatalogMetadata {
+  readonly displayName: string;
+  readonly category: SceneBlockCategory;
+  readonly ports: readonly ScenePortDeclaration[];
+  readonly configFields: readonly SceneCatalogConfigField[];
+}
+
+export interface SceneCatalogConfigField extends SceneConfigFieldCatalog {
+  readonly key: string;
+}
+
+export interface SceneBlockDefinition<
+  TConfig,
+  TRole extends SceneContributionRole = SceneContributionRole,
+> {
   readonly type: string;
-  readonly role: SceneContribution['role'];
+  readonly role: TRole;
+  readonly catalog: SceneCatalogMetadata;
+  readonly configSchema: z.ZodType<TConfig>;
   readonly readConfig: (
     raw: Readonly<Record<string, unknown>>,
     blockId: string,
     diagnostics: SceneDiagnostic[],
   ) => TConfig | null;
-  readonly contribute: (config: TConfig) => SceneContribution;
+  readonly contribute: (config: TConfig) => Extract<SceneContribution, { readonly role: TRole }>;
 }
 
-// ---------------------------------------------------------------------------
-// Registry — value-constructor, no module-level singleton (mirrors frontend).
-// ---------------------------------------------------------------------------
+export interface SceneBlockDeclaration<
+  TFields extends SceneConfigFields,
+  TRole extends SceneContributionRole,
+> {
+  readonly type: string;
+  readonly role: TRole;
+  readonly catalog: Omit<SceneCatalogMetadata, 'configFields'>;
+  readonly config: TFields;
+  readonly contribute: (
+    config: SceneConfigFor<TFields>,
+  ) => Extract<SceneContribution, { readonly role: TRole }>;
+}
+
+type SceneConfigShape<TFields extends SceneConfigFields> = {
+  readonly [K in keyof TFields]: TFields[K]['schema'];
+};
+
+export function defineSceneBlock<
+  const TFields extends SceneConfigFields,
+  const TRole extends SceneContributionRole,
+>(
+  declaration: SceneBlockDeclaration<TFields, TRole>,
+): SceneBlockDefinition<SceneConfigFor<TFields>, TRole> {
+  // [LAW:one-source-of-truth] One field map derives both parsing and catalog metadata.
+  const configSchema = z.object(configShape(declaration.config)) as z.ZodType<
+    SceneConfigFor<TFields>
+  >;
+  const catalog: SceneCatalogMetadata = {
+    ...declaration.catalog,
+    configFields: Object.entries(declaration.config).map(([key, field]) => ({
+      key,
+      ...field.catalog,
+    })),
+  };
+
+  return {
+    type: declaration.type,
+    role: declaration.role,
+    catalog,
+    configSchema,
+    readConfig: (raw, blockId, diagnostics) => {
+      const result = configSchema.safeParse(raw);
+      if (result.success) return result.data;
+      for (const issue of result.error.issues) {
+        diagnostics.push({
+          blockId,
+          message: formatConfigIssue(blockId, declaration.type, issue),
+        });
+      }
+      return null;
+    },
+    contribute: declaration.contribute,
+  };
+}
+
+function configShape<TFields extends SceneConfigFields>(
+  fields: TFields,
+): SceneConfigShape<TFields> {
+  return Object.fromEntries(
+    Object.entries(fields).map(([key, field]) => [key, field.schema]),
+  ) as SceneConfigShape<TFields>;
+}
+
+function formatConfigIssue(blockId: string, blockType: string, issue: z.core.$ZodIssue): string {
+  const path = issue.path.length === 0 ? '<root>' : issue.path.join('.');
+  return `[scene] block '${blockId}' (${blockType}): config '${path}' ${issue.message}`;
+}
 
 export interface SceneRegistry {
   readonly get: (type: string) => SceneBlockDefinition<unknown> | undefined;
+  readonly catalog: readonly SceneCatalogMetadata[];
 }
 
 export function buildSceneRegistry(
@@ -139,101 +192,64 @@ export function buildSceneRegistry(
 ): SceneRegistry {
   const byType = new Map<string, SceneBlockDefinition<unknown>>();
   for (const block of blocks) {
+    validateSceneBlockDefinition(block);
     if (byType.has(block.type)) {
       throw new Error(`[scene] Duplicate scene block type in registry: '${block.type}'`);
     }
     byType.set(block.type, block);
   }
-  return { get: (type) => byType.get(type) };
+  return {
+    get: (type) => byType.get(type),
+    catalog: Array.from(byType.values(), (block) => block.catalog),
+  };
 }
 
-// ---------------------------------------------------------------------------
-// Config-reading helpers — one loud, validated read per primitive.
-// ---------------------------------------------------------------------------
+function validateSceneBlockDefinition(block: SceneBlockDefinition<unknown>): void {
+  const catalog = block.catalog;
+  const missing = [
+    requiredText(block.type, 'type'),
+    requiredValue(catalog, 'catalog'),
+    catalog === undefined ? null : requiredText(catalog.displayName, 'catalog.displayName'),
+    catalog === undefined ? null : requiredText(catalog.category, 'catalog.category'),
+    catalog === undefined ? null : requiredItems(catalog.ports, 'catalog.ports'),
+    requiredValue(block.configSchema, 'configSchema'),
+  ].filter((entry): entry is string => entry !== null);
 
-/**
- * Read a finite number from raw config, pushing a diagnostic if absent or not a
- * finite number. Returns null on failure so the caller can keep collecting
- * other field errors before bailing.
- */
-export function readFiniteNumber(
-  raw: Readonly<Record<string, unknown>>,
-  key: string,
-  blockId: string,
-  diagnostics: SceneDiagnostic[],
-): number | null {
-  const value = raw[key];
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    diagnostics.push({
-      blockId,
-      message: `[scene] block '${blockId}': config '${key}' must be a finite number`,
-    });
-    return null;
+  if (missing.length > 0) {
+    throw new Error(`[scene] invalid scene block contract '${block.type || '<unknown>'}': ${missing.join(', ')}`);
   }
-  return value;
 }
 
-/** Read a number that must be strictly positive (e.g. a spacing or size). */
-export function readPositiveNumber(
-  raw: Readonly<Record<string, unknown>>,
-  key: string,
-  blockId: string,
-  diagnostics: SceneDiagnostic[],
-): number | null {
-  const value = readFiniteNumber(raw, key, blockId, diagnostics);
-  if (value === null) return null;
-  if (value <= 0) {
-    diagnostics.push({
-      blockId,
-      message: `[scene] block '${blockId}': config '${key}' must be > 0 (got ${value})`,
-    });
-    return null;
-  }
-  return value;
+function requiredText(value: string, label: string): string | null {
+  return value.length === 0 ? label : null;
 }
 
-/**
- * Read an optional non-empty string (e.g. an asset id reference). Absent config
- * returns `undefined` (a legitimate "not set"); a present-but-non-string or
- * empty value is a loud diagnostic and returns `null`.
- *
- * [LAW:dataflow-not-control-flow] The three outcomes are distinct values
- *   (`undefined` set-absent, `null` invalid, the string when valid), so the
- *   caller selects a material shell from the value rather than guessing.
- */
-export function readOptionalString(
-  raw: Readonly<Record<string, unknown>>,
-  key: string,
-  blockId: string,
-  diagnostics: SceneDiagnostic[],
-): string | null | undefined {
-  const value = raw[key];
-  if (value === undefined) return undefined;
-  if (typeof value !== 'string' || value.length === 0) {
-    diagnostics.push({
-      blockId,
-      message: `[scene] block '${blockId}': config '${key}' must be a non-empty string when present`,
-    });
-    return null;
-  }
-  return value;
+function requiredItems(value: readonly unknown[], label: string): string | null {
+  return value.length === 0 ? label : null;
 }
 
-/** Read a positive integer (e.g. a grid row/column count). */
-export function readPositiveInt(
-  raw: Readonly<Record<string, unknown>>,
-  key: string,
-  blockId: string,
-  diagnostics: SceneDiagnostic[],
-): number | null {
-  const value = readFiniteNumber(raw, key, blockId, diagnostics);
-  if (value === null) return null;
-  if (!Number.isInteger(value) || value <= 0) {
-    diagnostics.push({
-      blockId,
-      message: `[scene] block '${blockId}': config '${key}' must be a positive integer (got ${value})`,
-    });
-    return null;
-  }
-  return value;
+function requiredValue(value: unknown, label: string): string | null {
+  return value === undefined || value === null ? label : null;
 }
+
+export const sceneConfig = {
+  finiteNumber: (catalog: SceneConfigFieldCatalog): SceneConfigField<number> => ({
+    schema: z.number().finite(),
+    catalog,
+  }),
+  positiveNumber: (catalog: SceneConfigFieldCatalog): SceneConfigField<number> => ({
+    schema: z.number().finite().positive(),
+    catalog,
+  }),
+  positiveInt: (catalog: SceneConfigFieldCatalog): SceneConfigField<number> => ({
+    schema: z.number().int().positive(),
+    catalog,
+  }),
+  optionalAssetId: (
+    catalog: SceneConfigFieldCatalog,
+  ): SceneConfigField<string | undefined> => ({
+    // [LAW:types-are-the-program] Empty strings are not asset identities.
+    schema: z.string().min(1).optional(),
+    catalog,
+  }),
+} as const;


### PR DESCRIPTION
## Summary
- add a ScenePlan-native block declaration contract that derives Zod config parsing and catalog config metadata from one field map
- add typed scene port/value/category metadata to the registry catalog
- migrate InstanceGrid and DrawInstances to the new declaration shape and cover malformed registration plus legacy import boundaries

## Verification
- npx vitest run src/pillars/scene/
- timeout 180 npx tsc --noEmit

Ticket: oscilla-pillars-scene-nt56.1