### PR TITLE
feat(pillars-scene nt56.15): persist authored PillarPatch across reload

### DIFF
--- a/src/pillars/__tests__/persistence.test.ts
+++ b/src/pillars/__tests__/persistence.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Round-trip contract for the pure pillar-patch wire format.
+ *
+ * [LAW:behavior-not-structure] Assert the meaning: every authored demo patch
+ *   survives serialize → deserialize unchanged, and an unreadable blob becomes a
+ *   typed failure rather than a thrown exception or a partial patch.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { SCENE_PLAN_DEMOS } from '../fixtures/scene-demos';
+import {
+  PILLAR_PATCH_FORMAT_VERSION,
+  deserializePillarPatch,
+  serializePillarPatch,
+} from '../persistence';
+
+describe('pillar-patch serialization', () => {
+  it('round-trips every authored demo patch with no loss', () => {
+    for (const [id, demo] of Object.entries(SCENE_PLAN_DEMOS)) {
+      const patch = demo.makePatch();
+      const result = deserializePillarPatch(serializePillarPatch(patch));
+      expect(result.ok, `${id} should deserialize`).toBe(true);
+      if (result.ok) {
+        expect(result.patch, `${id} should round-trip unchanged`).toEqual(patch);
+      }
+    }
+  });
+
+  it('writes a versioned envelope', () => {
+    const patch = SCENE_PLAN_DEMOS['grid-of-squares'].makePatch();
+    const envelope = JSON.parse(serializePillarPatch(patch)) as { version: number };
+    expect(envelope.version).toBe(PILLAR_PATCH_FORMAT_VERSION);
+  });
+
+  it('fails on a non-JSON string instead of throwing', () => {
+    const result = deserializePillarPatch('{ not json');
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/not valid JSON/);
+  });
+
+  it('fails on valid JSON that is not a patch envelope', () => {
+    const result = deserializePillarPatch(JSON.stringify({ hello: 'world' }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error).toMatch(/envelope/);
+  });
+
+  it('rejects an envelope from an unknown future version', () => {
+    const patch = SCENE_PLAN_DEMOS['grid-of-squares'].makePatch();
+    const futureBlob = JSON.stringify({ version: PILLAR_PATCH_FORMAT_VERSION + 1, patch });
+    const result = deserializePillarPatch(futureBlob);
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects a patch with a structurally invalid block', () => {
+    // `kind` is an enum; an arbitrary string is not a legal PillarKind.
+    const bad = JSON.stringify({
+      version: PILLAR_PATCH_FORMAT_VERSION,
+      patch: {
+        blocks: [{ id: 'b0', kind: 'not-a-kind', type: 'InstanceGrid', config: {} }],
+        edges: [],
+      },
+    });
+    const result = deserializePillarPatch(bad);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/pillars/persistence.ts
+++ b/src/pillars/persistence.ts
@@ -1,0 +1,65 @@
+/**
+ * src/pillars/persistence.ts
+ *
+ * The wire format for an authored `PillarPatch`: a pure, versioned, lossless
+ * round-trip between a `PillarPatch` and a string. This module performs NO I/O —
+ * it neither reads nor writes storage. [LAW:effects-at-boundaries] The effectful
+ * shell (localStorage read/write, first-visit default) lives in
+ * `src/services/PillarPatchPersistence.ts`; this is the pure core both that shell
+ * and the round-trip test exercise without a storage mock.
+ *
+ * Deserialization is a trust boundary: the input string is untrusted (a user may
+ * hand-edit it, or an older app version may have written it). It returns a
+ * discriminated ok|error value, never throws and never silently produces a
+ * partial patch. [LAW:types-are-the-program] [LAW:no-silent-failure]
+ */
+
+import { z } from 'zod';
+
+import { PillarPatchSchema, type PillarPatch } from './types';
+
+/**
+ * The persisted envelope version. A blob written by a future, incompatible
+ * schema must be REJECTED loudly rather than mis-parsed against today's shape;
+ * `z.literal` makes any other value fail the parse. [LAW:no-silent-failure]
+ * This is a single guard with one current value, not a mode to branch on.
+ * [LAW:no-mode-explosion]
+ */
+export const PILLAR_PATCH_FORMAT_VERSION = 1 as const;
+
+const SerializedPillarPatchSchema = z.object({
+  version: z.literal(PILLAR_PATCH_FORMAT_VERSION),
+  patch: PillarPatchSchema,
+});
+
+/** A deserialize attempt: a valid patch, or a human-readable reason it failed. */
+export type DeserializeResult =
+  | { readonly ok: true; readonly patch: PillarPatch }
+  | { readonly ok: false; readonly error: string };
+
+/** Serialize an authored patch to a versioned JSON string for storage. */
+export function serializePillarPatch(patch: PillarPatch): string {
+  return JSON.stringify({ version: PILLAR_PATCH_FORMAT_VERSION, patch });
+}
+
+/**
+ * Parse a persisted string back into a `PillarPatch`. The two failure modes —
+ * the string is not JSON, or the JSON is not a valid versioned patch — both
+ * become a typed `{ ok: false }` so callers handle absence-of-valid-data as
+ * data, not as a thrown exception. [LAW:dataflow-not-control-flow]
+ */
+export function deserializePillarPatch(text: string): DeserializeResult {
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { ok: false, error: `not valid JSON: ${detail}` };
+  }
+
+  const parsed = SerializedPillarPatchSchema.safeParse(json);
+  if (!parsed.success) {
+    return { ok: false, error: `not a valid PillarPatch envelope: ${parsed.error.message}` };
+  }
+  return { ok: true, patch: parsed.data.patch };
+}

--- a/src/pillars/types/graph.ts
+++ b/src/pillars/types/graph.ts
@@ -4,26 +4,56 @@
  * The user-authored graph type. PillarPatch is the input to the frontend.
  * Compiler-internal types (NormalizedGraph, LoweringContext, BlockDefinition,
  * etc.) live in block-api.ts and the phase directories.
+ *
+ * The shape is expressed as Zod schemas so the runtime validator (used at the
+ * persistence trust boundary — see src/pillars/persistence.ts), the JSON
+ * round-trip, and the TypeScript type are ONE artifact rather than three that
+ * drift. [LAW:one-source-of-truth] This mirrors the type-system layer in
+ * `schemas.ts`: a hand-edited or stale-version persisted patch fails
+ * `PillarPatchSchema.safeParse` at runtime AND a structurally-wrong literal is
+ * unassignable at compile time. [LAW:types-are-the-program]
  */
 
-export type PillarKind = 'generator' | 'modifier' | 'material' | 'intent';
+import { z } from 'zod';
 
-export interface PillarBlock {
-  readonly id: string;
-  readonly kind: PillarKind;
-  readonly type: string;
-  readonly config: Readonly<Record<string, unknown>>;
-}
+export const PillarKindSchema = z.enum(['generator', 'modifier', 'material', 'intent']);
+export type PillarKind = z.infer<typeof PillarKindSchema>;
 
-export interface PillarEdge {
-  readonly id: string;
-  readonly source: string;
-  readonly target: string;
-  readonly inputSlot: string;
-  readonly role: 'primary' | 'secondary' | 'material';
-}
+/** The edge's role; see PillarEdgeSchema. */
+export const PillarEdgeRoleSchema = z.enum(['primary', 'secondary', 'material']);
+export type PillarEdgeRole = z.infer<typeof PillarEdgeRoleSchema>;
 
-export interface PillarPatch {
-  readonly blocks: readonly PillarBlock[];
-  readonly edges: readonly PillarEdge[];
-}
+/**
+ * A block's config is an open bag of authored control values (numbers, strings,
+ * booleans). It is deliberately `unknown`-valued here — the block's own schema
+ * validates the payload on compile, so the persistence boundary only asserts the
+ * *envelope* shape, never re-validates config semantics. [LAW:single-enforcer]
+ */
+export const PillarBlockSchema = z
+  .object({
+    id: z.string(),
+    kind: PillarKindSchema,
+    type: z.string(),
+    config: z.record(z.string(), z.unknown()).readonly(),
+  })
+  .readonly();
+export type PillarBlock = z.infer<typeof PillarBlockSchema>;
+
+export const PillarEdgeSchema = z
+  .object({
+    id: z.string(),
+    source: z.string(),
+    target: z.string(),
+    inputSlot: z.string(),
+    role: PillarEdgeRoleSchema,
+  })
+  .readonly();
+export type PillarEdge = z.infer<typeof PillarEdgeSchema>;
+
+export const PillarPatchSchema = z
+  .object({
+    blocks: z.array(PillarBlockSchema).readonly(),
+    edges: z.array(PillarEdgeSchema).readonly(),
+  })
+  .readonly();
+export type PillarPatch = z.infer<typeof PillarPatchSchema>;

--- a/src/services/PillarPatchPersistence.ts
+++ b/src/services/PillarPatchPersistence.ts
@@ -1,0 +1,80 @@
+/**
+ * src/services/PillarPatchPersistence.ts
+ *
+ * The effectful shell around the pure pillar-patch wire format
+ * (src/pillars/persistence.ts): it reads and writes the authored `PillarPatch`
+ * to localStorage. This is the one place pillar-patch persistence touches the
+ * world. [LAW:effects-at-boundaries]
+ *
+ * [LAW:single-enforcer] localStorage capability detection is delegated to
+ *   `resolveLocalStorageCapability` (shared with V1 patch persistence), not
+ *   re-implemented here.
+ * [LAW:no-silent-failure] A read that finds a value it cannot parse is reported
+ *   as `failed`, never silently collapsed into `empty` — the difference between
+ *   "the user has no saved patch" and "the user's saved patch was lost" must
+ *   reach the diagnostics boundary, not be swallowed.
+ */
+
+import {
+  deserializePillarPatch,
+  serializePillarPatch,
+} from '../pillars/persistence';
+import type { PillarPatch } from '../pillars/types';
+import { resolveLocalStorageCapability } from './local-storage-capability';
+
+/** Namespaced + version-suffixed so it never collides with the V1 patch key. */
+export const PILLAR_PATCH_STORAGE_KEY = 'oscilla-pillar-patch-v1';
+
+/**
+ * The outcome of a load. `empty` (no capability, or nothing stored) is the
+ * first-visit case the caller answers with the default starter patch; `failed`
+ * is a stored-but-unrecoverable patch the caller must surface loudly before
+ * falling back. [LAW:dataflow-not-control-flow]
+ */
+export type PillarPatchLoadResult =
+  | { readonly kind: 'loaded'; readonly patch: PillarPatch }
+  | { readonly kind: 'empty' }
+  | { readonly kind: 'failed'; readonly error: string };
+
+/** The outcome of a save: success, or a human-readable write failure. */
+export type PillarPatchSaveResult =
+  | { readonly kind: 'saved' }
+  | { readonly kind: 'failed'; readonly error: string };
+
+/**
+ * Persist the authored patch. Absence of a storage capability (Node/SSR/test)
+ * is not a failure — there is simply nothing to write — so it returns `saved`.
+ * Only a real write rejection (e.g. quota exceeded) is a `failed`.
+ */
+export function savePillarPatchToStorage(patch: PillarPatch): PillarPatchSaveResult {
+  const storage = resolveLocalStorageCapability();
+  if (storage === null) return { kind: 'saved' };
+  try {
+    storage.setItem(PILLAR_PATCH_STORAGE_KEY, serializePillarPatch(patch));
+    return { kind: 'saved' };
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { kind: 'failed', error: `failed to write authored patch to storage: ${detail}` };
+  }
+}
+
+/** Read the authored patch back. See `PillarPatchLoadResult` for the cases. */
+export function loadPillarPatchFromStorage(): PillarPatchLoadResult {
+  const storage = resolveLocalStorageCapability();
+  if (storage === null) return { kind: 'empty' };
+
+  let stored: string | null;
+  try {
+    stored = storage.getItem(PILLAR_PATCH_STORAGE_KEY);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { kind: 'failed', error: `failed to read authored patch from storage: ${detail}` };
+  }
+  if (stored === null) return { kind: 'empty' };
+
+  const result = deserializePillarPatch(stored);
+  if (!result.ok) {
+    return { kind: 'failed', error: `stored authored patch is unreadable: ${result.error}` };
+  }
+  return { kind: 'loaded', patch: result.patch };
+}

--- a/src/services/RuntimeService.ts
+++ b/src/services/RuntimeService.ts
@@ -472,6 +472,13 @@ export class RuntimeService {
     await this.installEditorPlan(initial.plan);
     this.scenePlanInstalled = true;
 
+    // [LAW:single-enforcer] The native editor thread is where the authored patch
+    //   becomes live and user-editable, so it is where its persistence begins.
+    //   Save failures route to the diagnostics boundary this service owns.
+    store.pillarPatch.startPersistence((message) => {
+      store.diagnostics.log({ level: 'warn', message: `PillarPatchPersistence(save): ${message}` });
+    });
+
     // [LAW:effects-at-boundaries] The store computes the plan (pure); this
     //   reaction is the single effect boundary that installs it.
     // [LAW:dataflow-not-control-flow] An edit that fails to compile skips the

--- a/src/services/__tests__/PillarPatchPersistence.test.ts
+++ b/src/services/__tests__/PillarPatchPersistence.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Storage shell contract for pillar-patch persistence.
+ *
+ * [LAW:behavior-not-structure] Assert the meaning: an authored patch saved to
+ *   storage loads back identically (survives reload); no saved patch reports
+ *   `empty` (the first-visit default case); a stored-but-unreadable patch reports
+ *   `failed` (never silently treated as empty). [LAW:no-silent-failure]
+ *
+ * `resolveLocalStorageCapability` accepts only a `value` descriptor on
+ * `globalThis.localStorage` in the Node test runtime, so the mock is installed
+ * that way (mirroring the V1 PatchPersistence test).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { makeGridOfSquaresPatch } from '../../pillars/fixtures/grid-of-squares';
+import { serializePillarPatch } from '../../pillars/persistence';
+import {
+  PILLAR_PATCH_STORAGE_KEY,
+  loadPillarPatchFromStorage,
+  savePillarPatchToStorage,
+} from '../PillarPatchPersistence';
+
+const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+function installStorage(store: Map<string, string>): void {
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+    },
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (originalLocalStorage) {
+    Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+  } else {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  }
+});
+
+describe('pillar-patch storage', () => {
+  it('round-trips an authored patch across save → load (survives reload)', () => {
+    installStorage(new Map());
+    const patch = makeGridOfSquaresPatch();
+
+    expect(savePillarPatchToStorage(patch)).toEqual({ kind: 'saved' });
+
+    const loaded = loadPillarPatchFromStorage();
+    expect(loaded.kind).toBe('loaded');
+    if (loaded.kind === 'loaded') expect(loaded.patch).toEqual(patch);
+  });
+
+  it('reports empty when nothing is stored (first-visit default case)', () => {
+    installStorage(new Map());
+    expect(loadPillarPatchFromStorage()).toEqual({ kind: 'empty' });
+  });
+
+  it('reports empty when no storage capability exists', () => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    expect(loadPillarPatchFromStorage()).toEqual({ kind: 'empty' });
+  });
+
+  it('reports failed for a stored-but-unreadable patch instead of empty', () => {
+    const store = new Map<string, string>([[PILLAR_PATCH_STORAGE_KEY, '{ corrupt']]);
+    installStorage(store);
+    const loaded = loadPillarPatchFromStorage();
+    expect(loaded.kind).toBe('failed');
+    if (loaded.kind === 'failed') expect(loaded.error).toMatch(/unreadable/);
+  });
+
+  it('reports failed when a write rejects (e.g. quota)', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('quota exceeded');
+        },
+      },
+    });
+    const result = savePillarPatchToStorage(makeGridOfSquaresPatch());
+    expect(result.kind).toBe('failed');
+    if (result.kind === 'failed') expect(result.error).toMatch(/quota exceeded/);
+  });
+
+  it('is no-op success when no storage capability exists', () => {
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+    expect(savePillarPatchToStorage(makeGridOfSquaresPatch())).toEqual({ kind: 'saved' });
+  });
+
+  it('rejects a patch persisted under an incompatible future version', () => {
+    const futureBlob = JSON.stringify({ version: 999, patch: makeGridOfSquaresPatch() });
+    const store = new Map<string, string>([[PILLAR_PATCH_STORAGE_KEY, futureBlob]]);
+    installStorage(store);
+    expect(loadPillarPatchFromStorage().kind).toBe('failed');
+
+    // Sanity: the current version under the same key loads.
+    store.set(PILLAR_PATCH_STORAGE_KEY, serializePillarPatch(makeGridOfSquaresPatch()));
+    expect(loadPillarPatchFromStorage().kind).toBe('loaded');
+  });
+});

