### PR TITLE
feat(pillars-scene nt56.17): promote Three native editor as default boot; V1 opt-in via ?v1=true

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,21 +20,21 @@ Oscilla Animator v2 is a browser-based animation editor for creating procedural,
 
 ## Migration State
 
-The codebase is mid-migration via **strangler fig pattern**. The **renderer direction is the "Three fork"**: a three.js (`three@0.184`, TSL) `WebGPURenderer` (`ThreeForkRenderer`) behind the `createWebGPURenderer()` seam, fed by the **pillar compiler** (`src/pillars/`) which lowers an authored patch to a backend-neutral **`ScenePlan`** (`compileScenePlan`). The earlier **Rust/WASM/WebGPU + GPU-IR** renderer and the **`PipelineInstallPayload`** path are **frozen legacy** — operational as a replaceable backend, not extended (the code marks them `FROZEN LEGACY`, e.g. `src/pillars/assembly/payload.ts`). **V1** (backend + JS runtime) is still the **default boot**; the Three path is a `?scenePlan=<id>`-selected steel thread, not yet the default.
+The codebase is mid-migration via **strangler fig pattern**. The **renderer direction is the "Three fork"**: a three.js (`three@0.184`, TSL) `WebGPURenderer` (`ThreeForkRenderer`) behind the `createWebGPURenderer()` seam, fed by the **pillar compiler** (`src/pillars/`) which lowers an authored patch to a backend-neutral **`ScenePlan`** (`compileScenePlan`). The earlier **Rust/WASM/WebGPU + GPU-IR** renderer and the **`PipelineInstallPayload`** path are **frozen legacy** — operational as a replaceable backend, not extended (the code marks them `FROZEN LEGACY`, e.g. `src/pillars/assembly/payload.ts`). The Three path is now the **default boot**: no URL param opens the native ScenePlan editor. **V1** (backend + JS runtime) is **deprecated**, reachable only via the explicit `?v1=true` opt-in.
 
 > **Source of truth for this migration** (these win over older GPU-IR text and ambiguous ticket prose):
 > `design-docs/three-migration-backend-canon.md` · `design-docs/three-migration-renderer-seam-inventory.md` (keep/freeze/delete map) · `design-docs/three-fork-integration-proposal.md`. Tracker epic: `oscilla-pillars-cleanup-ulu`. [LAW:one-source-of-truth]
 
-### Three lineages (one live, one default-but-legacy, one frozen)
+### Three lineages (one live default, one deprecated opt-in, one frozen)
 
 ```
   authored Patch
        │
-       ├─► V1 backend (LEGACY, DEFAULT BOOT) ─► JS Runtime (ScheduleExecutor) ─► stub
-       │
-       ├─► Pillar compiler ─► ScenePlan ─► Three fork renderer (LIVE) ─► WebGPU Canvas
+       ├─► Pillar compiler ─► ScenePlan ─► Three fork renderer (LIVE, DEFAULT BOOT) ─► WebGPU Canvas
        │     src/pillars/ · compileScenePlan      ScenePlan → TSL scene graph
-       │     (activated by ?scenePlan=<id>)
+       │     (no-param boot opens the native editor)
+       │
+       ├─► V1 backend (DEPRECATED, opt-in ?v1=true) ─► JS Runtime (ScheduleExecutor) ─► stub
        │
        └─► [FROZEN] Pillar/C1 ─► PipelineInstallPayload ─► Rust/WASM Worker (Naga → WGSL → WebGPU)
 ```
@@ -43,9 +43,9 @@ The codebase is mid-migration via **strangler fig pattern**. The **renderer dire
 
 | Area | Status |
 |---|---|
-| `src/render/webgpu/three/` — ThreeForkRenderer, ScenePlan realizer, TSL | **LIVE — current renderer** |
+| `src/render/webgpu/three/` — ThreeForkRenderer, ScenePlan realizer, TSL | **LIVE — current renderer, default boot** |
 | `src/pillars/` + `src/pillars/scene/` (`compileScenePlan`) | **ACTIVE — authored patch → ScenePlan; the open backlog is `pillars-*`** |
