### PR TITLE
feat(pillars-scene nt56.2): ScenePlan capability matrix + enforcement tests

### DIFF
--- a/design-docs/three-migration-capability-matrix.md
+++ b/design-docs/three-migration-capability-matrix.md
@@ -1,0 +1,216 @@
+# Three Migration Capability Matrix: Native Block Library
+
+**Date:** 2026-06-29
+**Status:** Groundwork
+**Backlog:** `oscilla-pillars-scene-nt56.2` (epic `oscilla-pillars-scene-nt56`)
+**Scope source:** [three-migration-backend-canon.md](./three-migration-backend-canon.md) ·
+[three-migration-scene-plan.md](./three-migration-scene-plan.md) ·
+[three-fork-deltas.md](./three-fork-deltas.md) §3
+
+## Purpose
+
+This is the one capability matrix for the Three-native block library: it says
+which typed values and ScenePlan resources are *legal* execution data, and maps
+each user-facing native block category onto the backend-neutral ScenePlan
+concept that realizes it. Block work crystallizes if every block invents its own
+capability shape; this matrix is the shared vocabulary every native block,
+modifier, material, and asset block compiles into.
+
+`// [LAW:one-source-of-truth]` **ScenePlan is the source of truth for
+backend-neutral execution data.** This document is a *projection* of the
+ScenePlan types in [`src/render/scene-plan/`](../src/render/scene-plan/) — it
+does not define a second, parallel capability enum that could drift from them.
+When a row below names a "ScenePlan data concept", that concept is a concrete
+type in `plan.ts` / `expr.ts` / `refs.ts`, and the type — not this prose — is
+authoritative.
+
+`// [LAW:types-are-the-program]` The matrix is *embodied in discriminated
+unions*, not enforced by checks: a capability is legal iff the ScenePlan types
+can represent it. An illegal capability (a textured material with no texture, a
+color with no space, a runtime value masquerading as a constant) is
+unrepresentable by construction, not rejected at runtime.
+
+## How To Read This Matrix
+
+A native block is authored, type-checked, and lowered along one path:
+
+```
+authored block (category, config, ports)
+   │  contribute()
+   ▼
+SceneContribution (role: instanceSource | draw)      src/pillars/scene/scene-block.ts
+   │  assembleScenePlan()
+   ▼
+ScenePlan data concept (resource def / binding / expr) src/render/scene-plan/
+```
+
+So three vocabularies meet here and must agree:
+
+1. **Block categories** (`SceneBlockCategory`) — the palette grouping the user sees.
+2. **Port value kinds** (`SceneValueKind`) — the typed value a port carries between blocks.
+3. **ScenePlan data concepts** — the backend-neutral execution data a block lowers into.
+
+The matrix below pins each to the next, and marks every capability **Realized**
+(a ScenePlan variant the first block set uses today) or **Deferred** (named here,
+no ScenePlan variant minted yet — owned by a later ticket).
+
+## 1. Block Categories → ScenePlan Contribution
+
+`SceneBlockCategory` is the authoring grouping; `SceneContribution.role` is what
+the block hands to assembly. Categories are a palette concern and may be richer
+than roles (many categories collapse onto the two assembly roles today).
+
+| Block category | Contribution role | ScenePlan data concept it produces | Status |
+|----------------|-------------------|-------------------------------------|--------|
+| `instance`     | `instanceSource`  | `InstancingPlan` (count + `TransformBinding`) + `ColorBinding` | **Realized** |
+| `modifier`     | `instanceSource`  | rewrites `TransformBinding` / `ColorBinding` `PlanExpr` trees (no new variant) | **Realized** (foundation: nt56.4) |
+| `draw`         | `draw`            | `SceneObject` + `DrawItem` + `CameraPlan` + `GeometryDef` | **Realized** |
+| `material`     | `draw`            | `MaterialDef` (the shading model on the draw's object) | **Realized** |
+| `color`        | `instanceSource`  | `ColorBinding` (a color the instance source carries) | **Realized** (primitives: nt56.5) |
+| `asset`        | `draw`            | `TextureDef` minted into `ScenePlan.resources.textures` | **Realized** (asset blocks: nt56.6) |
+
+`// [LAW:dataflow-not-control-flow]` A block's contribution is a *value* of the
+`SceneContribution` union, not a branch in the lowering. Adding a category does
+not add a code path to assembly; it adds a row that produces one of these
+concepts.
+
+## 2. Port Value Kinds → ScenePlan Data Concept
+
+`SceneValueKind` (the value a typed port carries, declared in
+`src/pillars/scene/scene-block.ts`) maps onto ScenePlan data concepts as follows.
+A **Deferred** kind is a legal *port* vocabulary entry whose ScenePlan
+realization is owned by a later ticket — there is intentionally no plan variant
+for it yet, so a half-built capability cannot be half-represented.
+
+| Port value kind   | ScenePlan data concept | Status |
+|-------------------|-------------------------|--------|
+| `instanceBundle`  | `InstancingPlan` + `ColorBinding` (assembly's `InstanceBundle`) | **Realized** |
+| `geometry`        | `GeometryDef` (`rectangle` \| `point`) | **Realized** |
+| `materialShell`   | `MaterialDef` (`unlitColor` \| `texturedUnlit`) | **Realized** |
+| `texture`         | `TextureDef` (`asset`) behind a `TextureRef` | **Realized** |
+| `camera`          | `CameraPlan` (`orthographic`) | **Realized** |
+| `color`           | `ColorBinding` (`hsl` \| `rgb` \| `rgba`) | **Realized** |
+| `scalar`          | `PlanExpr` (one backend-neutral scalar value) | **Realized** |
+| `mask`            | *(none yet)* — per-instance visibility predicate | **Deferred** |
+
+`// [LAW:types-are-the-program]` `mask` is the only port kind with no ScenePlan
+concept. It stays a port-vocabulary entry only; minting a `mask` plan variant
+before a mask block exists would make an unfinished capability representable.
+The matrix records the deferral rather than the type permitting it.
+
+## 3. ScenePlan Resource Tables
+
+Every plan carries all five resource tables (`ScenePlanResources`). A table is a
+ref-keyed record; a deferred capability is an **empty table**, never an absent
+field or a flag.
+
+| Resource table     | Resource def            | Status |
+|--------------------|-------------------------|--------|
+| `geometries`       | `GeometryDef`           | **Realized** |
+| `materials`        | `MaterialDef`           | **Realized** |
+| `textures`         | `TextureDef`            | **Realized** (asset-resolved by the bridge) |
+| `computeResources` | `ComputeResourceDef`    | **Deferred** — empty; TSL compute (three-fork-deltas §4.2) |
+| `postChains`       | `PostChainDef`          | **Deferred** — empty; Three post nodes (three-fork-deltas §3) |
+
+`// [LAW:dataflow-not-control-flow]` `computeResources` and `postChains` are
+present-but-empty for the first block set. The shape is fixed; only the contents
+vary. A renderer iterating a table sees zero entries, not a missing key.
+
+## 4. Per-Value Expression Vocabulary (`PlanExpr`)
+
+A `PlanExpr` is the backend-neutral description of one scalar value — the
+realization of every `scalar` port and every channel of a `TransformBinding` or
+`ColorBinding`. Its vocabulary is sized to the first demo patches
+(`[LAW:no-mode-explosion]`); new operators are added to these unions and
+consumers stay exhaustive.
+
+| Concept            | Members | Status |
+|--------------------|---------|--------|
+| Runtime inputs (`PlanInputChannel`) | `time` (realized); `mouseX/Y`, `mouseButtons`, `audioLow/Mid/High`, `gaugeActive` (mirrors runtime envelope) | **Realized** (`time`) |
+| Intrinsics (`PlanIntrinsic`) | `index`, `rank` | **Realized** |
+| Unary ops (`PlanUnaryOp`) | `floor`, `sin`, `cos`, `negate` | **Realized** |
+| Binary ops (`PlanBinaryOp`) | `add`, `sub`, `mul`, `div`, `mod` | **Realized** |
+| Leaves | `const` (baked) vs `input` (runtime channel) — structurally distinct | **Realized** |
+
+`// [LAW:dataflow-not-control-flow]` The `const` vs `input` split is structural,
+not a flag: a runtime value is an `input` node and a baked value is a `const`
+node. "Is this value animated?" is answered by the shape, never by a boolean.
+
+## 5. Render Orchestration
+
+| Concept        | ScenePlan type | Members | Status |
+|----------------|----------------|---------|--------|
+| Camera         | `CameraPlan`   | `orthographic` (perspective added as a new variant when needed) | **Realized** (`orthographic`) |
+| Render target  | `RenderTarget` | `previewCanvas` (offscreen/MRT targets added as variants when needed) | **Realized** (`previewCanvas`) |
+| Per-frame inputs | `RenderPlan.inputs` | derived `PlanInputChannel[]` (projection of the plan's exprs) | **Realized** |
+| Post chain     | `RenderPlan.postChain` | `PostChainRef \| null` (null today) | **Deferred** |
+
+`// [LAW:one-source-of-truth]` `RenderPlan.inputs` is *derived* from the plan's
+expressions (`src/pillars/scene/inputs.ts`), never hand-declared — the
+expressions are the single source of truth and the input list is their
+projection.
+
+## 6. Deferred Capability Register
+
+Named here so blocks do not invent ad-hoc shapes for them. Each lands as a new
+**discriminated variant or a populated table**, never a boolean flag, when its
+owning ticket arrives.
+
+| Deferred capability | How it lands | Owner |
+|---------------------|--------------|-------|
+| Per-instance scale  | new field(s) on `TransformBinding` | first patch needing it |
+| Perspective camera  | new variant of `CameraPlan` | first patch needing it |
+| Additional render targets (offscreen/MRT) | new members of `RenderTarget` | first patch needing it |
+| Per-instance visibility (`mask`) | new ScenePlan binding + `mask` port realization | first mask block |
+| Compute / storage   | entries in `computeResources` (`ComputeResourceDef`) | TSL compute ticket (three-fork-deltas §4.2) |
+| Postprocessing      | entries in `postChains` + non-null `RenderPlan.postChain` | Three post ticket (three-fork-deltas §3) |
+| Additional color spaces / material kinds | new `ColorBinding` / `MaterialDef` variants | nt56.5 |
+
+`// [LAW:carrying-cost]` Each deferred capability is a *named slot*, not built
+machinery. Documenting the slot costs nothing and keeps the type minimal;
+building it speculatively would add carrying cost with no caller.
+
+## 7. Gap Analysis: Variants Needed by the First Block Set
+
+The ticket asks for "any missing ScenePlan pure-data variants needed by the
+first block set." Result: **none.** Walking the first block slices against the
+type surface:
+
+- **instance sources** → `InstancingPlan` + `TransformBinding` + `ColorBinding` — present.
+- **modifiers** → compose `PlanExpr` trees over an existing bundle — no new variant.
+- **draw / material shells** → `GeometryDef` + `MaterialDef` + `CameraPlan` — present.
+- **color** → `ColorBinding` (`hsl`/`rgb`/`rgba`) — present.
+- **assets** → `TextureDef` minted into the `textures` table — present.
+- **validation** → operates on the existing plan + contributions — no new variant.
+
+So this ticket adds no speculative variants; it ratifies the existing type
+surface as the capability matrix and locks it with tests (§8). New variants
+arrive with the tickets in §6 that actually need them.
+
+## 8. Enforcement
+
+`// [LAW:single-enforcer]` Two mechanical gates keep this matrix honest; both
+live under [`src/render/scene-plan/__tests__/`](../src/render/scene-plan/__tests__/).
+
+1. **Representative round-trip** (`capability-matrix.test.ts`) — builds one
+   ScenePlan that exercises *every* Realized variant in the matrix (both
+   geometries, all three color spaces, both materials, every `PlanExpr` kind,
+   the deferred-but-populated resource defs) and asserts a
+   `JSON.parse(JSON.stringify(plan))` round-trip is structurally equal. This
+   proves every matrix row is pure, serializable data — and that the matrix
+   cannot claim a variant the types cannot represent.
+
+2. **Backend-neutrality guard** (`scene-plan.test.ts`) — asserts no ScenePlan
+   source imports `three`, `boundary-contract`, the legacy `PipelineInstallPayload`
+   path (`pillars/assembly`), the GPU-IR stack (`render/gpu-ir`, `render/rust`),
+   or `render/wasm`. `// [LAW:no-silent-failure]` A legacy import is a loud test
+   failure, not a silent re-coupling to the frozen payload path.
+
+## Related References
+
+- [three-migration-scene-plan.md](./three-migration-scene-plan.md) — how ScenePlan replaces `PipelineInstallPayload`
+- [three-migration-backend-canon.md](./three-migration-backend-canon.md) — ownership, seams, dead concepts
+- [three-fork-deltas.md](./three-fork-deltas.md) — capability tiers; deferred compute/post/asset surface
+- [three-migration-first-proof-contract.md](./three-migration-first-proof-contract.md) — steel-thread target
+- `src/render/scene-plan/` — the authoritative types this matrix projects
+- `src/pillars/scene/scene-block.ts` — block contract, `SceneValueKind`, `SceneBlockCategory`

--- a/src/render/scene-plan/__tests__/capability-matrix.test.ts
+++ b/src/render/scene-plan/__tests__/capability-matrix.test.ts
@@ -1,0 +1,259 @@
+/**
+ * Capability-matrix contract test for the backend-neutral ScenePlan.
+ *
+ * design-docs/three-migration-capability-matrix.md is the matrix; ScenePlan is
+ * its source of truth. This test builds ONE representative plan that exercises
+ * every *Realized* variant the matrix lists — both geometries, all three color
+ * spaces, both materials, every PlanExpr kind and operator, and the
+ * deferred-but-populated compute/post resource defs — and proves it survives a
+ * `JSON.parse(JSON.stringify(plan))` round-trip unchanged.
+ *
+ * Two things are locked at once:
+ *  - If the matrix claims a variant the types cannot represent, this file fails
+ *    to compile (the builders/types are the gate).
+ *  - If any variant is not pure data (a closure, a class instance, a renderer
+ *    object), the JSON round-trip diverges and the test fails.
+ *
+ * [LAW:behavior-not-structure] Asserts the plan can REPRESENT each capability as
+ *   serializable data — not how a renderer realizes it.
+ * [LAW:types-are-the-program] The exprKinds/op walker proves the representative
+ *   plan covers the entire PlanExpr vocabulary, so the matrix cannot silently
+ *   omit an operator.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  SCENE_PLAN_VERSION,
+  defineScenePlan,
+  geometryRef,
+  materialRef,
+  textureRef,
+  sceneObjectRef,
+  computeResourceRef,
+  postChainRef,
+  konst,
+  input,
+  intrinsic,
+  floor,
+  sin,
+  cos,
+  negate,
+  add,
+  sub,
+  mul,
+  div,
+  mod,
+  type PlanExpr,
+  type PlanUnaryOp,
+  type PlanBinaryOp,
+  type ScenePlan,
+} from '../index';
+
+import { assetId } from '../../../core/ids';
+
+/**
+ * A plan that touches every Realized capability row in the matrix. It is not a
+ * meaningful animation — it is a *coverage* artifact: each resource table, color
+ * space, geometry, material, and PlanExpr operator appears at least once.
+ */
+function buildCapabilityCoveragePlan(): ScenePlan {
+  // Geometry: rectangle + point.
+  const rect = geometryRef('cap:rect');
+  const point = geometryRef('cap:point');
+
+  // Materials: unlitColor over hsl / rgb / rgba, plus texturedUnlit.
+  const matHsl = materialRef('cap:mat-hsl');
+  const matRgb = materialRef('cap:mat-rgb');
+  const matRgba = materialRef('cap:mat-rgba');
+  const matTex = materialRef('cap:mat-tex');
+
+  const tex = textureRef('cap:tex');
+  const storage = computeResourceRef('cap:storage');
+  const post = postChainRef('cap:post');
+
+  const objHsl = sceneObjectRef('cap:obj-hsl');
+  const objRgb = sceneObjectRef('cap:obj-rgb');
+  const objRgba = sceneObjectRef('cap:obj-rgba');
+  const objTex = sceneObjectRef('cap:obj-tex');
+
+  const index = intrinsic('index');
+  const rank = intrinsic('rank');
+  const time = input('time');
+
+  // Spread every unary + binary operator across the transforms so the walker
+  // below observes the full PlanExpr vocabulary in one plan.
+  const transformA = {
+    // binary: add, mul; leaf: const; intrinsic: index
+    positionX: add(mul(index, konst(0.1)), konst(0.5)),
+    // binary: div, mod; unary: floor
+    positionY: floor(div(mod(index, konst(10)), konst(2))),
+    // unary: negate; binary: sub; input: time
+    rotation: negate(sub(time, konst(1))),
+  };
+  const transformB = {
+    // unary: sin, cos
+    positionX: sin(rank),
+    positionY: cos(rank),
+    rotation: konst(0),
+  };
+
+  return defineScenePlan({
+    version: SCENE_PLAN_VERSION,
+    resources: {
+      geometries: {
+        [rect]: { kind: 'rectangle', width: 0.08, height: 0.08 },
+        [point]: { kind: 'point' },
+      },
+      materials: {
+        [matHsl]: {
+          kind: 'unlitColor',
+          color: { space: 'hsl', h: add(rank, mul(time, konst(0.2))), s: konst(0.8), l: konst(0.6) },
+        },
+        [matRgb]: {
+          kind: 'unlitColor',
+          color: { space: 'rgb', r: rank, g: konst(0.5), b: konst(0.25) },
+        },
+        [matRgba]: {
+          kind: 'unlitColor',
+          color: { space: 'rgba', r: konst(1), g: konst(0), b: konst(0), a: konst(0.5) },
+        },
+        [matTex]: { kind: 'texturedUnlit', texture: tex },
+      },
+      textures: {
+        [tex]: { kind: 'asset', assetId: assetId('cap:asset') },
+      },
+      // Deferred capabilities, populated here to prove the table shape round-trips
+      // even when non-empty (the steel thread leaves these empty).
+      computeResources: {
+        [storage]: { kind: 'storage', byteLength: 256 },
+      },
+      postChains: {
+        [post]: { kind: 'passes', passes: ['bloom', 'vignette'] },
+      },
+    },
+    objects: {
+      [objHsl]: { geometry: rect, material: matHsl, instancing: { count: 16, transform: transformA } },
+      [objRgb]: { geometry: point, material: matRgb, instancing: { count: 4, transform: transformB } },
+      [objRgba]: { geometry: rect, material: matRgba, instancing: { count: 1, transform: transformB } },
+      [objTex]: { geometry: rect, material: matTex, instancing: { count: 1, transform: transformB } },
+    },
+    render: {
+      camera: { kind: 'orthographic', halfExtentX: 0.6, halfExtentY: 0.6 },
+      inputs: ['time'],
+      draws: [
+        { target: 'previewCanvas', object: objHsl },
+        { target: 'previewCanvas', object: objRgb },
+        { target: 'previewCanvas', object: objRgba },
+        { target: 'previewCanvas', object: objTex },
+      ],
+      postChain: post,
+    },
+  });
+}
+
+/** Walk every PlanExpr in the plan, collecting the kinds and operators present. */
+function collectExprVocabulary(plan: ScenePlan): {
+  readonly kinds: Set<PlanExpr['kind']>;
+  readonly unary: Set<PlanUnaryOp>;
+  readonly binary: Set<PlanBinaryOp>;
+} {
+  const kinds = new Set<PlanExpr['kind']>();
+  const unary = new Set<PlanUnaryOp>();
+  const binary = new Set<PlanBinaryOp>();
+
+  const visit = (expr: PlanExpr): void => {
+    kinds.add(expr.kind);
+    switch (expr.kind) {
+      case 'const':
+      case 'input':
+      case 'intrinsic':
+        return;
+      case 'unary':
+        unary.add(expr.op);
+        visit(expr.arg);
+        return;
+      case 'binary':
+        binary.add(expr.op);
+        visit(expr.lhs);
+        visit(expr.rhs);
+        return;
+    }
+  };
+
+  for (const object of Object.values(plan.objects)) {
+    visit(object.instancing.transform.positionX);
+    visit(object.instancing.transform.positionY);
+    visit(object.instancing.transform.rotation);
+  }
+  for (const material of Object.values(plan.resources.materials)) {
+    if (material.kind !== 'unlitColor') continue;
+    const c = material.color;
+    if (c.space === 'rgba') visit(c.a);
+    if (c.space === 'rgb' || c.space === 'rgba') {
+      visit(c.r);
+      visit(c.g);
+      visit(c.b);
+    }
+    if (c.space === 'hsl') {
+      visit(c.h);
+      visit(c.s);
+      visit(c.l);
+    }
+  }
+
+  return { kinds, unary, binary };
+}
+
+describe('ScenePlan capability matrix — representative coverage', () => {
+  const plan = buildCapabilityCoveragePlan();
+
+  it('round-trips through JSON unchanged (every Realized variant is pure data)', () => {
+    const roundTripped = JSON.parse(JSON.stringify(plan));
+    expect(roundTripped).toEqual(plan);
+  });
+
+  it('covers both geometry variants', () => {
+    const kinds = Object.values(plan.resources.geometries).map((g) => g.kind).sort();
+    expect(kinds).toEqual(['point', 'rectangle']);
+  });
+
+  it('covers all three color spaces', () => {
+    const spaces = Object.values(plan.resources.materials)
+      .filter((m) => m.kind === 'unlitColor')
+      .map((m) => (m.kind === 'unlitColor' ? m.color.space : null))
+      .sort();
+    expect(spaces).toEqual(['hsl', 'rgb', 'rgba']);
+  });
+
+  it('covers both material variants', () => {
+    const kinds = new Set(Object.values(plan.resources.materials).map((m) => m.kind));
+    expect(kinds).toEqual(new Set(['unlitColor', 'texturedUnlit']));
+  });
+
+  it('populates every resource table, including the deferred compute/post tables', () => {
+    expect(Object.keys(plan.resources.geometries).length).toBeGreaterThan(0);
+    expect(Object.keys(plan.resources.materials).length).toBeGreaterThan(0);
+    expect(Object.keys(plan.resources.textures).length).toBeGreaterThan(0);
+    expect(Object.keys(plan.resources.computeResources).length).toBeGreaterThan(0);
+    expect(Object.keys(plan.resources.postChains).length).toBeGreaterThan(0);
+  });
+
+  it('exercises the entire PlanExpr vocabulary', () => {
+    const { kinds, unary, binary } = collectExprVocabulary(plan);
+    expect(kinds).toEqual(new Set(['const', 'input', 'intrinsic', 'unary', 'binary']));
+    expect(unary).toEqual(new Set<PlanUnaryOp>(['floor', 'sin', 'cos', 'negate']));
+    expect(binary).toEqual(new Set<PlanBinaryOp>(['add', 'sub', 'mul', 'div', 'mod']));
+  });
+
+  it('frames with an orthographic camera and draws to the preview canvas', () => {
+    expect(plan.render.camera.kind).toBe('orthographic');
+    expect(new Set(plan.render.draws.map((d) => d.target))).toEqual(new Set(['previewCanvas']));
+  });
+
+  it('references a non-null post chain by handle when one is present', () => {
+    expect(plan.render.postChain).not.toBeNull();
+    if (plan.render.postChain === null) return;
+    expect(plan.resources.postChains[plan.render.postChain]).toBeDefined();
+  });
+});

--- a/src/render/scene-plan/__tests__/scene-plan.test.ts
+++ b/src/render/scene-plan/__tests__/scene-plan.test.ts
@@ -173,18 +173,31 @@ describe('ScenePlan — handle discipline', () => {
 });
 
 describe('ScenePlan — backend neutrality (source-level)', () => {
-  it('imports nothing from the Rust boundary or any renderer backend', () => {
+  it('imports nothing from Three, the Rust boundary, or the legacy payload path', () => {
     const sources = readdirSync(SCENE_PLAN_DIR)
       .filter((f) => f.endsWith('.ts'))
       .map((f) => readFileSync(join(SCENE_PLAN_DIR, f), 'utf8'));
     expect(sources.length).toBeGreaterThan(0);
     for (const src of sources) {
-      // [LAW:one-source-of-truth] ScenePlan must not re-derive or depend on the
-      // frozen Rust-boundary payload (no dual ownership).
-      expect(src).not.toContain('boundary-contract');
+      // Assert the *imports*, not mere mentions: doc comments legitimately name
+      // PipelineInstallPayload to explain what ScenePlan replaces.
+      // [LAW:behavior-not-structure] Test the dependency, not the prose.
+
+      // [LAW:one-source-of-truth] No dependency on the frozen Rust-boundary
+      //   payload or the legacy GPU-IR/PipelineInstallPayload assembly path —
+      //   ScenePlan does not re-derive from or sync with a second target.
+      expect(src).not.toMatch(/from ['"][^'"]*boundary-contract/);
+      expect(src).not.toMatch(/from ['"][^'"]*pillars\/assembly/);
+      expect(src).not.toMatch(/from ['"][^'"]*render\/gpu-ir/);
+      expect(src).not.toMatch(/from ['"][^'"]*render\/rust/);
+      // Legacy payload types must not be imported even via a re-export barrel.
+      expect(src).not.toMatch(
+        /import\s+[^;]*(PipelineInstallPayload|ExprIR|RosterEntry|MemoryManifest|SourceBundle)[^;]*from/,
+      );
+
       // [LAW:locality-or-seam] No Three / WASM coupling leaks into the plan types.
       expect(src).not.toMatch(/from ['"]three/);
-      expect(src).not.toContain('render/wasm');
+      expect(src).not.toMatch(/from ['"][^'"]*render\/wasm/);
     }
   });
 });


### PR DESCRIPTION
Closes the orphaned `oscilla-pillars-scene-nt56.2` — *ScenePlan capability matrix for native blocks* (epic `oscilla-pillars-scene-nt56`).

## What & why
Block work crystallizes if every native block invents its own capability shape. This ratifies the existing ScenePlan type surface as the **one capability matrix** for the Three-native block library and locks it with tests. ScenePlan is the source of truth for backend-neutral execution data; the new doc is a *projection* of those types, **not** a parallel capability enum that could drift. `[LAW:one-source-of-truth]` `[LAW:types-are-the-program]`

## Changes
- **`design-docs/three-migration-capability-matrix.md`** — maps native block categories, port value kinds (`SceneValueKind`), the `PlanExpr` vocabulary, and render orchestration onto concrete ScenePlan data concepts, each marked **Realized** vs **Deferred**. Deferred capabilities (compute, post, mask, perspective camera, per-instance scale) land as discriminated variants or populated tables — never boolean flags. `[LAW:dataflow-not-control-flow]` `[LAW:no-mode-explosion]`
- **`capability-matrix.test.ts`** — builds one representative plan exercising every Realized variant (both geometries, all three color spaces, both materials, the full `PlanExpr` kind/operator vocabulary via a walker, populated compute/post tables) and proves it round-trips through JSON unchanged.
- **`scene-plan.test.ts`** — strengthens the source-level backend-neutrality guard to also reject imports of the legacy payload path (`pillars/assembly`, `render/gpu-ir`, `render/rust`, and `PipelineInstallPayload`/`ExprIR`/`RosterEntry`/`MemoryManifest`/`SourceBundle` types). Asserts the *import*, not the mention, so legitimate doc-comment prose naming `PipelineInstallPayload` is allowed. `[LAW:behavior-not-structure]` `[LAW:no-silent-failure]`

## Gap analysis (the "missing variants" clause)
Walking the first block set (instance sources, modifiers, draw/material shells, color, assets, validation) against the type surface: **no new ScenePlan variants are needed** — every capability is already representable. This ticket adds no speculative variants; new ones arrive with the tickets that actually need them (documented in the doc's Deferred register).

## Verification
- `npx vitest run src/render/scene-plan src/pillars/scene/` → **42 pass** (was 34; +8 new).
- `npm run typecheck` → clean.
- Guard regexes proven to fire on all 7 legacy-import forms and ignore legitimate prose (offline regex check).
- `npx eslint` on touched files → clean.

https://claude.ai/code/session_01JjUhtNw852fyaLWShLFv5i