--- a/src/stores/PillarPatchStore.ts
+++ b/src/stores/PillarPatchStore.ts
@@ -17,10 +17,11 @@
  *   data the runtime and UI read, not a branch this store takes.
  */
 
-import { makeAutoObservable } from 'mobx';
+import { makeAutoObservable, reaction } from 'mobx';
 
 import { makeGridOfSquaresPatch } from '../pillars/fixtures/grid-of-squares';
 import type { PillarBlock, PillarEdge, PillarPatch } from '../pillars/types';
+import { savePillarPatchToStorage } from '../services/PillarPatchPersistence';
 import {
   ALL_SCENE_BLOCKS,
   buildSceneRegistry,
@@ -163,6 +164,38 @@ export class PillarPatchStore {
 
   removeEdge(id: string): void {
     this.edges = this.edges.filter((e) => e.id !== id);
+  }
+
+  // ── Persistence ───────────────────────────────────────────────────────────
+
+  private persistDisposer: (() => void) | null = null;
+
+  /**
+   * Auto-persist the authored patch to storage on every edit (debounced). The
+   * store owns its own save lifecycle — the only writer of the pillar-patch key.
+   * [LAW:single-enforcer] [LAW:effects-at-boundaries] The store computes; the
+   *   injected `savePillarPatchToStorage` performs the write at the boundary.
+   *
+   * A write failure (e.g. quota) flows to `onIssue` rather than being swallowed;
+   * the diagnostics boundary (RuntimeService) injects the reporter so this store
+   * keeps no global state. [LAW:no-silent-failure] [LAW:no-shared-mutable-globals]
+   */
+  startPersistence(onIssue: (message: string) => void): void {
+    this.stopPersistence();
+    this.persistDisposer = reaction(
+      () => this.patch,
+      (patch) => {
+        const result = savePillarPatchToStorage(patch);
+        if (result.kind === 'failed') onIssue(result.error);
+      },
+      { delay: 500 },
+    );
+  }
+
+  /** Stop auto-persistence. Call on dispose/HMR cleanup. */
+  stopPersistence(): void {
+    this.persistDisposer?.();
+    this.persistDisposer = null;
   }
 
   // ── Internal ──────────────────────────────────────────────────────────────

--- a/src/stores/RootStore.ts
+++ b/src/stores/RootStore.ts
@@ -37,6 +37,7 @@ import {
   clearPatchPersistenceIssues,
 } from '../services/PatchPersistence';
 import { debugService } from '../services/DebugService';
+import { loadPillarPatchFromStorage } from '../services/PillarPatchPersistence';
 import type { Edge } from '../graph/Patch';
 
 type PatchSnapshot = ImmutablePatch;
@@ -225,8 +226,24 @@ export class RootStore {
     // Create ExpressionEditorStore (active block for docked expression workbench)
     this.expressionEditor = new ExpressionEditorStore();
 
-    // Create PillarPatchStore (authored native patch for the ScenePlan editor)
-    this.pillarPatch = new PillarPatchStore();
+    // Create PillarPatchStore (authored native patch for the ScenePlan editor),
+    // seeded from storage. [LAW:effects-at-boundaries] The load is performed once
+    // at the composition root; the store itself stays seeded by pure data and
+    // owns only its save reaction.
+    // [LAW:no-silent-failure] A stored-but-unreadable patch is logged as an error
+    //   before falling back to the default starter — never silently discarded.
+    const loadedPillarPatch = loadPillarPatchFromStorage();
+    if (loadedPillarPatch.kind === 'failed') {
+      this.diagnostics.log({
+        level: 'error',
+        message: `PillarPatchPersistence(load): ${loadedPillarPatch.error}`,
+      });
+    }
+    // `undefined` triggers the store's default starter patch (the single source
+    // of the first-visit fallback). [LAW:one-source-of-truth]
+    this.pillarPatch = new PillarPatchStore(
+      loadedPillarPatch.kind === 'loaded' ? loadedPillarPatch.patch : undefined,
+    );
 
     // Wire up callback for MobX reactivity
     this.diagnosticHub.setOnRevisionChange(() => this.diagnostics.incrementRevision());
@@ -346,6 +363,9 @@ export class RootStore {
 
     // Dispose PatchStore persistence
     this.patch.stopPersistence();
+
+    // Dispose PillarPatchStore persistence
+    this.pillarPatch.stopPersistence();
 
     // Dispose DiagnosticHub
     this.diagnosticHub.dispose();

--- a/src/stores/__tests__/PillarPatchStore.test.ts
+++ b/src/stores/__tests__/PillarPatchStore.test.ts
@@ -6,8 +6,9 @@
  *   without throwing. Never assert internal block array identity.
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 
+import { loadPillarPatchFromStorage } from '../../services/PillarPatchPersistence';
 import { PillarPatchStore } from '../PillarPatchStore';
 
 describe('PillarPatchStore', () => {
@@ -74,5 +75,95 @@ describe('PillarPatchStore', () => {
     const types = store.catalog.map((c) => c.type);
     expect(types).toContain('InstanceGrid');
     expect(types).toContain('DrawInstances');
+  });
+
+  it('seeds from an explicit saved patch instead of the default starter', () => {
+    const saved = {
+      blocks: [{ id: 'grid', kind: 'generator' as const, type: 'InstanceGrid', config: { rows: 3, cols: 3 } }],
+      edges: [],
+    };
+    const store = new PillarPatchStore(saved);
+    expect(store.patch.blocks).toHaveLength(1);
+    expect(store.patch.blocks[0].config.rows).toBe(3);
+  });
+});
+
+describe('PillarPatchStore persistence', () => {
+  const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+        setItem: (key: string, value: string) => void store.set(key, value),
+        removeItem: (key: string) => void store.delete(key),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalLocalStorage) {
+      Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+    } else {
+      delete (globalThis as { localStorage?: unknown }).localStorage;
+    }
+  });
+
+  it('persists an edit so a fresh store reloads it (survives reload)', () => {
+    const store = new PillarPatchStore();
+    store.startPersistence(() => {});
+    store.updateConfig('grid', 'rows', 7);
+    vi.runAllTimers(); // flush the debounced save reaction
+
+    const loaded = loadPillarPatchFromStorage();
+    expect(loaded.kind).toBe('loaded');
+    if (loaded.kind !== 'loaded') return;
+
+    const reloaded = new PillarPatchStore(loaded.patch);
+    const grid = reloaded.patch.blocks.find((b) => b.id === 'grid');
+    expect(grid?.config.rows).toBe(7);
+    store.stopPersistence();
+  });
+
+  it('stops writing after stopPersistence', () => {
+    const store = new PillarPatchStore();
+    store.startPersistence(() => {});
+    store.updateConfig('grid', 'rows', 5);
+    vi.runAllTimers();
+    store.stopPersistence();
+
+    store.updateConfig('grid', 'rows', 9);
+    vi.runAllTimers();
+
+    const loaded = loadPillarPatchFromStorage();
+    expect(loaded.kind).toBe('loaded');
+    if (loaded.kind !== 'loaded') return;
+    const grid = loaded.patch.blocks.find((b) => b.id === 'grid');
+    // The post-stop edit (9) was never written; storage still holds 5.
+    expect(grid?.config.rows).toBe(5);
+  });
+
+  it('reports a write failure through the injected reporter', () => {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('quota exceeded');
+        },
+      },
+    });
+    const issues: string[] = [];
+    const store = new PillarPatchStore();
+    store.startPersistence((message) => issues.push(message));
+    store.updateConfig('grid', 'rows', 4);
+    vi.runAllTimers();
+    store.stopPersistence();
+
+    expect(issues.some((m) => /quota exceeded/.test(m))).toBe(true);
   });
 });