-| `compiler/backend/` + `src/blocks/` + `src/runtime/` (V1) | **LEGACY — still the default boot path** |
+| `compiler/backend/` + `src/blocks/` + `src/runtime/` (V1) | **DEPRECATED — opt-in only via `?v1=true`** |
 | `compiler/backend-v2/` + `src/blocks-v2/`; `src/pillars/compile.ts` + `src/pillars/assembly/` (`PipelineInstallPayload`) | **FROZEN LEGACY** |
 | `src/render/wasm/rust/`, `src/render/rust/`, `src/render/gpu-ir/` (Rust renderer + GPU-IR / Boundary DSL) | **FROZEN LEGACY** |
 | `src/render/Canvas2DRenderer.ts`, `src/render/SVGRenderer.ts`, `src/compiler/passes-v2/` | **DELETED** |
@@ -54,7 +54,7 @@ The codebase is mid-migration via **strangler fig pattern**. The **renderer dire
 
 - **Never fix V1 bugs** — V1 (backend/blocks/runtime) is legacy.
 - **Do not extend the frozen stack** — the Rust/WASM/GPU-IR renderer and the `PipelineInstallPayload` path are frozen. New renderer/compiler work follows **pillar → `ScenePlan` → Three**.
-- **No feature flags** — path selection is `?scenePlan=<id>` (steel thread) vs default V1 boot, plus tests; never runtime toggles.
+- **No feature flags** — boot-path selection is the default native editor vs. the `?v1=true` legacy opt-in vs. a `?scenePlan=<id>` demo steel thread, resolved once in `resolveBootSelection()`, plus tests; never runtime toggles.
 - When ticket text or older docs conflict with the canon docs above, the canon docs win. [LAW:one-source-of-truth]
 
 ## Development Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,14 @@ The codebase is mid-migration via strangler fig. The **renderer direction is the
 
 | System | Status | Notes |
 |--------|--------|-------|
-| **Three fork renderer** (`src/render/webgpu/three/`) | **LIVE — the direction** | three.js `WebGPURenderer`; pure `ScenePlan` → TSL scene-graph realizer; constructed at the `createWebGPURenderer` seam, driven from `RuntimeService` |
+| **Three fork renderer** (`src/render/webgpu/three/`) | **LIVE — the default boot** | three.js `WebGPURenderer`; pure `ScenePlan` → TSL scene-graph realizer; constructed at the `createWebGPURenderer` seam, driven from `RuntimeService`; no-param boot opens the native editor |
 | **Pillar compiler → ScenePlan** (`src/pillars/`, `src/pillars/scene/`) | **ACTIVE** | authored patch → `ScenePlan` (`compileScenePlan`); the active backlog lives in the `pillars-*` epics |
-| **V1 backend / blocks / runtime** (`compiler/backend/`, `src/blocks/`, `src/runtime/`) | **LEGACY — still the default boot** | JS frame executor; the app boots this unless `?scenePlan=<id>` selects the Three steel thread |
+| **V1 backend / blocks / runtime** (`compiler/backend/`, `src/blocks/`, `src/runtime/`) | **DEPRECATED — opt-in only (`?v1=true`)** | JS frame executor; no longer the default boot — reachable only via the explicit `?v1=true` escape hatch |
 | **C1 backend / blocks-v2 + pillar `PipelineInstallPayload`** (`compiler/backend-v2/`, `src/blocks-v2/`, `src/pillars/compile.ts`, `src/pillars/assembly/`) | **FROZEN LEGACY** | targeted the Rust renderer; superseded by the ScenePlan path |
 | **Rust renderer + GPU-IR / Boundary DSL** (`src/render/wasm/rust/`, `src/render/rust/`, `src/render/gpu-ir/`) | **FROZEN LEGACY** | operational, not extended — do not add to it |
 | **Canvas2D / SVG renderers** | **DELETED** | |
 
