### PR TITLE
feat(pillars-scene nt56.3): native insertability + diagnostics for scene blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@types/earcut": "^3.0.0",
     "@types/estree": "^1.0.8",
     "@types/node": "^25.0.10",
-    "@types/three": "0.184.1",
+    "@types/three": "0.185.0",
     "@vitest/coverage-v8": "^2.1.9",
     "dependency-cruiser": "^17.3.8",
     "eslint": "^9.39.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-dom": "^19.2.3",
     "reactflow": "^11.11.4",
     "simplex-noise": "^4.0.3",
-    "three": "0.184.0",
+    "three": "0.185.0",
     "wgsl_reflect": "^1.2.3",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,8 +120,8 @@ importers:
         specifier: ^25.0.10
         version: 25.0.10
       '@types/three':
-        specifier: 0.184.1
-        version: 0.184.1
+        specifier: 0.185.0
+        version: 0.185.0
       '@vitest/coverage-v8':
         specifier: ^2.1.9
         version: 2.1.9(vitest@2.1.9(@types/node@25.0.10)(jsdom@27.4.0))
@@ -1241,8 +1241,8 @@ packages:
   '@types/stats.js@0.17.4':
     resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
 
-  '@types/three@0.184.1':
-    resolution: {integrity: sha512-6q4VdiqVsrTRqmk62/BnlcAvIrnDM0zf2ZDVKI5kZiniWrSaOHaQzmbp+BNzoggc/8tgW412pL//wZIxu2PPTA==}
+  '@types/three@0.185.0':
+    resolution: {integrity: sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -4667,7 +4667,7 @@ snapshots:
 
   '@types/stats.js@0.17.4': {}
 
-  '@types/three@0.184.1':
+  '@types/three@0.185.0':
     dependencies:
       '@dimforge/rapier3d-compat': 0.12.0
       '@tweenjs/tween.js': 23.1.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       three:
-        specifier: 0.184.0
-        version: 0.184.0
+        specifier: 0.185.0
+        version: 0.185.0
       wgsl_reflect:
         specifier: ^1.2.3
         version: 1.2.3
@@ -3245,8 +3245,8 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
-  three@0.184.0:
-    resolution: {integrity: sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==}
+  three@0.185.0:
+    resolution: {integrity: sha512-+yRrcRO2iZa8uzvNNl0d7cL4huhgKgBvVJ0njcTe8xFqZ6DMAFZdCKDP91SEAuj25bNAj7k1QQdf+srZywVK6w==}
 
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
@@ -6874,7 +6874,7 @@ snapshots:
 
   text-table@0.2.0: {}
 
-  three@0.184.0: {}
+  three@0.185.0: {}
 
   through@2.3.8: {}
 

--- a/src/pillars/scene/__tests__/insertability.test.ts
+++ b/src/pillars/scene/__tests__/insertability.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for the palette insertability query (nt56.3): "given the port I selected,
+ * which blocks can connect here?" — answered from declared catalog ports, never a
+ * compile.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { buildSceneRegistry } from '../scene-block';
+import { ALL_SCENE_BLOCKS } from '../blocks';
+import { connectableScenePorts } from '../insertability';
+import type {
+  SceneBlockCategory,
+  SceneBlockDefinition,
+  SceneCatalogMetadata,
+  ScenePortDeclaration,
+  SceneRegistry,
+  SceneValueKind,
+} from '../scene-block';
+
+function port(
+  id: string,
+  direction: 'input' | 'output',
+  value: SceneValueKind,
+): ScenePortDeclaration {
+  return { id, label: id, direction, value };
+}
+
+function catalogOf(
+  type: string,
+  ports: readonly ScenePortDeclaration[],
+  category: SceneBlockCategory = 'instance',
+): SceneCatalogMetadata {
+  return { type, displayName: type, category, ports, configFields: [] };
+}
+
+function metadataRegistry(catalogs: readonly SceneCatalogMetadata[]): SceneRegistry {
+  const byType = new Map<string, SceneBlockDefinition<unknown>>(
+    catalogs.map((c) => [c.type, { catalog: c } as unknown as SceneBlockDefinition<unknown>]),
+  );
+  return { get: (t) => byType.get(t), catalog: catalogs };
+}
+
+describe('connectableScenePorts — over the native block set', () => {
+  const registry = buildSceneRegistry(ALL_SCENE_BLOCKS);
+
+  it('a selected instanceBundle output offers the draw primary input', () => {
+    const matches = connectableScenePorts(registry, { value: 'instanceBundle', direction: 'output' });
+    expect(matches).toHaveLength(1);
+    expect(matches[0]).toMatchObject({
+      blockType: 'DrawInstances',
+      displayName: 'Draw Instances',
+      port: { id: 'primary', direction: 'input', value: 'instanceBundle' },
+      compatibility: { kind: 'compatible' },
+    });
+  });
+
+  it('a selected instanceBundle input offers the grid instances output', () => {
+    const matches = connectableScenePorts(registry, { value: 'instanceBundle', direction: 'input' });
+    expect(matches.map((m) => m.blockType)).toEqual(['InstanceGrid']);
+    expect(matches[0].port).toMatchObject({ id: 'instances', direction: 'output' });
+  });
+
+  it('offers nothing for a value no port consumes (materialShell input)', () => {
+    expect(connectableScenePorts(registry, { value: 'materialShell', direction: 'output' })).toEqual([]);
+  });
+
+  it('excludes a hard mismatch — a scalar output finds no instanceBundle input', () => {
+    expect(connectableScenePorts(registry, { value: 'scalar', direction: 'output' })).toEqual([]);
+  });
+});
+
+describe('connectableScenePorts — adaptation and deferred kinds', () => {
+  it('offers an adapter-bridged candidate when a route declares one', () => {
+    const registry = metadataRegistry([catalogOf('ColorSink', [port('in', 'input', 'color')], 'color')]);
+    const matches = connectableScenePorts(
+      registry,
+      { value: 'scalar', direction: 'output' },
+      [{ from: 'scalar', to: 'color', via: 'ScalarToColor' }],
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].compatibility).toMatchObject({ kind: 'adaptationNeeded', via: 'ScalarToColor' });
+  });
+
+  it('never offers a deferred (mask) port — it has no lowering target', () => {
+    const registry = metadataRegistry([catalogOf('MaskSink', [port('in', 'input', 'mask')], 'draw')]);
+    expect(connectableScenePorts(registry, { value: 'mask', direction: 'output' })).toEqual([]);
+  });
+});

--- a/src/pillars/scene/__tests__/port-compatibility.test.ts
+++ b/src/pillars/scene/__tests__/port-compatibility.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the port-compatibility algebra (nt56.3). These pin the verdict
+ * for each shape of wire purely from the value-kind vocabulary and the route
+ * table — no registry, patch, or ScenePlan involved.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  compareScenePorts,
+  SCENE_VALUE_REALIZATION,
+  NATIVE_ADAPTATION_ROUTES,
+  type AdaptationRoute,
+} from '../port-compatibility';
+import type { SceneValueKind } from '../scene-block';
+
+describe('compareScenePorts', () => {
+  it('like-for-like realized kinds are directly compatible', () => {
+    expect(compareScenePorts('instanceBundle', 'instanceBundle')).toEqual({ kind: 'compatible' });
+    expect(compareScenePorts('scalar', 'scalar')).toEqual({ kind: 'compatible' });
+  });
+
+  it('unlike realized kinds with no route are a hard mismatch', () => {
+    expect(compareScenePorts('instanceBundle', 'scalar')).toEqual({
+      kind: 'mismatch',
+      from: 'instanceBundle',
+      to: 'scalar',
+    });
+  });
+
+  it('unlike kinds with a declared route need adaptation, naming the adapter', () => {
+    const routes: readonly AdaptationRoute[] = [
+      { from: 'scalar', to: 'color', via: 'ScalarToColor' },
+    ];
+    expect(compareScenePorts('scalar', 'color', routes)).toEqual({
+      kind: 'adaptationNeeded',
+      from: 'scalar',
+      to: 'color',
+      via: 'ScalarToColor',
+    });
+  });
+
+  it('a route is directional — it does not bridge the reverse wire', () => {
+    const routes: readonly AdaptationRoute[] = [
+      { from: 'scalar', to: 'color', via: 'ScalarToColor' },
+    ];
+    expect(compareScenePorts('color', 'scalar', routes).kind).toBe('mismatch');
+  });
+
+  it('a deferred kind (mask) on either side is unsupported, kind match notwithstanding', () => {
+    expect(compareScenePorts('mask', 'mask')).toEqual({ kind: 'unsupported', value: 'mask' });
+    expect(compareScenePorts('scalar', 'mask')).toEqual({ kind: 'unsupported', value: 'mask' });
+    expect(compareScenePorts('mask', 'scalar')).toEqual({ kind: 'unsupported', value: 'mask' });
+  });
+
+  it('classifies every value kind as realized or deferred (matrix §2 is total)', () => {
+    const kinds: readonly SceneValueKind[] = [
+      'instanceBundle',
+      'geometry',
+      'materialShell',
+      'texture',
+      'camera',
+      'color',
+      'scalar',
+      'mask',
+    ];
+    for (const k of kinds) {
+      expect(SCENE_VALUE_REALIZATION[k]).toMatch(/^(realized|deferred)$/);
+    }
+    // mask is the only deferred kind per the capability matrix.
+    const deferred = kinds.filter((k) => SCENE_VALUE_REALIZATION[k] === 'deferred');
+    expect(deferred).toEqual(['mask']);
+  });
+
+  it('ships no speculative native adaptation routes', () => {
+    expect(NATIVE_ADAPTATION_ROUTES).toEqual([]);
+  });
+});