### PR DESCRIPTION
## What & why

Closes **oscilla-pillars-scene-nt56.15**. The authored native patch now survives reload via localStorage, with the default starter patch (grid-of-squares) as the first-visit fallback — the Patch DSL save/load model the spec described but no scene-native ticket carried.

`PillarPatch` is pure JSON-safe data (the epic's "ScenePlan stays pure data" constraint pushed the authored layer pure too), so persistence is a clean parts-and-seams split rather than a serializer that knows about the renderer.

## Design (parts & seams)

- **`src/pillars/types/graph.ts` → zod SSOT.** The patch shape is now zod schemas + `z.infer` types (mirroring the existing `schemas.ts` philosophy), so the persistence validator and the TS type are one artifact that cannot drift. `[LAW:one-source-of-truth]`
- **`src/pillars/persistence.ts` (pure).** Versioned envelope; `serializePillarPatch` / `deserializePillarPatch` returns a discriminated `ok | error`. No I/O; deserialize is a trust boundary that returns a typed failure, never throws. `[LAW:effects-at-boundaries]` `[LAW:types-are-the-program]`
- **`src/services/PillarPatchPersistence.ts` (effect shell).** Reuses the shared `resolveLocalStorageCapability` single-enforcer. Load returns `loaded | empty | failed`, so a corrupt blob is never mistaken for "nothing saved." `[LAW:no-silent-failure]`
- **`PillarPatchStore`** gains `start/stopPersistence` (debounced save reaction), routing write failures to an injected reporter — no global mutable singleton. `[LAW:no-shared-mutable-globals]`
- **`RootStore`** seeds the store from storage at the composition root (logging a corrupt blob loudly); **`RuntimeService`** starts persistence in the native editor thread and disposes it with the store. `undefined` seed triggers the store's existing default starter — single source of the fallback.

## Verification

- Pure round-trip over **every authored demo patch** + version/shape rejection.
- Service save/load round-trip, `empty` (first-visit), corrupt-is-loud, quota write failure, future-version rejection.
- Store survives-reload + stop-after-stopPersistence + reporter-on-failure.
- `npm run typecheck`, `npm run lint`, full suite green (**2304 passed, 0 failures**) — the `graph.ts` zod conversion regressed nothing across all 33 consumers.

**Not a rendering change:** the ScenePlan→realizer pipeline and the default starter patch are untouched; only the seed *source* changed, verified byte-for-byte by round-trip tests. The visual gate does not apply (no visual delta).

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7