### PR TITLE
docs(pillars-scene brkm.1): record empty native adaptation table decision

### DIFF
--- a/src/pillars/scene/port-compatibility.ts
+++ b/src/pillars/scene/port-compatibility.ts
@@ -49,9 +49,12 @@ export const SCENE_VALUE_REALIZATION: Readonly<
  * block the user must insert. Adaptation is never an implicit coercion: a wire
  * that needs it is a diagnostic naming the adapter, not a silent conversion.
  *
- * The native adaptation vocabulary (broadcast, unit/color conversion,
- * cross-domain remap) is owned by `oscilla-pillars-scene-brkm.1`; this table
- * grows there as real adapter blocks land.
+ * The native adaptation vocabulary was investigated (brkm.1) and is empty by
+ * decision: broadcast and unit conversion are unrepresentable in this model (no
+ * cardinality axis, no unit type), color-space difference is resolved inside
+ * color-consuming blocks (not a wire coercion), and cross-domain remap is a
+ * deferred ScenePlan binding owned by the demo that needs it — not a route. This
+ * table grows only if a future ticket cuts a real adapter block to register here.
  */
 export interface AdaptationRoute {
   readonly from: SceneValueKind;


### PR DESCRIPTION
## What

Closes the brkm.1 investigation (*native port adaptation needs*) by recording its decision in the code that owns the extension point.

**Decision:** `NATIVE_ADAPTATION_ROUTES` stays empty. All four adaptation kinds the ticket asked about close as **not-needed** — no native adaptation block/feature tickets cut, no rerank. Mirrors how brkm.2 resolved.

| Kind | Verdict |
|------|---------|
| Broadcast (signal→field) | Unrepresentable: ScenePlan has no cardinality axis; a `scalar` `PlanExpr` is evaluated per-instance in TSL, so it broadcasts by evaluation. |
| Unit conversion | Unrepresentable: no unit type; authored as ordinary math (Expression × const). |
| Color conversion (hsl↔rgb) | Not a port adaptation: `color→color` is `compatible`; space difference resolved inside color-consuming blocks (Brightness). Vocabulary owned by brkm.3 / nt56.5. |
| Cross-domain / field remap | Deferred ScenePlan binding owned by the demo that needs it (nt56.8 territory), not a port-coercion route. |

## Why a code change

The investigation's deliverable is the backlog decision (recorded on the lit ticket, now closed). This commit only fixes the one stale `port-compatibility.ts` comment that named brkm.1 as the table's *pending owner* — now that brkm.1 has concluded, that pointer would have been a lie. The `AdaptationRoute` extension slot stays as the named-but-empty registration point (`[LAW:carrying-cost]`); it grows only if a future ticket cuts a real adapter block.

## Verification

- `npm run typecheck` — clean
- `npx eslint src/pillars/scene/port-compatibility.ts` — clean
- Comment-only change; no behavior affected.

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7