--- a/src/pillars/scene/__tests__/validate.test.ts
+++ b/src/pillars/scene/__tests__/validate.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for ScenePlan-native patch validation (nt56.3). They exercise the four
+ * acceptance shapes — match, mismatch, missing-input, adaptation-needed — plus
+ * graceful handling of partial/unconnected graphs and a source-level guard that
+ * the validation layer stays off the legacy block ABI and Rust boundary.
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it, expect } from 'vitest';
+
+import { buildSceneRegistry } from '../scene-block';
+import { ALL_SCENE_BLOCKS } from '../blocks';
+import { validateScenePatch, formatSceneDiagnostic } from '../validate';
+import { makeGridOfSquaresPatch } from '../../fixtures/grid-of-squares';
+import type {
+  SceneBlockCategory,
+  SceneBlockDefinition,
+  SceneCatalogMetadata,
+  ScenePortDeclaration,
+  SceneRegistry,
+  SceneValueKind,
+} from '../scene-block';
+import type { AdaptationRoute } from '../port-compatibility';
+import type { PillarPatch } from '../../types';
+
+const SCENE_DIR = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function port(
+  id: string,
+  direction: 'input' | 'output',
+  value: SceneValueKind,
+): ScenePortDeclaration {
+  return { id, label: id, direction, value };
+}
+
+function catalogOf(
+  type: string,
+  ports: readonly ScenePortDeclaration[],
+  category: SceneBlockCategory = 'instance',
+): SceneCatalogMetadata {
+  return { type, displayName: type, category, ports, configFields: [] };
+}
+
+/**
+ * A registry built from declared catalog metadata alone — the only surface the
+ * validation layer reads. It lets a test pin a wire's verdict without authoring a
+ * full block `contribute()` body.
+ */
+function metadataRegistry(catalogs: readonly SceneCatalogMetadata[]): SceneRegistry {
+  const byType = new Map<string, SceneBlockDefinition<unknown>>(
+    catalogs.map((c) => [c.type, { catalog: c } as unknown as SceneBlockDefinition<unknown>]),
+  );
+  return { get: (t) => byType.get(t), catalog: catalogs };
+}
+
+function wire(source: string, target: string, inputSlot: string): PillarPatch['edges'][number] {
+  return { id: `${source}->${target}`, source, target, inputSlot, role: 'primary' };
+}
+
+describe('validateScenePatch — direct match', () => {
+  const registry = buildSceneRegistry(ALL_SCENE_BLOCKS);
+
+  it('accepts the authored Grid of Squares patch with no diagnostics', () => {
+    const result = validateScenePatch(registry, makeGridOfSquaresPatch());
+    expect(result.diagnostics).toEqual([]);
+    expect(result.edges).toEqual([{ edgeId: 'e0', compatibility: { kind: 'compatible' } }]);
+  });
+});
+
+describe('validateScenePatch — missing required input', () => {
+  const registry = buildSceneRegistry(ALL_SCENE_BLOCKS);
+
+  it('flags a draw whose primary instance input is unconnected', () => {
+    const patch: PillarPatch = {
+      blocks: [{ id: 'draw', kind: 'intent', type: 'DrawInstances', config: {} }],
+      edges: [],
+    };
+    const result = validateScenePatch(registry, patch);
+    const missing = result.diagnostics.filter((d) => d.kind === 'missingRequiredInput');
+    expect(missing).toHaveLength(1);
+    expect(missing[0]).toEqual({
+      kind: 'missingRequiredInput',
+      address: { blockId: 'draw', blockType: 'DrawInstances', portId: 'primary', value: 'instanceBundle' },
+    });
+  });
+});
+
+describe('validateScenePatch — incompatible wire (mismatch)', () => {
+  const registry = metadataRegistry([
+    catalogOf('Scalar', [port('out', 'output', 'scalar')]),
+    catalogOf('InstanceSink', [port('in', 'input', 'instanceBundle')], 'draw'),
+  ]);
+
+  it('reports a scalar output wired into an instanceBundle input', () => {
+    const patch: PillarPatch = {
+      blocks: [
+        { id: 's', kind: 'generator', type: 'Scalar', config: {} },
+        { id: 'k', kind: 'intent', type: 'InstanceSink', config: {} },
+      ],
+      edges: [wire('s', 'k', 'in')],
+    };
+    const result = validateScenePatch(registry, patch);
+    expect(result.edges[0].compatibility.kind).toBe('mismatch');
+    const incompatible = result.diagnostics.find((d) => d.kind === 'incompatiblePorts');
+    expect(incompatible).toMatchObject({
+      kind: 'incompatiblePorts',
+      from: { value: 'scalar', blockId: 's' },
+      to: { value: 'instanceBundle', blockId: 'k', portId: 'in' },
+    });
+  });
+});
+
+describe('validateScenePatch — adaptation needed', () => {
+  const registry = metadataRegistry([
+    catalogOf('Scalar', [port('out', 'output', 'scalar')]),
+    catalogOf('ColorSink', [port('in', 'input', 'color')], 'color'),
+  ]);
+  const routes: readonly AdaptationRoute[] = [{ from: 'scalar', to: 'color', via: 'ScalarToColor' }];
+
+  it('points a scalar→color wire at the explicit adapter block, not an implicit coercion', () => {
+    const patch: PillarPatch = {
+      blocks: [
+        { id: 's', kind: 'generator', type: 'Scalar', config: {} },
+        { id: 'c', kind: 'material', type: 'ColorSink', config: {} },
+      ],
+      edges: [wire('s', 'c', 'in')],
+    };
+    const result = validateScenePatch(registry, patch, routes);
+    expect(result.edges[0].compatibility).toEqual({
+      kind: 'adaptationNeeded',
+      from: 'scalar',
+      to: 'color',
+      via: 'ScalarToColor',
+    });
+    const adapt = result.diagnostics.find((d) => d.kind === 'adaptationRequired');
+    expect(adapt).toMatchObject({ kind: 'adaptationRequired', via: 'ScalarToColor' });
+    expect(formatSceneDiagnostic(adapt!)).toContain('ScalarToColor');
+  });
+});
+
+describe('validateScenePatch — unsupported (deferred) capability', () => {
+  const registry = metadataRegistry([
+    catalogOf('MaskGen', [port('out', 'output', 'mask')]),
+    catalogOf('MaskSink', [port('in', 'input', 'mask')], 'draw'),
+  ]);
+
+  it('reports a mask wire as unsupported — mask has no ScenePlan realization yet', () => {
+    const patch: PillarPatch = {
+      blocks: [
+        { id: 'm', kind: 'generator', type: 'MaskGen', config: {} },
+        { id: 'k', kind: 'intent', type: 'MaskSink', config: {} },
+      ],
+      edges: [wire('m', 'k', 'in')],
+    };
+    const result = validateScenePatch(registry, patch);
+    const unsupported = result.diagnostics.find((d) => d.kind === 'unsupportedCapability');
+    expect(unsupported).toMatchObject({ kind: 'unsupportedCapability', value: 'mask' });
+  });
+});
+
+describe('validateScenePatch — partial graphs never throw', () => {
+  const registry = buildSceneRegistry(ALL_SCENE_BLOCKS);
+
+  it('reports an unknown block type without throwing', () => {
+    const patch: PillarPatch = {
+      blocks: [{ id: 'x', kind: 'generator', type: 'NotABlock', config: {} }],
+      edges: [],
+    };
+    expect(() => validateScenePatch(registry, patch)).not.toThrow();
+    const result = validateScenePatch(registry, patch);
+    expect(result.diagnostics).toContainEqual({
+      kind: 'unknownBlock',
+      blockId: 'x',
+      blockType: 'NotABlock',
+    });
+  });
+
+  it('reports a dangling edge to a missing block as unresolved, not a crash', () => {
+    const patch: PillarPatch = { blocks: [], edges: [wire('a', 'b', 'primary')] };
+    const result = validateScenePatch(registry, patch);
+    expect(result.edges[0].compatibility).toEqual({ kind: 'unresolved' });
+    expect(result.diagnostics.some((d) => d.kind === 'danglingEdge' && d.endpoint === 'source')).toBe(true);
+    expect(result.diagnostics.some((d) => d.kind === 'danglingEdge' && d.endpoint === 'target')).toBe(true);
+  });
+
+  it('formats every diagnostic kind to a non-empty message', () => {
+    const patch: PillarPatch = {
+      blocks: [{ id: 'x', kind: 'generator', type: 'NotABlock', config: {} }],
+      edges: [wire('a', 'b', 'primary')],
+    };
+    const result = validateScenePatch(registry, patch);
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    for (const d of result.diagnostics) {
+      expect(formatSceneDiagnostic(d).length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('validateScenePatch — source-level backend neutrality', () => {
+  it('the validation layer imports neither the legacy block ABI nor the Rust boundary', () => {
+    const files = ['port-compatibility.ts', 'validate.ts', 'insertability.ts'];
+    for (const file of files) {
+      const src = readFileSync(join(SCENE_DIR, file), 'utf8');
+      expect(src).not.toMatch(/from ['"][^'"]*block-api/);
+      expect(src).not.toMatch(/from ['"][^'"]*boundary-contract/);
+      expect(src).not.toMatch(/from ['"]three/);
+    }
+  });
+});

--- a/src/pillars/scene/index.ts
+++ b/src/pillars/scene/index.ts
@@ -22,9 +22,33 @@ export {
   type SceneDiagnostic,
   type SceneCatalogMetadata,
   type ScenePortDeclaration,
+  type ScenePortDirection,
   type SceneValueKind,
   type InstanceBundle,
   type DrawShell,
   type MaterialShell,
   type SceneRegistry,
 } from './scene-block';
+
+// Validation & insertability — answer "what can connect here?" and surface
+// diagnostics from declared contracts, without running compileScenePlan.
+export {
+  compareScenePorts,
+  SCENE_VALUE_REALIZATION,
+  NATIVE_ADAPTATION_ROUTES,
+  type AdaptationRoute,
+  type PortCompatibility,
+} from './port-compatibility';
+export {
+  validateScenePatch,
+  formatSceneDiagnostic,
+  type SceneValidation,
+  type SceneValidationDiagnostic,
+  type SceneEdgeVerdict,
+  type ScenePortAddress,
+} from './validate';
+export {
+  connectableScenePorts,
+  type ScenePortSelection,
+  type ConnectableScenePort,
+} from './insertability';

--- a/src/pillars/scene/insertability.ts
+++ b/src/pillars/scene/insertability.ts
@@ -1,0 +1,93 @@
+/**
+ * src/pillars/scene/insertability.ts
+ *
+ * The palette query: "given the port I selected, which blocks can connect here?"
+ * It reads only declared catalog metadata (`SceneCatalogMetadata.ports`) — never
+ * a block's `contribute()` body and never a `ScenePlan`. The answer is a list of
+ * candidate ports tagged with the compatibility verdict, so the palette can show
+ * a direct wire distinctly from one that needs an adapter.
+ *
+ * [LAW:decomposition] Insertability and patch validation are two queries over the
+ *   same port-compatibility algebra; this part answers the palette's question and
+ *   nothing else.
+ * [LAW:effects-at-boundaries] Pure over declared data: same registry + selection
+ *   in, same candidate list out.
+ */
+
+import type {
+  SceneRegistry,
+  ScenePortDeclaration,
+  ScenePortDirection,
+  SceneValueKind,
+} from './scene-block';
+import {
+  compareScenePorts,
+  NATIVE_ADAPTATION_ROUTES,
+  type AdaptationRoute,
+  type PortCompatibility,
+} from './port-compatibility';
+
+/** The port the user has selected in the editor. */
+export interface ScenePortSelection {
+  readonly value: SceneValueKind;
+  readonly direction: ScenePortDirection;
+}
+
+/** A catalog port that can connect to the selection, with how it connects. */
+export interface ConnectableScenePort {
+  readonly blockType: string;
+  readonly displayName: string;
+  readonly port: ScenePortDeclaration;
+  readonly compatibility: PortCompatibility;
+}
+
+const OPPOSITE: Readonly<Record<ScenePortDirection, ScenePortDirection>> = {
+  input: 'output',
+  output: 'input',
+};
+
+/**
+ * Orient the selection and a candidate into the directional (`from` → `to`) pair
+ * the compatibility algebra expects: the output side is always `from`, the input
+ * side always `to`.
+ */
+function orient(
+  selection: ScenePortSelection,
+  candidate: SceneValueKind,
+): { readonly from: SceneValueKind; readonly to: SceneValueKind } {
+  return selection.direction === 'output'
+    ? { from: selection.value, to: candidate }
+    : { from: candidate, to: selection.value };
+}
+
+function isConnectable(verdict: PortCompatibility): boolean {
+  // A direct wire or an adapter-bridged wire is offerable; a mismatch or a
+  // deferred (unsupported) kind is not a valid insertion.
+  return verdict.kind === 'compatible' || verdict.kind === 'adaptationNeeded';
+}
+
+/**
+ * The catalog ports that can receive or feed the selected port. A selected output
+ * is matched against input ports; a selected input against output ports. Both
+ * direct and adapter-bridged candidates are returned, tagged by verdict; the
+ * palette decides how to present each.
+ */
+export function connectableScenePorts(
+  registry: SceneRegistry,
+  selection: ScenePortSelection,
+  routes: readonly AdaptationRoute[] = NATIVE_ADAPTATION_ROUTES,
+): readonly ConnectableScenePort[] {
+  const wantDirection = OPPOSITE[selection.direction];
+  const matches: ConnectableScenePort[] = [];
+  for (const block of registry.catalog) {
+    for (const port of block.ports) {
+      if (port.direction !== wantDirection) continue;
+      const { from, to } = orient(selection, port.value);
+      const compatibility = compareScenePorts(from, to, routes);
+      if (isConnectable(compatibility)) {
+        matches.push({ blockType: block.type, displayName: block.displayName, port, compatibility });
+      }
+    }
+  }
+  return matches;
+}

--- a/src/pillars/scene/port-compatibility.ts
+++ b/src/pillars/scene/port-compatibility.ts
@@ -1,0 +1,111 @@
+/**
+ * src/pillars/scene/port-compatibility.ts
+ *
+ * The typed algebra that answers "can a value of port kind A feed a port of kind
+ * B?" for the Three-native block library. It reads only the declared port value
+ * vocabulary (`SceneValueKind`) and the capability matrix — never a ScenePlan, a
+ * block's `contribute()` body, or the renderer.
+ *
+ * Scope authority: design-docs/three-migration-capability-matrix.md §2 (port
+ *   value kinds → ScenePlan data concept) and §6 (deferred capability register).
+ *
+ * [LAW:types-are-the-program] Compatibility is a discriminated *value*, not a
+ *   branch probe: every wire verdict is one `PortCompatibility`, so consumers
+ *   stay exhaustive and a new value kind forces a decision here, not a silent
+ *   fall-through at every callsite.
+ * [LAW:dataflow-not-control-flow] Which verdict a wire gets is decided by data
+ *   (the realization record and the route table), never by special-casing a
+ *   block type.
+ */
+
+import type { SceneValueKind } from './scene-block';
+
+/**
+ * The capability matrix §2 "Status" column, as data: which port value kinds have
+ * a ScenePlan realization today. `mask` is the sole deferred kind — a per-instance
+ * visibility predicate with no plan variant minted yet, so wiring it has no
+ * lowering target (matrix §6).
+ *
+ * [LAW:one-source-of-truth] This record is the code form of the matrix's
+ *   Realized/Deferred column; the prose doc projects it, not the reverse.
+ * [LAW:types-are-the-program] `Record<SceneValueKind, …>` is total: adding a
+ *   value kind is a compile error here until it is classified realized/deferred.
+ */
+export const SCENE_VALUE_REALIZATION: Readonly<
+  Record<SceneValueKind, 'realized' | 'deferred'>
+> = {
+  instanceBundle: 'realized',
+  geometry: 'realized',
+  materialShell: 'realized',
+  texture: 'realized',
+  camera: 'realized',
+  color: 'realized',
+  scalar: 'realized',
+  mask: 'deferred',
+};
+
+/**
+ * A declared bridge from one port value kind to another via an explicit adapter
+ * block the user must insert. Adaptation is never an implicit coercion: a wire
+ * that needs it is a diagnostic naming the adapter, not a silent conversion.
+ *
+ * The native adaptation vocabulary (broadcast, unit/color conversion,
+ * cross-domain remap) is owned by `oscilla-pillars-scene-brkm.1`; this table
+ * grows there as real adapter blocks land.
+ */
+export interface AdaptationRoute {
+  readonly from: SceneValueKind;
+  readonly to: SceneValueKind;
+  /** The adapter block type a user inserts to bridge `from` → `to`. */
+  readonly via: string;
+}
+
+/**
+ * The native adaptation routes. Empty today: the first block set wires only
+ * like-for-like kinds, and no value kind is silently coercible.
+ *
+ * [LAW:carrying-cost] A named slot, not built machinery — documenting that
+ *   adaptation is route-driven costs nothing; minting speculative routes before
+ *   a real adapter block exists would add carrying cost with no caller.
+ */
+export const NATIVE_ADAPTATION_ROUTES: readonly AdaptationRoute[] = [];
+
+/**
+ * The verdict of comparing a source output value kind (`from`) against a target
+ * input value kind (`to`). Directional: a route bridges `from` → `to`, not the
+ * reverse.
+ */
+export type PortCompatibility =
+  | { readonly kind: 'compatible' }
+  | {
+      readonly kind: 'adaptationNeeded';
+      readonly from: SceneValueKind;
+      readonly to: SceneValueKind;
+      readonly via: string;
+    }
+  | { readonly kind: 'mismatch'; readonly from: SceneValueKind; readonly to: SceneValueKind }
+  | { readonly kind: 'unsupported'; readonly value: SceneValueKind };
+
+/**
+ * Compare a source output kind against a target input kind.
+ *
+ * A deferred kind on either side wins first: it has no ScenePlan realization, so
+ * the wire cannot lower regardless of whether the kinds match. Then like-for-like
+ * is compatible; an unlike pair is bridgeable iff a route declares an adapter;
+ * otherwise it is a hard mismatch.
+ *
+ * [LAW:no-defensive-null-guards] Variability is in the returned value, not in
+ *   whether downstream code runs — callers match on the verdict.
+ */
+export function compareScenePorts(
+  from: SceneValueKind,
+  to: SceneValueKind,
+  routes: readonly AdaptationRoute[] = NATIVE_ADAPTATION_ROUTES,
+): PortCompatibility {
+  if (SCENE_VALUE_REALIZATION[to] === 'deferred') return { kind: 'unsupported', value: to };
+  if (SCENE_VALUE_REALIZATION[from] === 'deferred') return { kind: 'unsupported', value: from };
+  if (from === to) return { kind: 'compatible' };
+  const route = routes.find((r) => r.from === from && r.to === to);
+  if (route) return { kind: 'adaptationNeeded', from, to, via: route.via };
+  return { kind: 'mismatch', from, to };
+}

--- a/src/pillars/scene/scene-block.ts
+++ b/src/pillars/scene/scene-block.ts
@@ -88,6 +88,8 @@ export type SceneConfigFor<TFields extends SceneConfigFields> = {
 };
 
 export interface SceneCatalogMetadata {
+  /** The block type this catalog entry describes — what the palette instantiates. */
+  readonly type: string;
   readonly displayName: string;
   readonly category: SceneBlockCategory;
   readonly ports: readonly ScenePortDeclaration[];
@@ -120,7 +122,8 @@ export interface SceneBlockDeclaration<
 > {
   readonly type: string;
   readonly role: TRole;
-  readonly catalog: Omit<SceneCatalogMetadata, 'configFields'>;
+  // `type` and `configFields` are derived from the declaration, not repeated here.
+  readonly catalog: Omit<SceneCatalogMetadata, 'configFields' | 'type'>;
   readonly config: TFields;
   readonly contribute: (
     config: SceneConfigFor<TFields>,
@@ -142,6 +145,7 @@ export function defineSceneBlock<
     SceneConfigFor<TFields>
   >;
   const catalog: SceneCatalogMetadata = {
+    type: declaration.type,
     ...declaration.catalog,
     configFields: Object.entries(declaration.config).map(([key, field]) => ({
       key,

--- a/src/pillars/scene/validate.ts
+++ b/src/pillars/scene/validate.ts
@@ -1,0 +1,253 @@
+/**
+ * src/pillars/scene/validate.ts
+ *
+ * Validate an authored scene patch against the declared block contracts —
+ * without assembling a `ScenePlan`. The editor uses this to surface errors as
+ * the user wires blocks: per-edge compatibility verdicts plus a flat diagnostics
+ * list. It reads the registry's catalog metadata and the patch graph only; it
+ * never calls a block's `contribute()` or touches the renderer.
+ *
+ * [LAW:no-silent-failure] Every problem is a structured diagnostic; a partial or
+ *   unconnected graph yields diagnostics, never a throw.
+ * [LAW:dataflow-not-control-flow] An edge's outcome is a `PortCompatibility`
+ *   value mapped to a diagnostic value — there is no per-block branch in the
+ *   validation walk.
+ */
+
+import type { PillarBlock, PillarEdge, PillarPatch } from '../types';
+import type {
+  SceneRegistry,
+  ScenePortDeclaration,
+  SceneValueKind,
+} from './scene-block';
+import {
+  compareScenePorts,
+  NATIVE_ADAPTATION_ROUTES,
+  type AdaptationRoute,
+  type PortCompatibility,
+} from './port-compatibility';
+
+/** Where a port lives, for diagnostics and editor highlighting. */
+export interface ScenePortAddress {
+  readonly blockId: string;
+  readonly blockType: string;
+  readonly portId: string;
+  readonly value: SceneValueKind;
+}
+
+/**
+ * One problem found in a patch. Each kind is a *specific* diagnostic the editor
+ * can render distinctly. `unresolved*` kinds keep a partial graph from throwing.
+ */
+export type SceneValidationDiagnostic =
+  | { readonly kind: 'unknownBlock'; readonly blockId: string; readonly blockType: string }
+  | {
+      readonly kind: 'danglingEdge';
+      readonly edgeId: string;
+      readonly endpoint: 'source' | 'target';
+      readonly missingBlockId: string;
+    }
+  | {
+      readonly kind: 'unresolvedPort';
+      readonly edgeId: string;
+      readonly endpoint: 'source' | 'target';
+      readonly blockId: string;
+      readonly portId: string | null;
+    }
+  | {
+      readonly kind: 'incompatiblePorts';
+      readonly edgeId: string;
+      readonly from: ScenePortAddress;
+      readonly to: ScenePortAddress;
+    }
+  | {
+      readonly kind: 'adaptationRequired';
+      readonly edgeId: string;
+      readonly from: ScenePortAddress;
+      readonly to: ScenePortAddress;
+      readonly via: string;
+    }
+  | {
+      readonly kind: 'unsupportedCapability';
+      readonly edgeId: string;
+      readonly address: ScenePortAddress;
+      readonly value: SceneValueKind;
+    }
+  | { readonly kind: 'missingRequiredInput'; readonly address: ScenePortAddress };
+
+/** The per-edge verdict the editor can paint onto each wire. */
+export interface SceneEdgeVerdict {
+  readonly edgeId: string;
+  readonly compatibility: PortCompatibility | { readonly kind: 'unresolved' };
+}
+
+export interface SceneValidation {
+  readonly edges: readonly SceneEdgeVerdict[];
+  readonly diagnostics: readonly SceneValidationDiagnostic[];
+}
+
+const UNRESOLVED: SceneEdgeVerdict['compatibility'] = { kind: 'unresolved' };
+
+function addressOf(block: PillarBlock, port: ScenePortDeclaration): ScenePortAddress {
+  return { blockId: block.id, blockType: block.type, portId: port.id, value: port.value };
+}
+
+/**
+ * The output port an edge draws *from*. The edge model names only the target's
+ * input slot, so the source port is resolved by elimination: a block with a
+ * single output has an unambiguous one. Zero or many outputs cannot be resolved
+ * from the edge alone — that is surfaced, not guessed.
+ */
+function soleOutputPort(ports: readonly ScenePortDeclaration[]): ScenePortDeclaration | null {
+  const outputs = ports.filter((p) => p.direction === 'output');
+  return outputs.length === 1 ? outputs[0] : null;
+}
+
+/**
+ * Map a non-compatible verdict to its diagnostic. `compatible` produces none —
+ * it is recorded only as the edge verdict. Exhaustive over the union so a new
+ * verdict kind forces a decision here.
+ */
+function diagnoseEdge(
+  edgeId: string,
+  from: ScenePortAddress,
+  to: ScenePortAddress,
+  verdict: PortCompatibility,
+): SceneValidationDiagnostic | null {
+  switch (verdict.kind) {
+    case 'compatible':
+      return null;
+    case 'mismatch':
+      return { kind: 'incompatiblePorts', edgeId, from, to };
+    case 'adaptationNeeded':
+      return { kind: 'adaptationRequired', edgeId, from, to, via: verdict.via };
+    case 'unsupported': {
+      // Report the deferred endpoint: it is whichever side carries the kind.
+      const address = to.value === verdict.value ? to : from;
+      return { kind: 'unsupportedCapability', edgeId, address, value: verdict.value };
+    }
+    default:
+      return assertNever(verdict);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`[scene] unhandled compatibility verdict: ${JSON.stringify(value)}`);
+}
+
+export function validateScenePatch(
+  registry: SceneRegistry,
+  patch: PillarPatch,
+  routes: readonly AdaptationRoute[] = NATIVE_ADAPTATION_ROUTES,
+): SceneValidation {
+  const diagnostics: SceneValidationDiagnostic[] = [];
+  const blocksById = new Map(patch.blocks.map((b) => [b.id, b]));
+
+  // Unknown block types: the palette wired a type the registry does not define.
+  for (const block of patch.blocks) {
+    if (registry.get(block.type) === undefined) {
+      diagnostics.push({ kind: 'unknownBlock', blockId: block.id, blockType: block.type });
+    }
+  }
+
+  // Required inputs: every declared input port must be fed by an edge. (No scene
+  // input is optional today; an optional flag would be added to the contract
+  // before any input could go unwired.)
+  for (const block of patch.blocks) {
+    const def = registry.get(block.type);
+    if (def === undefined) continue;
+    for (const port of def.catalog.ports) {
+      if (port.direction !== 'input') continue;
+      const fed = patch.edges.some((e) => e.target === block.id && e.inputSlot === port.id);
+      if (!fed) diagnostics.push({ kind: 'missingRequiredInput', address: addressOf(block, port) });
+    }
+  }
+
+  const edges = patch.edges.map((edge) =>
+    verdictForEdge(edge, registry, blocksById, routes, diagnostics),
+  );
+  return { edges, diagnostics };
+}
+
+/**
+ * The human-readable form of a diagnostic, for the editor's error surface.
+ *
+ * [LAW:one-source-of-truth] Derived from the structured diagnostic on demand —
+ *   never stored on it, so the message cannot drift from its fields. Exhaustive
+ *   over the union: a new diagnostic kind is a compile error until phrased.
+ */
+export function formatSceneDiagnostic(d: SceneValidationDiagnostic): string {
+  switch (d.kind) {
+    case 'unknownBlock':
+      return `[scene] block '${d.blockId}': unknown block type '${d.blockType}'`;
+    case 'danglingEdge':
+      return `[scene] edge '${d.edgeId}': ${d.endpoint} block '${d.missingBlockId}' does not exist`;
+    case 'unresolvedPort':
+      return d.endpoint === 'source'
+        ? `[scene] edge '${d.edgeId}': cannot resolve a single output port on source block '${d.blockId}'`
+        : `[scene] edge '${d.edgeId}': block '${d.blockId}' has no input port '${d.portId}'`;
+    case 'incompatiblePorts':
+      return `[scene] edge '${d.edgeId}': '${d.from.value}' (from '${d.from.blockId}') cannot connect to '${d.to.value}' (on '${d.to.blockId}.${d.to.portId}')`;
+    case 'adaptationRequired':
+      return `[scene] edge '${d.edgeId}': '${d.from.value}' → '${d.to.value}' needs an explicit adapter block '${d.via}'; implicit coercion is not allowed`;
+    case 'unsupportedCapability':
+      return `[scene] edge '${d.edgeId}': port value '${d.value}' (on '${d.address.blockId}.${d.address.portId}') has no ScenePlan realization yet`;
+    case 'missingRequiredInput':
+      return `[scene] block '${d.address.blockId}': required input '${d.address.portId}' (${d.address.value}) is not connected`;
+    default:
+      return assertNever(d);
+  }
+}
+
+/**
+ * The compatibility verdict for one edge, accumulating any diagnostic it raises.
+ * Each unresolved step (missing block, unknown type, unresolvable port) yields an
+ * `unresolved` verdict rather than throwing, so a half-wired graph still validates.
+ */
+function verdictForEdge(
+  edge: PillarEdge,
+  registry: SceneRegistry,
+  blocksById: ReadonlyMap<string, PillarBlock>,
+  routes: readonly AdaptationRoute[],
+  diagnostics: SceneValidationDiagnostic[],
+): SceneEdgeVerdict {
+  const sourceBlock = blocksById.get(edge.source);
+  const targetBlock = blocksById.get(edge.target);
+  if (sourceBlock === undefined) {
+    diagnostics.push({ kind: 'danglingEdge', edgeId: edge.id, endpoint: 'source', missingBlockId: edge.source });
+  }
+  if (targetBlock === undefined) {
+    diagnostics.push({ kind: 'danglingEdge', edgeId: edge.id, endpoint: 'target', missingBlockId: edge.target });
+  }
+  if (sourceBlock === undefined || targetBlock === undefined) {
+    return { edgeId: edge.id, compatibility: UNRESOLVED };
+  }
+
+  const sourceDef = registry.get(sourceBlock.type);
+  const targetDef = registry.get(targetBlock.type);
+  // Unknown block types are already reported above; the wire is unresolvable.
+  if (sourceDef === undefined || targetDef === undefined) {
+    return { edgeId: edge.id, compatibility: UNRESOLVED };
+  }
+
+  const sourcePort = soleOutputPort(sourceDef.catalog.ports);
+  const targetPort = targetDef.catalog.ports.find(
+    (p) => p.direction === 'input' && p.id === edge.inputSlot,
+  );
+  if (sourcePort === null) {
+    diagnostics.push({ kind: 'unresolvedPort', edgeId: edge.id, endpoint: 'source', blockId: sourceBlock.id, portId: null });
+  }
+  if (targetPort === undefined) {
+    diagnostics.push({ kind: 'unresolvedPort', edgeId: edge.id, endpoint: 'target', blockId: targetBlock.id, portId: edge.inputSlot });
+  }
+  if (sourcePort === null || targetPort === undefined) {
+    return { edgeId: edge.id, compatibility: UNRESOLVED };
+  }
+
+  const from = addressOf(sourceBlock, sourcePort);
+  const to = addressOf(targetBlock, targetPort);
+  const compatibility = compareScenePorts(sourcePort.value, targetPort.value, routes);
+  const diagnostic = diagnoseEdge(edge.id, from, to, compatibility);
+  if (diagnostic !== null) diagnostics.push(diagnostic);
+  return { edgeId: edge.id, compatibility };
+}


### PR DESCRIPTION
## What

Implements **oscilla-pillars-scene-nt56.3** — ScenePlan-native insertability and diagnostics. The editor can now answer "what can connect here?" and surface clear errors **from declared scene block contracts, without running `compileScenePlan`**.

Three focused parts over the capability-matrix port vocabulary (`src/pillars/scene/`):

- **`port-compatibility.ts`** — the typed algebra. `SCENE_VALUE_REALIZATION` encodes the matrix §2 Realized/Deferred column as data (`mask` is the sole deferred kind → wiring it has no lowering target). `compareScenePorts` returns a discriminated `PortCompatibility` value (`compatible | adaptationNeeded | mismatch | unsupported`). Adaptation is route-driven and never an implicit coercion; the native route table is empty (owned by `brkm.1`).
- **`validate.ts`** — `validateScenePatch` → per-edge verdicts + a discriminated diagnostics list (`unknownBlock`, `danglingEdge`, `unresolvedPort`, `incompatiblePorts`, `adaptationRequired`, `unsupportedCapability`, `missingRequiredInput`). Partial/unconnected graphs validate without throwing. `formatSceneDiagnostic` derives human messages (never stored → can't drift).
- **`insertability.ts`** — `connectableScenePorts` answers the palette query from catalog metadata only; it cannot reach a block's `contribute()` body.

`SceneCatalogMetadata` gains `type` (derived from the declaration, one source of truth) so the palette can name the block to instantiate from declared metadata alone.

## Acceptance

- Selecting a port yields the correct connectable-block set; incompatible wire + missing-required-input each produce a specific diagnostic; a partial graph validates without throwing. ✅
- `npx vitest run src/pillars/scene/` passes (45 tests), covering **match, mismatch, missing-input, adaptation-needed** (+ deferred `mask`). ✅
- Source-level guard proves the layer imports neither `src/pillars/block-api.ts` nor the Rust boundary contract. ✅
- Full suite green (2238 passed), `tsc --noEmit` clean, ESLint clean.

## Note on bundled commits

This branch also carries two commits that precede the nt56.3 work:
- The **stranded nt56.2 deliverable** (`feat(pillars-scene nt56.2): capability matrix + enforcement tests`). nt56.2 is closed in lit but its capability-matrix doc — the **scope authority** for this ticket — was never merged to master. Rather than build on a missing foundation or duplicate the doc, it's cherry-picked here so the matrix lands with the layer that consumes it. The abandoned `oscilla-pillars-scene-nt56.2_capability-matrix` branch can be deleted after merge.
- A pre-existing **three.js 0.184→0.185 bump** already committed to local master but unpushed to origin.

[LAW:types-are-the-program] · [LAW:dataflow-not-control-flow]

https://claude.ai/code/session_01JjUhtNw852fyaLWShLFv5i