-**Default boot is still V1.** The Three path activates via `?scenePlan=<id>` (a steel thread proven for two demos: Grid of Squares, Textured Tiles); promoting it to the default is remaining migration work (`oscilla-pillars-cleanup-ulu`).
+**Default boot is the Three native editor.** No URL param opens the Three-backed editor with the persisted (or starter) patch, animating immediately. `?v1=true` is the explicit opt-in that boots the deprecated V1 runtime; `?scenePlan=<id>` still selects a fixed demo steel thread (e.g. Grid of Squares, Textured Tiles). Boot-path policy is resolved in one place — `resolveBootSelection()` in `src/testing/test-params.ts`.
 
 **Rules for legacy code**: Never fix bugs in V1 (backend/blocks/runtime). Treat the Rust/WASM/GPU-IR stack and the `PipelineInstallPayload` path (incl. C1 `backend-v2` and `src/pillars/compile.ts` / `src/pillars/assembly/`) as **frozen** — do not extend them. New renderer/compiler work follows **pillar → `ScenePlan` → Three** (see the canon docs above).
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,17 +13,20 @@ import {
   interceptLoadDemoPatch,
   validateRuntimeConsole,
   validateShowPreview,
+  validateV1OptIn,
 } from './testing/test-params';
 
-// ─── Pre-React test parameter handling ───────────────────────────────────────
+// ─── Pre-React startup parameter handling ────────────────────────────────────
 // [LAW:single-enforcer] These run once before React mounts.
 // interceptLoadDemoPatch: clears localStorage, stashes filename, triggers reload.
 // validateShowPreview: throws on invalid values (fast feedback for test runners).
 // validateRuntimeConsole: validates runtime logging toggle for debug sessions.
+// validateV1OptIn: validates the ?v1= legacy opt-in (default boot is the Three editor).
 const navigating = interceptLoadDemoPatch();
 if (!navigating) {
   validateShowPreview();
   validateRuntimeConsole();
+  validateV1OptIn();
 }
 
 // ─── Normal boot (only if not redirecting) ───────────────────────────────────

--- a/src/services/RuntimeService.ts
+++ b/src/services/RuntimeService.ts
@@ -29,8 +29,7 @@ import {
 } from './PatchPersistence';
 import {
   consumeTestDemoFilename,
-  readScenePlanSelection,
-  NATIVE_EDITOR_SCENE_PLAN_ID,
+  resolveBootSelection,
 } from '../testing/test-params';
 import { compileScenePlan } from '../pillars/scene';
 import type { ScenePlan } from '../render/scene-plan';
@@ -933,18 +932,20 @@ export class RuntimeService {
         throw new Error(`RuntimeService: WebGPU renderer initialization failed: ${message}`);
       }
 
-      // [LAW:dataflow-not-control-flow] Startup selects one render source. The
-      //   ScenePlan steel thread (Three backend) is self-contained: it needs no
-      //   V1 compile worker, persistence, or live recompile, so it installs its
-      //   plan and starts the loop here, then returns before any V1 setup.
-      const scenePlanId = readScenePlanSelection();
-      if (scenePlanId === NATIVE_EDITOR_SCENE_PLAN_ID) {
+      // [LAW:dataflow-not-control-flow] Startup selects one render source from a
+      //   resolved discriminated value, not scattered "is the param present?"
+      //   checks. The native editor is the default; V1 is the explicit opt-in.
+      //   Both Three paths are self-contained — they need no V1 compile worker,
+      //   persistence, or live recompile — so they install their plan, start the
+      //   loop, and return before any V1 setup. Only `v1-legacy` falls through.
+      const boot = resolveBootSelection();
+      if (boot.kind === 'native-editor') {
         await this.startNativeEditorThread();
         markRuntimeBootstrapSucceeded();
         return;
       }
-      if (scenePlanId !== null) {
-        await this.startScenePlanSteelThread(scenePlanId);
+      if (boot.kind === 'scene-plan-demo') {
+        await this.startScenePlanSteelThread(boot.planId);
         markRuntimeBootstrapSucceeded();
         return;
       }

--- a/src/testing/__tests__/boot-selection.test.ts
+++ b/src/testing/__tests__/boot-selection.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveBootSelection, isNativeEditorSelection, validateV1OptIn } from '../test-params';
+
+/**
+ * The resolver is the single authority for boot-path selection. These tests pin
+ * the policy: the Three native editor is the default, V1 is an explicit opt-in,
+ * and fixed ScenePlan demos remain reachable. [LAW:behavior-not-structure]
+ */
+
+const originalLocation = window.location;
+
+function setSearch(search: string): void {
+  Object.defineProperty(window, 'location', {
+    value: { ...originalLocation, search },
+    writable: true,
+    configurable: true,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'location', {
+    value: originalLocation,
+    writable: true,
+    configurable: true,
+  });
+});
+
+describe('resolveBootSelection', () => {
+  it('defaults to the native editor when no relevant param is present', () => {
+    setSearch('');
+    expect(resolveBootSelection()).toEqual({ kind: 'native-editor' });
+    expect(isNativeEditorSelection()).toBe(true);
+  });
+
+  it('keeps the native editor default when unrelated params are present', () => {
+    setSearch('?showPreview=true&runtimeConsole=1');
+    expect(resolveBootSelection()).toEqual({ kind: 'native-editor' });
+  });
+
+  it('selects V1 when ?v1=true', () => {
+    setSearch('?v1=true');
+    expect(resolveBootSelection()).toEqual({ kind: 'v1-legacy' });
+    expect(isNativeEditorSelection()).toBe(false);
+  });
+
+  it('selects V1 when ?v1=1', () => {
+    setSearch('?v1=1');
+    expect(resolveBootSelection()).toEqual({ kind: 'v1-legacy' });
+  });
+
+  it('does NOT select V1 for ?v1=false (default native editor)', () => {
+    setSearch('?v1=false');
+    expect(resolveBootSelection()).toEqual({ kind: 'native-editor' });
+  });
+
+  it('selects the native editor for the explicit reserved id ?scenePlan=editor', () => {
+    setSearch('?scenePlan=editor');
+    expect(resolveBootSelection()).toEqual({ kind: 'native-editor' });
+  });
+
+  it('selects a fixed demo steel thread for any other ?scenePlan=<id>', () => {
+    setSearch('?scenePlan=grid-of-squares');
+    expect(resolveBootSelection()).toEqual({
+      kind: 'scene-plan-demo',
+      planId: 'grid-of-squares',
+    });
+  });
+
+  it('lets ?v1=true win over a ?scenePlan= demo (explicit legacy opt-in)', () => {
+    setSearch('?v1=true&scenePlan=grid-of-squares');
+    expect(resolveBootSelection()).toEqual({ kind: 'v1-legacy' });
+  });
+});
+
+describe('validateV1OptIn', () => {
+  it('accepts valid boolean spellings and absence', () => {
+    for (const search of ['', '?v1=true', '?v1=false', '?v1=1', '?v1=0']) {
+      setSearch(search);
+      expect(() => validateV1OptIn()).not.toThrow();
+    }
+  });
+
+  it('throws on an invalid ?v1= value', () => {
+    setSearch('?v1=yes');
+    expect(() => validateV1OptIn()).toThrow(/Invalid v1 value/);
+  });
+});

--- a/src/testing/test-params.ts
+++ b/src/testing/test-params.ts
@@ -1,14 +1,17 @@
 /**
- * Test Automation Query Parameters
+ * Startup Query Parameters
  *
- * Single source of truth for test parameter detection and nuqs parsers.
+ * Single source of truth for startup/test parameter detection and nuqs parsers,
+ * including the product boot-path selection (see {@link resolveBootSelection}).
  *
- * Two params:
+ * Params:
+ * - `v1=<true|false|1|0>` — opt into the legacy V1 runtime (default boot is Three)
+ * - `scenePlan=<id>` — select the native editor (`editor`) or a fixed demo steel thread
  * - `loadDemoPatch=<filename>` — pre-React, raw URLSearchParams (EXCEPTION: cannot use nuqs)
  * - `showPreview=<true|false|1|0>` — nuqs hook for minimal preview layout
  * - `runtimeConsole=<true|false|1|0>` — enable periodic runtime frame logs in browser console
  *
- * [LAW:one-source-of-truth] All test param logic lives here.
+ * [LAW:one-source-of-truth] All startup param logic lives here.
  * [LAW:single-enforcer] Pre-React validation runs once in main.ts.
  */
 
@@ -65,41 +68,86 @@ export function consumeTestDemoFilename(): string | null {
   return filename;
 }
 
-// ─── scenePlan (ScenePlan steel-thread selector) ────────────────────────────
+// ─── boot selection (which render path the URL selects) ─────────────────────
 
 const SCENE_PLAN_PARAM = 'scenePlan';
+const V1_OPT_IN_PARAM = 'v1';
+const VALID_V1_OPT_IN = new Set(['true', 'false', '1', '0']);
 
 /**
  * The reserved `?scenePlan=` id that selects the live native editor instead of a
  * fixed demo fixture: the authored patch is driven from `PillarPatchStore` and
- * recompiled into the renderer on every edit, rather than compiled once.
- *
- * [LAW:no-mode-explosion] One selector (`scenePlan`) chooses the non-V1 render
- *   path; the editor is a documented reserved value of it, not a parallel param.
+ * recompiled into the renderer on every edit, rather than compiled once. This is
+ * the explicit spelling of the default boot path (see {@link resolveBootSelection}).
  */
-export const NATIVE_EDITOR_SCENE_PLAN_ID = 'editor';
+const NATIVE_EDITOR_SCENE_PLAN_ID = 'editor';
 
 /**
- * Whether the current URL selects the live native editor surface.
+ * The boot path the current URL selects. Exactly one of three outcomes; this
+ * compiler-checked union is the single authority that both the runtime dispatch
+ * (`RuntimeService.init`) and the UI layout (`App`) match on.
+ *
+ * [LAW:types-are-the-program] Three boot outcomes are three variants, not an
+ *   overloaded `string | null` where one branch's absence silently meant "V1".
+ *   The default and the V1 opt-in are encoded once in the resolver below, never
+ *   re-derived from a "was a param present?" check at a callsite.
  */
-export function isNativeEditorSelection(): boolean {
-  return readScenePlanSelection() === NATIVE_EDITOR_SCENE_PLAN_ID;
+export type BootSelection =
+  | { readonly kind: 'native-editor' }
+  | { readonly kind: 'scene-plan-demo'; readonly planId: string }
+  | { readonly kind: 'v1-legacy' };
+
+function isV1OptIn(params: URLSearchParams): boolean {
+  const value = params.get(V1_OPT_IN_PARAM);
+  return value === 'true' || value === '1';
 }
 
 /**
- * Read ?scenePlan=<id> — select an authored patch to render through the
- * ScenePlan → Three backend steel thread instead of the V1 editor runtime.
- * Returns the id or null. The reserved id {@link NATIVE_EDITOR_SCENE_PLAN_ID}
- * selects the live editor; any other id selects a fixed demo fixture.
+ * Resolve which render path boot selects from the current URL. The Three-backed
+ * native editor is the default; the legacy V1 runtime is an explicit opt-in.
  *
- * Unlike loadDemoPatch this needs no reload: it touches neither localStorage
- * nor the V1 patch store, so it is read directly at runtime init.
+ * Policy (single authority for boot-path selection):
+ *   ?v1=true|1            → V1 legacy runtime (the documented escape hatch)
+ *   ?scenePlan=editor     → native editor (explicit spelling of the default)
+ *   ?scenePlan=<other>    → fixed ScenePlan demo steel thread
+ *   (no relevant param)   → native editor
  *
- * [LAW:single-enforcer] All test-param parsing lives in this module.
+ * [LAW:single-enforcer] All boot-path URL policy lives here; consumers match the
+ *   union, they never re-read these params.
+ * [LAW:dataflow-not-control-flow] The default is a value the resolver emits, not
+ *   a "no param ⇒ fall through to V1" branch hidden at the dispatch site.
  */
-export function readScenePlanSelection(): string | null {
-  if (typeof window === 'undefined') return null;
-  return new URLSearchParams(window.location.search).get(SCENE_PLAN_PARAM);
+export function resolveBootSelection(): BootSelection {
+  if (typeof window === 'undefined') return { kind: 'native-editor' };
+  const params = new URLSearchParams(window.location.search);
+  if (isV1OptIn(params)) return { kind: 'v1-legacy' };
+  const planId = params.get(SCENE_PLAN_PARAM);
+  if (planId === null || planId === NATIVE_EDITOR_SCENE_PLAN_ID) {
+    return { kind: 'native-editor' };
+  }
+  return { kind: 'scene-plan-demo', planId };
+}
+
+/**
+ * Whether the current URL selects the live native editor surface — the UI-layout
+ * projection of {@link resolveBootSelection} (native-editor chrome vs. V1 chrome).
+ */
+export function isNativeEditorSelection(): boolean {
+  return resolveBootSelection().kind === 'native-editor';
+}
+
+/**
+ * Validate ?v1= early (pre-React). Throws on invalid values — fast feedback for
+ * the legacy opt-in. No-op if param is absent.
+ */
+export function validateV1OptIn(): void {
+  const params = new URLSearchParams(window.location.search);
+  const value = params.get(V1_OPT_IN_PARAM);
+  if (value !== null && !VALID_V1_OPT_IN.has(value)) {
+    throw new Error(
+      `[test-params] Invalid v1 value: "${value}". Must be true/false/1/0.`
+    );
+  }
 }
 
 // ─── showPreview (nuqs) ─────────────────────────────────────────────────────

--- a/src/ui/components/app/App.tsx
+++ b/src/ui/components/app/App.tsx
@@ -114,9 +114,9 @@ interface AppProps {
 
 export const App: React.FC<AppProps> = ({ onCanvasReady, onStoreReady, onStatsSinkReady, externalWriteBus }) => {
   const showPreview = useShowPreview();
-  // [LAW:no-mode-explosion] The native editor is selected by the same
-  //   ?scenePlan= mechanism as the demo steel thread (reserved id), not a
-  //   separate runtime toggle.
+  // [LAW:single-enforcer] The native editor is the default boot surface; both
+  //   this layout choice and the runtime dispatch read the same resolved boot
+  //   selection, so the UI chrome and the render path can never disagree.
   const nativeEditor = isNativeEditorSelection();
   const [stats, setStats] = useState('FPS: --');
 


### PR DESCRIPTION
Closes **oscilla-pillars-scene-nt56.17** — Promote Three as default boot + demote V1 to opt-in.

## What
No-param boot now opens the **Three-backed native ScenePlan editor** with the persisted/starter patch animating immediately. The legacy **V1 runtime is opt-in only** via the explicit `?v1=true` escape hatch. Fixed ScenePlan demo steel threads (`?scenePlan=<id>`) are preserved unchanged.

## Why this shape
The boot-path selection is **one concept with three outcomes** (native editor / fixed ScenePlan demo / V1 legacy), but it was faked as `string | null` from `readScenePlanSelection()` where `null` silently meant "V1 default". This ticket both *flips the default* and *adds a new concept* (`?v1=true`) — exactly the moment to make the type honest.

- `BootSelection` discriminated union resolved **once** in `resolveBootSelection()` (`test-params.ts`), the single enforcer for URL→boot policy. The default lives in exactly one place: the resolver's fallthrough. `[LAW:types-are-the-program]` `[LAW:single-enforcer]` `[LAW:dataflow-not-control-flow]`
- `RuntimeService.init` and `App` both match the union, so the render path and UI chrome can never disagree.
- No feature flags — selection is URL param + tests only.

## Changes
- **`test-params.ts`**: `BootSelection` + `resolveBootSelection()` + `validateV1OptIn()`; `isNativeEditorSelection()` reprojected onto the union; magic `editor` id now module-private; `readScenePlanSelection()` removed (subsumed).
- **`RuntimeService.ts`**: exhaustive match on the union replaces the `scenePlanId`/`null` fallthrough.
- **`main.ts`**: pre-React `?v1=` validation alongside the other startup params.
- **`App.tsx`**: layout comment reflects the shared resolved selection.
- **`CLAUDE.md`** (both): migration tables/diagrams mark Three the default boot and V1 a deprecated opt-in.

## Verification
- `npm run typecheck` clean; `npm run lint` clean on changed files.
- Full suite **2314 passed** (+10 new resolver tests in `boot-selection.test.ts`).
- **Visual gate** (real-GPU headless Chrome):
  - No-param boot → grid-of-squares starter **animating immediately** (squares rotate, color cycle advances 0→601ms), diagnostics "No problems — patch renders".
  - `?v1=true` → full V1 editor (dockview chrome, React Flow graph) boots **without error**.

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7