### PR TITLE
feat(pillars-scene nt56.8): native demo fixtures for target animations

### DIFF
--- a/design-docs/three-migration-capability-matrix.md
+++ b/design-docs/three-migration-capability-matrix.md
@@ -129,7 +129,7 @@ consumers stay exhaustive.
 | Runtime inputs (`PlanInputChannel`) | `time` (realized); `mouseX/Y`, `mouseButtons`, `audioLow/Mid/High`, `gaugeActive` (mirrors runtime envelope) | **Realized** (`time`) |
 | Intrinsics (`PlanIntrinsic`) | `index`, `rank` | **Realized** |
 | Unary ops (`PlanUnaryOp`) | `floor`, `sin`, `cos`, `negate` | **Realized** |
-| Binary ops (`PlanBinaryOp`) | `add`, `sub`, `mul`, `div`, `mod` | **Realized** |
+| Binary ops (`PlanBinaryOp`) | `add`, `sub`, `mul`, `div`, `mod`, `step` (threshold → boolean) | **Realized** |
 | Leaves | `const` (baked) vs `input` (runtime channel) — structurally distinct | **Realized** |
 
 `// [LAW:dataflow-not-control-flow]` The `const` vs `input` split is structural,

--- a/src/pillars/fixtures/conditional-visibility.ts
+++ b/src/pillars/fixtures/conditional-visibility.ts
@@ -1,0 +1,54 @@
+/**
+ * src/pillars/fixtures/conditional-visibility.ts
+ *
+ * Native replacement for the "Conditional Visibility" demo (DEMO-PATCHES.md §1):
+ * a field of points where a single threshold scalar controls which are visible —
+ * proving show/hide is opacity (a material decision), not a domain operation that
+ * removes instances. Built from native scene blocks: a bare `InstanceCount`
+ * source, a `RingLayout` spreading the points, and a `ThresholdVisibility`
+ * material modifier whose per-instance alpha is `step(threshold, field)`. As time
+ * drifts, the visible arcs sweep around the ring.
+ *
+ * Chain: InstanceCount(240) → RingLayout → ThresholdVisibility → DrawInstances.
+ *
+ * Faithful to the architectural claim (boolean per-instance opacity from a
+ * threshold over a per-instance field). The original's *noise-driven density*
+ * over a scatter layout needs a hash/fract PlanExpr operator and ScatterUV, both
+ * out of this slice's vocabulary — captured as a follow-up child ticket.
+ *
+ * [LAW:dataflow-not-control-flow] Every point is drawn; visibility is the value
+ *   of its alpha (0 or 1), never a branch that skips an instance.
+ */
+
+import type { PillarPatch } from '../types';
+
+export function makeConditionalVisibilityPatch(): PillarPatch {
+  return {
+    blocks: [
+      { id: 'count', kind: 'generator', type: 'InstanceCount', config: { count: 240 } },
+      {
+        id: 'ring',
+        kind: 'modifier',
+        type: 'RingLayout',
+        config: { radius: 0.45, angularSpeed: 0 },
+      },
+      {
+        id: 'visibility',
+        kind: 'modifier',
+        type: 'ThresholdVisibility',
+        config: { color: '#38e1c8', threshold: 0.55, frequency: 25, speed: 1.5 },
+      },
+      {
+        id: 'draw',
+        kind: 'intent',
+        type: 'DrawInstances',
+        config: { size: 0.02, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 },
+      },
+    ],
+    edges: [
+      { id: 'e0', source: 'count', target: 'ring', inputSlot: 'primary', role: 'primary' },
+      { id: 'e1', source: 'ring', target: 'visibility', inputSlot: 'primary', role: 'primary' },
+      { id: 'e2', source: 'visibility', target: 'draw', inputSlot: 'primary', role: 'primary' },
+    ],
+  };
+}

--- a/src/pillars/fixtures/kaleidoscope.ts
+++ b/src/pillars/fixtures/kaleidoscope.ts
@@ -1,0 +1,51 @@
+/**
+ * src/pillars/fixtures/kaleidoscope.ts
+ *
+ * Native replacement for the "Kaleidoscope" demo (DEMO-PATCHES.md §1): a single
+ * shape repeated N times with N-fold rotational symmetry from index math alone —
+ * no mirror primitive. Built from native scene blocks: a bare `InstanceCount`
+ * source, a `RingLayout` arranging the copies on a circle, and a `Kaleidoscope`
+ * modifier giving each copy its `index`-derived facing (`index · TAU / N`). The
+ * composition is a slowly-drifting pinwheel rosette colored across the ring.
+ *
+ * Chain: InstanceCount(12) → RingLayout → Kaleidoscope → ColorCycle → DrawInstances.
+ *
+ * [LAW:composability] The symmetry order is the upstream count: the same
+ *   `Kaleidoscope` modifier is 6-fold or 12-fold purely by the `InstanceCount`
+ *   feeding it — no per-fold config.
+ */
+
+import type { PillarPatch } from '../types';
+
+export function makeKaleidoscopePatch(): PillarPatch {
+  return {
+    blocks: [
+      { id: 'count', kind: 'generator', type: 'InstanceCount', config: { count: 12 } },
+      {
+        id: 'ring',
+        kind: 'modifier',
+        type: 'RingLayout',
+        config: { radius: 0.34, angularSpeed: 0.2 },
+      },
+      { id: 'kaleido', kind: 'modifier', type: 'Kaleidoscope', config: {} },
+      {
+        id: 'color',
+        kind: 'modifier',
+        type: 'ColorCycle',
+        config: { spread: 1, cycleSpeed: 0.08, vividness: 0.85, brightness: 0.6 },
+      },
+      {
+        id: 'draw',
+        kind: 'intent',
+        type: 'DrawInstances',
+        config: { size: 0.14, cameraHalfExtentX: 0.55, cameraHalfExtentY: 0.55 },
+      },
+    ],
+    edges: [
+      { id: 'e0', source: 'count', target: 'ring', inputSlot: 'primary', role: 'primary' },
+      { id: 'e1', source: 'ring', target: 'kaleido', inputSlot: 'primary', role: 'primary' },
+      { id: 'e2', source: 'kaleido', target: 'color', inputSlot: 'primary', role: 'primary' },
+      { id: 'e3', source: 'color', target: 'draw', inputSlot: 'primary', role: 'primary' },
+    ],
+  };
+}

--- a/src/pillars/fixtures/ring-orbit.ts
+++ b/src/pillars/fixtures/ring-orbit.ts
@@ -1,0 +1,51 @@
+/**
+ * src/pillars/fixtures/ring-orbit.ts
+ *
+ * Native replacement for the legacy "orbit ring" demo: instances arranged evenly
+ * around a circle that orbits the origin over time, colored across the ring by
+ * rank so the rotation is visible frame-to-frame. Built entirely from native
+ * scene blocks — a bare `InstanceCount` source with the circular placement and
+ * orbital spin authored as a composable `RingLayout` *modifier*, never a fused
+ * per-demo ring source.
+ *
+ * Chain: InstanceCount → RingLayout → ColorCycle → DrawInstances. This is also a
+ * multi-block modifier chain (layout + color folded onto a count source).
+ *
+ * [LAW:composability] The motion (orbit) is `RingLayout`'s `angularSpeed` value,
+ *   not a separate orbit block; the same layout is a static ring at speed 0.
+ * [LAW:one-source-of-truth] These parameters are the authored intent; the
+ *   ScenePlan is derived by `compileScenePlan`, never hand-authored alongside.
+ */
+
+import type { PillarPatch } from '../types';
+
+export function makeRingOrbitPatch(): PillarPatch {
+  return {
+    blocks: [
+      { id: 'count', kind: 'generator', type: 'InstanceCount', config: { count: 64 } },
+      {
+        id: 'ring',
+        kind: 'modifier',
+        type: 'RingLayout',
+        config: { radius: 0.45, angularSpeed: 0.5 },
+      },
+      {
+        id: 'color',
+        kind: 'modifier',
+        type: 'ColorCycle',
+        config: { spread: 1, cycleSpeed: 0.1, vividness: 0.8, brightness: 0.6 },
+      },
+      {
+        id: 'draw',
+        kind: 'intent',
+        type: 'DrawInstances',
+        config: { size: 0.05, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 },
+      },
+    ],
+    edges: [
+      { id: 'e0', source: 'count', target: 'ring', inputSlot: 'primary', role: 'primary' },
+      { id: 'e1', source: 'ring', target: 'color', inputSlot: 'primary', role: 'primary' },
+      { id: 'e2', source: 'color', target: 'draw', inputSlot: 'primary', role: 'primary' },
+    ],
+  };
+}

--- a/src/pillars/fixtures/scene-demos.ts
+++ b/src/pillars/fixtures/scene-demos.ts
@@ -27,6 +27,10 @@ import { makeGridOfSquaresPatch } from './grid-of-squares';
 import { makeInstanceWavePatch } from './instance-wave';
 import { makeInstanceGradientPatch } from './instance-gradient';
 import { makeTexturedTilesPatch, TEXTURED_TILES_ASSETS } from './textured-tiles';
+import { makeRingOrbitPatch } from './ring-orbit';
+import { makeSpirographPatch } from './spirograph';
+import { makeKaleidoscopePatch } from './kaleidoscope';
+import { makeConditionalVisibilityPatch } from './conditional-visibility';
 
 /** An authored ScenePlan proof target plus the assets its patch references. */
 export interface ScenePlanDemo {
@@ -48,4 +52,11 @@ export const SCENE_PLAN_DEMOS: Readonly<Record<string, ScenePlanDemo>> = {
   // Asset-bridge proof target (oscilla-pillars-cleanup-ulu.4): a grid of
   // texture-mapped tiles resolved through the AssetRegistry + ThreeLoadingBridge.
   'textured-tiles': { makePatch: makeTexturedTilesPatch, assets: TEXTURED_TILES_ASSETS },
+  // Target-animation fixtures (oscilla-pillars-scene-nt56.8): each recreates a
+  // legacy demo behavior from native blocks only, with layouts authored as
+  // composable modifiers over a bare InstanceCount source. No assets.
+  'ring-orbit': { makePatch: makeRingOrbitPatch, assets: [] },
+  'spirograph': { makePatch: makeSpirographPatch, assets: [] },
+  'kaleidoscope': { makePatch: makeKaleidoscopePatch, assets: [] },
+  'conditional-visibility': { makePatch: makeConditionalVisibilityPatch, assets: [] },
 };

--- a/src/pillars/fixtures/spirograph.ts
+++ b/src/pillars/fixtures/spirograph.ts
@@ -1,0 +1,50 @@
+/**
+ * src/pillars/fixtures/spirograph.ts
+ *
+ * Native replacement for the "Spirograph Trace" demo (DEMO-PATCHES.md §1): a
+ * dense field of points tracing a Lissajous figure, with `rank` used as a phase
+ * delay so each instance is a different moment along the curve and the whole
+ * trace flows over time. Built from native scene blocks only — a bare
+ * `InstanceCount` source and a `Spirograph` layout *modifier*; the emergent
+ * geometry comes from the `freqA:freqB` oscillator ratio, not a fused source.
+ *
+ * Chain: InstanceCount(600) → Spirograph(3:2) → ColorCycle → DrawInstances.
+ * The dots are small squares (the renderer's `point` geometry is a placeholder
+ * unit quad, so a small rectangle is the size-correct dot today).
+ *
+ * [LAW:dataflow-not-control-flow] The figure is the value of the frequency ratio;
+ *   a different ratio is a different curve with no new block.
+ */
+
+import type { PillarPatch } from '../types';
+
+export function makeSpirographPatch(): PillarPatch {
+  return {
+    blocks: [
+      { id: 'count', kind: 'generator', type: 'InstanceCount', config: { count: 600 } },
+      {
+        id: 'spiro',
+        kind: 'modifier',
+        type: 'Spirograph',
+        config: { radius: 0.5, freqA: 3, freqB: 2, speed: 0.4 },
+      },
+      {
+        id: 'color',
+        kind: 'modifier',
+        type: 'ColorCycle',
+        config: { spread: 1, cycleSpeed: 0.15, vividness: 0.9, brightness: 0.6 },
+      },
+      {
+        id: 'draw',
+        kind: 'intent',
+        type: 'DrawInstances',
+        config: { size: 0.014, cameraHalfExtentX: 0.65, cameraHalfExtentY: 0.65 },
+      },
+    ],
+    edges: [
+      { id: 'e0', source: 'count', target: 'spiro', inputSlot: 'primary', role: 'primary' },
+      { id: 'e1', source: 'spiro', target: 'color', inputSlot: 'primary', role: 'primary' },
+      { id: 'e2', source: 'color', target: 'draw', inputSlot: 'primary', role: 'primary' },
+    ],
+  };
+}

--- a/src/pillars/scene/__tests__/compile.test.ts
+++ b/src/pillars/scene/__tests__/compile.test.ts
@@ -219,15 +219,27 @@ describe('scene block contract — catalog and registration', () => {
 
     expect(catalog.map((block) => block.displayName)).toEqual([
       'Instance Grid',
+      'Instance Count',
+      'Ring Layout',
+      'Spirograph',
+      'Kaleidoscope',
       'Wave Offset',
       'Solid Color',
       'Gradient',
       'Color Cycle',
       'Brightness',
+      'Threshold Visibility',
       'Draw Instances',
     ]);
     expect(catalog.flatMap((block) => block.ports.map((port) => port.value))).toEqual([
       'instanceBundle', // InstanceGrid output
+      'instanceBundle', // InstanceCount output
+      'instanceBundle', // RingLayout input
+      'instanceBundle', // RingLayout output
+      'instanceBundle', // Spirograph input
+      'instanceBundle', // Spirograph output
+      'instanceBundle', // Kaleidoscope input
+      'instanceBundle', // Kaleidoscope output
       'instanceBundle', // WaveOffset input
       'instanceBundle', // WaveOffset output
       'instanceBundle', // SolidColor input
@@ -238,6 +250,8 @@ describe('scene block contract — catalog and registration', () => {
       'instanceBundle', // ColorCycle output
       'instanceBundle', // Brightness input
       'instanceBundle', // Brightness output
+      'instanceBundle', // ThresholdVisibility input
+      'instanceBundle', // ThresholdVisibility output
       'instanceBundle', // DrawInstances input
       'materialShell', // DrawInstances output
     ]);
@@ -247,6 +261,14 @@ describe('scene block contract — catalog and registration', () => {
       'spacing',
       'rotationPerIndex',
       'rotationPerTime',
+      'count', // InstanceCount
+      'radius', // RingLayout
+      'angularSpeed',
+      'radius', // Spirograph
+      'freqA',
+      'freqB',
+      'speed',
+      // Kaleidoscope has no config fields — N-fold order is the upstream count.
       'amplitude',
       'frequency',
       'speed',
@@ -258,6 +280,10 @@ describe('scene block contract — catalog and registration', () => {
       'vividness',
       'brightness',
       'factor',
+      'color', // ThresholdVisibility
+      'threshold',
+      'frequency',
+      'speed',
       'size',
       'cameraHalfExtentX',
       'cameraHalfExtentY',

--- a/src/pillars/scene/__tests__/demo-fixtures.test.ts
+++ b/src/pillars/scene/__tests__/demo-fixtures.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Integration tests for the native target-animation fixtures
+ * (oscilla-pillars-scene-nt56.8): each recreates a legacy demo behavior from
+ * native scene blocks only and compiles through `compileScenePlan` to a
+ * ScenePlan with the expected user-visible behavior and contracts.
+ *
+ * [LAW:behavior-not-structure] Assertions target what each plan *means* — the
+ *   instance count, that placement varies per instance (rank/index), that motion
+ *   is a runtime `time` input, that visibility is a per-instance opacity — not
+ *   the exact PlanExpr tree shape, which the lowering is free to refactor.
+ * [LAW:verifiable-goals] The registry sweep proves every demo the app can boot
+ *   via `?scenePlan=<id>` actually compiles, so a broken fixture fails loudly in
+ *   CI rather than only at runtime.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { compileScenePlan } from '../index';
+import { sceneObjectRef, type ScenePlan } from '../../../render/scene-plan';
+import { SCENE_PLAN_DEMOS } from '../../fixtures/scene-demos';
+import { makeRingOrbitPatch } from '../../fixtures/ring-orbit';
+import { makeSpirographPatch } from '../../fixtures/spirograph';
+import { makeKaleidoscopePatch } from '../../fixtures/kaleidoscope';
+import { makeConditionalVisibilityPatch } from '../../fixtures/conditional-visibility';
+import type { PillarPatch } from '../../types';
+
+function compileOk(patch: PillarPatch): ScenePlan {
+  const result = compileScenePlan(patch);
+  if (result.kind !== 'ok') {
+    throw new Error(`Expected ok ScenePlan, got errors: ${result.errors.join('; ')}`);
+  }
+  return result.plan;
+}
+
+function drawObject(plan: ScenePlan) {
+  return plan.objects[sceneObjectRef('draw')];
+}
+
+/** The one geometry the single draw renders. */
+function drawGeometry(plan: ScenePlan) {
+  return plan.resources.geometries[drawObject(plan).geometry];
+}
+
+/** The one material the single draw is shaded by. */
+function drawMaterial(plan: ScenePlan) {
+  return plan.resources.materials[drawObject(plan).material];
+}
+
+describe('native target-animation fixtures — registry sweep', () => {
+  it('every registered ScenePlan demo compiles to an ok plan', () => {
+    for (const [id, demo] of Object.entries(SCENE_PLAN_DEMOS)) {
+      const result = compileScenePlan(demo.makePatch());
+      if (result.kind !== 'ok') {
+        throw new Error(`demo '${id}' failed to compile: ${result.errors.join('; ')}`);
+      }
+      expect(result.plan.render.draws.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('every demo is built on a bare InstanceCount source, not a fused layout source', () => {
+    // [LAW:composability] The foundational cut: layouts are modifiers folded onto
+    //   a count source. The only legacy fused source still in use is the grid.
+    const layoutDemos = ['ring-orbit', 'spirograph', 'kaleidoscope', 'conditional-visibility'];
+    for (const id of layoutDemos) {
+      const patch = SCENE_PLAN_DEMOS[id].makePatch();
+      const sources = patch.blocks.filter((b) => b.kind === 'generator');
+      expect(sources.map((b) => b.type)).toEqual(['InstanceCount']);
+    }
+  });
+});
+
+describe('ring-orbit — circular layout that orbits over time', () => {
+  const plan = compileOk(makeRingOrbitPatch());
+  const object = drawObject(plan);
+
+  it('declares the authored instance count', () => {
+    expect(object.instancing.count).toBe(64);
+  });
+
+  it('places instances on a ring: position varies per instance via rank, with trig', () => {
+    const px = JSON.stringify(object.instancing.transform.positionX);
+    expect(px).toContain('"rank"');
+    expect(px).toContain('"cos"');
+    const py = JSON.stringify(object.instancing.transform.positionY);
+    expect(py).toContain('"rank"');
+    expect(py).toContain('"sin"');
+  });
+
+  it('orbits over time: position reads the runtime time channel', () => {
+    expect(plan.render.inputs).toContain('time');
+    expect(JSON.stringify(object.instancing.transform.positionX)).toContain('"time"');
+  });
+
+  it('colors the ring by the ColorCycle block (perceptual oklab)', () => {
+    const material = drawMaterial(plan);
+    expect(material.kind).toBe('unlitColor');
+    if (material.kind !== 'unlitColor') return;
+    expect(material.color.space).toBe('oklab');
+  });
+});
+
+describe('spirograph — Lissajous trace from rank-as-phase', () => {
+  const plan = compileOk(makeSpirographPatch());
+  const object = drawObject(plan);
+
+  it('declares a dense instance field', () => {
+    expect(object.instancing.count).toBe(600);
+  });
+
+  it('uses rank as a phase delay and animates over time', () => {
+    const px = JSON.stringify(object.instancing.transform.positionX);
+    expect(px).toContain('"rank"');
+    expect(px).toContain('"time"');
+    expect(plan.render.inputs).toContain('time');
+  });
+
+  it('draws small dots (sized rectangles, the size-correct point today)', () => {
+    const geo = drawGeometry(plan);
+    expect(geo.kind).toBe('rectangle');
+    if (geo.kind !== 'rectangle') return;
+    expect(geo.width).toBeLessThan(0.05);
+  });
+});
+
+describe('kaleidoscope — N-fold symmetry from index math', () => {
+  const plan = compileOk(makeKaleidoscopePatch());
+  const object = drawObject(plan);
+
+  it('declares the N copies (symmetry order)', () => {
+    expect(object.instancing.count).toBe(12);
+  });
+
+  it('derives per-instance facing from the index intrinsic', () => {
+    expect(JSON.stringify(object.instancing.transform.rotation)).toContain('"index"');
+  });
+
+  it('arranges the copies on a ring (position varies by rank)', () => {
+    expect(JSON.stringify(object.instancing.transform.positionX)).toContain('"rank"');
+  });
+});
+
+describe('conditional-visibility — show/hide as per-instance opacity', () => {
+  const plan = compileOk(makeConditionalVisibilityPatch());
+
+  it('shades the draw with a per-instance rgba opacity, not an opaque space', () => {
+    const material = drawMaterial(plan);
+    expect(material.kind).toBe('unlitColor');
+    if (material.kind !== 'unlitColor') return;
+    expect(material.color.space).toBe('rgba');
+  });
+
+  it('drives opacity by a threshold (step) over a per-instance, time-varying field', () => {
+    const material = drawMaterial(plan);
+    if (material.kind !== 'unlitColor' || material.color.space !== 'rgba') {
+      throw new Error('expected an rgba unlit material');
+    }
+    const alpha = JSON.stringify(material.color.a);
+    expect(alpha).toContain('"step"');
+    expect(alpha).toContain('"rank"');
+    expect(alpha).toContain('"time"');
+    expect(plan.render.inputs).toContain('time');
+  });
+
+  it('draws every instance — visibility is opacity, not a dropped instance', () => {
+    expect(drawObject(plan).instancing.count).toBe(240);
+  });
+});

--- a/src/pillars/scene/__tests__/insertability.test.ts
+++ b/src/pillars/scene/__tests__/insertability.test.ts
@@ -48,18 +48,18 @@ describe('connectableScenePorts — over the native block set', () => {
     const matches = connectableScenePorts(registry, { value: 'instanceBundle', direction: 'output' });
     // A modifier consumes a bundle and a draw consumes a bundle, so every
     // modifier and the draw are valid sinks for a bundle output.
-    expect(matches.map((m) => m.blockType)).toEqual(['WaveOffset', 'SolidColor', 'Gradient', 'ColorCycle', 'Brightness', 'DrawInstances']);
+    expect(matches.map((m) => m.blockType)).toEqual(['RingLayout', 'Spirograph', 'Kaleidoscope', 'WaveOffset', 'SolidColor', 'Gradient', 'ColorCycle', 'Brightness', 'ThresholdVisibility', 'DrawInstances']);
     for (const match of matches) {
       expect(match.port).toMatchObject({ id: 'primary', direction: 'input', value: 'instanceBundle' });
       expect(match.compatibility).toMatchObject({ kind: 'compatible' });
     }
   });
 
-  it('a selected instanceBundle input offers the grid and the modifiers as bundle outputs', () => {
+  it('a selected instanceBundle input offers the instance sources and the modifiers as bundle outputs', () => {
     const matches = connectableScenePorts(registry, { value: 'instanceBundle', direction: 'input' });
-    // A modifier also *produces* a bundle, so it is offerable as a source — the
-    // draw is excluded since its only output is a materialShell.
-    expect(matches.map((m) => m.blockType)).toEqual(['InstanceGrid', 'WaveOffset', 'SolidColor', 'Gradient', 'ColorCycle', 'Brightness']);
+    // Instance sources and modifiers both *produce* a bundle, so each is offerable
+    // as a source — the draw is excluded since its only output is a materialShell.
+    expect(matches.map((m) => m.blockType)).toEqual(['InstanceGrid', 'InstanceCount', 'RingLayout', 'Spirograph', 'Kaleidoscope', 'WaveOffset', 'SolidColor', 'Gradient', 'ColorCycle', 'Brightness', 'ThresholdVisibility']);
     for (const match of matches) {
       expect(match.port).toMatchObject({ id: 'instances', direction: 'output', value: 'instanceBundle' });
     }

--- a/src/pillars/scene/blocks/index.ts
+++ b/src/pillars/scene/blocks/index.ts
@@ -7,19 +7,29 @@
 
 import type { SceneBlockDefinition } from '../scene-block';
 import { InstanceGridBlock } from './instance-grid';
+import { InstanceCountBlock } from './instance-count';
+import { RingLayoutBlock } from './ring-layout';
+import { SpirographBlock } from './spirograph';
+import { KaleidoscopeBlock } from './kaleidoscope';
 import { WaveOffsetBlock } from './wave-offset';
 import { SolidColorBlock } from './solid-color';
 import { GradientBlock } from './gradient';
 import { ColorCycleBlock } from './color-cycle';
 import { BrightnessBlock } from './brightness';
+import { ThresholdVisibilityBlock } from './threshold-visibility';
 import { DrawInstancesBlock } from './draw-instances';
 
 export const ALL_SCENE_BLOCKS: readonly SceneBlockDefinition<unknown>[] = [
   InstanceGridBlock as SceneBlockDefinition<unknown>,
+  InstanceCountBlock as SceneBlockDefinition<unknown>,
+  RingLayoutBlock as SceneBlockDefinition<unknown>,
+  SpirographBlock as SceneBlockDefinition<unknown>,
+  KaleidoscopeBlock as SceneBlockDefinition<unknown>,
   WaveOffsetBlock as SceneBlockDefinition<unknown>,
   SolidColorBlock as SceneBlockDefinition<unknown>,
   GradientBlock as SceneBlockDefinition<unknown>,
   ColorCycleBlock as SceneBlockDefinition<unknown>,
   BrightnessBlock as SceneBlockDefinition<unknown>,
+  ThresholdVisibilityBlock as SceneBlockDefinition<unknown>,
   DrawInstancesBlock as SceneBlockDefinition<unknown>,
 ];

--- a/src/pillars/scene/blocks/instance-count.ts
+++ b/src/pillars/scene/blocks/instance-count.ts
@@ -1,0 +1,47 @@
+/**
+ * src/pillars/scene/blocks/instance-count.ts
+ *
+ * The bare instance source: N instances at the origin, unrotated, neutral white.
+ * It owns *count only* — the one thing a source must decide. Where the instances
+ * land, how they turn, and what color they are is each a downstream modifier's
+ * single concern.
+ *
+ * This is the composable base the demo library rests on: a layout (ring,
+ * spirograph, kaleidoscope) is a `rank`/`index`→transform *modifier* folded onto
+ * this source, not a fresh fused source. Contrast `InstanceGrid`, which welds
+ * count+layout+rotation into one block that serves exactly one demo.
+ *
+ * [LAW:decomposition] Count is this block's whole truth; a layout modifier
+ *   downstream supplies placement. The identity transform is the honest base
+ *   case (every instance at the origin), replaced by whatever layout folds over
+ *   it — not a silent default that hides a missing layout.
+ * [LAW:composability] Asks for nothing, does one thing completely: any layout
+ *   modifier drops onto it with no negotiation.
+ */
+
+import { konst } from '../../../render/scene-plan';
+import { defineSceneBlock, sceneConfig } from '../scene-block';
+
+const config = {
+  count: sceneConfig.positiveInt({ label: 'Count', control: 'integer' }),
+} as const;
+
+export const InstanceCountBlock = defineSceneBlock({
+  type: 'InstanceCount',
+  role: 'instanceSource',
+  catalog: {
+    displayName: 'Instance Count',
+    category: 'instance',
+    ports: [{ id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' }],
+  },
+  config,
+  contribute: (config) => ({
+    role: 'instanceSource',
+    bundle: {
+      count: config.count,
+      transform: { positionX: konst(0), positionY: konst(0), rotation: konst(0) },
+      // Neutral base color; a downstream color block replaces it.
+      color: { space: 'rgb', r: konst(1), g: konst(1), b: konst(1) },
+    },
+  }),
+});

--- a/src/pillars/scene/blocks/kaleidoscope.ts
+++ b/src/pillars/scene/blocks/kaleidoscope.ts
@@ -1,0 +1,50 @@
+/**
+ * src/pillars/scene/blocks/kaleidoscope.ts
+ *
+ * A layout modifier: give each instance an `index`-derived rotation so the N
+ * copies form an N-fold rotationally symmetric figure, where N is the upstream
+ * instance count. Rotation is `index · (TAU / count)` — symmetry emerges from
+ * pure index arithmetic, with no mirror primitive and no per-instance variation
+ * beyond the angle.
+ *
+ * It rewrites only the rotation channel, so it composes: drop it onto a bare
+ * `InstanceCount` (all at the origin) for an overlapping rosette, or after a
+ * `RingLayout` so each copy on the ring also faces its own angle — a pinwheel.
+ *
+ * [LAW:composability] Owns neither count, position, nor color; the symmetry order
+ *   is read from the bundle it transforms, so the same block is 6-fold or 12-fold
+ *   purely by the count feeding it.
+ */
+
+import { add, intrinsic, konst, mul } from '../../../render/scene-plan';
+import { defineSceneBlock } from '../scene-block';
+
+const TAU = 2 * Math.PI;
+
+export const KaleidoscopeBlock = defineSceneBlock({
+  type: 'Kaleidoscope',
+  role: 'modifier',
+  catalog: {
+    displayName: 'Kaleidoscope',
+    category: 'modifier',
+    ports: [
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
+    ],
+  },
+  config: {},
+  contribute: () => ({
+    role: 'modifier',
+    apply: (bundle) => ({
+      ...bundle,
+      transform: {
+        ...bundle.transform,
+        // N-fold: each index turns by one slice of the full circle.
+        rotation: add(
+          bundle.transform.rotation,
+          mul(intrinsic('index'), konst(TAU / bundle.count)),
+        ),
+      },
+    }),
+  }),
+});

--- a/src/pillars/scene/blocks/ring-layout.ts
+++ b/src/pillars/scene/blocks/ring-layout.ts
@@ -1,0 +1,58 @@
+/**
+ * src/pillars/scene/blocks/ring-layout.ts
+ *
+ * A layout modifier: arrange the upstream instances evenly around a circle by
+ * their `rank`, optionally orbiting the whole ring over time. Pure
+ * `rank`/`time`→position math folded onto the upstream transform — placement is
+ * a modifier, not a fused source (the demo library's foundational cut).
+ *
+ * `angularSpeed` of 0 is a static ring; any other value spins the ring about the
+ * origin — an orbit. The two are the same expression with a different value, not
+ * two blocks. [LAW:dataflow-not-control-flow]
+ *
+ * [LAW:composability] Owns neither count nor color: it transforms whatever
+ *   bundle feeds it. It drops onto a bare `InstanceCount` to make an orbit ring,
+ *   or after another layout to arrange that layout's output on a circle.
+ */
+
+import { add, cos, input, intrinsic, konst, mul, sin } from '../../../render/scene-plan';
+import { defineSceneBlock, sceneConfig } from '../scene-block';
+
+const TAU = 2 * Math.PI;
+
+const config = {
+  radius: sceneConfig.positiveNumber({ label: 'Radius', control: 'number' }),
+  angularSpeed: sceneConfig.finiteNumber({ label: 'Angular speed', control: 'number' }),
+} as const;
+
+export const RingLayoutBlock = defineSceneBlock({
+  type: 'RingLayout',
+  role: 'modifier',
+  catalog: {
+    displayName: 'Ring Layout',
+    category: 'modifier',
+    ports: [
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
+    ],
+  },
+  config,
+  contribute: (config) => ({
+    role: 'modifier',
+    apply: (bundle) => {
+      // angle = rank·TAU (even spacing) + time·angularSpeed (orbital spin).
+      const angle = add(
+        mul(intrinsic('rank'), konst(TAU)),
+        mul(input('time'), konst(config.angularSpeed)),
+      );
+      return {
+        ...bundle,
+        transform: {
+          ...bundle.transform,
+          positionX: add(bundle.transform.positionX, mul(konst(config.radius), cos(angle))),
+          positionY: add(bundle.transform.positionY, mul(konst(config.radius), sin(angle))),
+        },
+      };
+    },
+  }),
+});

--- a/src/pillars/scene/blocks/spirograph.ts
+++ b/src/pillars/scene/blocks/spirograph.ts
@@ -1,0 +1,67 @@
+/**
+ * src/pillars/scene/blocks/spirograph.ts
+ *
+ * A layout modifier: place each instance at a point on a Lissajous curve, using
+ * `rank` as a phase delay so each instance is a different moment along the trace.
+ * Two oscillators at ratio `freqA:freqB` over the shared phase produce the
+ * emergent figure; `speed` slides the sampling over time so the points flow
+ * along the curve. Pure `rank`/`time`→position math — no per-demo source block,
+ * no geometry beyond the point primitive.
+ *
+ * The figure is the value of `freqA:freqB`: a 1:1 ratio is an ellipse, 3:2 a
+ * three-lobe trace, and so on — variation lives in the operands, not in modes.
+ * [LAW:dataflow-not-control-flow]
+ *
+ * [LAW:composability] Owns neither count nor color; folds onto a bare
+ *   `InstanceCount` (point geometry) to draw the trace.
+ */
+
+import { add, cos, input, intrinsic, konst, mul, sin } from '../../../render/scene-plan';
+import { defineSceneBlock, sceneConfig } from '../scene-block';
+
+const TAU = 2 * Math.PI;
+
+const config = {
+  radius: sceneConfig.positiveNumber({ label: 'Radius', control: 'number' }),
+  freqA: sceneConfig.finiteNumber({ label: 'Frequency A', control: 'number' }),
+  freqB: sceneConfig.finiteNumber({ label: 'Frequency B', control: 'number' }),
+  speed: sceneConfig.finiteNumber({ label: 'Speed', control: 'number' }),
+} as const;
+
+export const SpirographBlock = defineSceneBlock({
+  type: 'Spirograph',
+  role: 'modifier',
+  catalog: {
+    displayName: 'Spirograph',
+    category: 'modifier',
+    ports: [
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
+    ],
+  },
+  config,
+  contribute: (config) => ({
+    role: 'modifier',
+    apply: (bundle) => {
+      // Shared phase: rank places each instance along the trace, time slides it.
+      const phase = add(
+        mul(intrinsic('rank'), konst(TAU)),
+        mul(input('time'), konst(config.speed)),
+      );
+      return {
+        ...bundle,
+        transform: {
+          ...bundle.transform,
+          positionX: add(
+            bundle.transform.positionX,
+            mul(konst(config.radius), sin(mul(konst(config.freqA), phase))),
+          ),
+          positionY: add(
+            bundle.transform.positionY,
+            mul(konst(config.radius), cos(mul(konst(config.freqB), phase))),
+          ),
+        },
+      };
+    },
+  }),
+});

--- a/src/pillars/scene/blocks/threshold-visibility.ts
+++ b/src/pillars/scene/blocks/threshold-visibility.ts
@@ -1,0 +1,51 @@
+/**
+ * src/pillars/scene/blocks/threshold-visibility.ts
+ *
+ * A color modifier: show or hide each instance by a threshold over a per-instance
+ * field, proving that visibility is a material decision (opacity 0 vs 1), not a
+ * domain operation that removes instances. The block names a base color and a
+ * `threshold`/`frequency`/`speed` intent; the rgba channel layout and the `step`
+ * that turns the field boolean live at the color seam (`thresholdVisibilityBinding`).
+ *
+ * [LAW:decomposition] Visibility is a color/material concern; placement stays
+ *   with the layout modifier upstream. No instance is added or dropped — every
+ *   instance is drawn, some at opacity 0.
+ * [LAW:dataflow-not-control-flow] Show/hide is the *value* of the alpha channel,
+ *   not a branch; the threshold scalar is a uniform every instance reads.
+ */
+
+import { defineSceneBlock, sceneConfig } from '../scene-block';
+import { thresholdVisibilityBinding } from '../color';
+
+const config = {
+  color: sceneConfig.color({ label: 'Color', control: 'color' }),
+  threshold: sceneConfig.finiteNumber({ label: 'Threshold', control: 'number' }),
+  frequency: sceneConfig.finiteNumber({ label: 'Frequency', control: 'number' }),
+  speed: sceneConfig.finiteNumber({ label: 'Speed', control: 'number' }),
+} as const;
+
+export const ThresholdVisibilityBlock = defineSceneBlock({
+  type: 'ThresholdVisibility',
+  role: 'modifier',
+  catalog: {
+    displayName: 'Threshold Visibility',
+    category: 'color',
+    ports: [
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
+    ],
+  },
+  config,
+  contribute: (config) => ({
+    role: 'modifier',
+    apply: (bundle) => ({
+      ...bundle,
+      color: thresholdVisibilityBinding(
+        config.color,
+        config.threshold,
+        config.frequency,
+        config.speed,
+      ),
+    }),
+  }),
+});

--- a/src/pillars/scene/color.ts
+++ b/src/pillars/scene/color.ts
@@ -13,7 +13,18 @@
  *   it does not touch three or the renderer.
  */
 
-import { add, cos, konst, mul, sin, type ColorBinding, type PlanExpr } from '../../render/scene-plan';
+import {
+  add,
+  cos,
+  input,
+  intrinsic,
+  konst,
+  mul,
+  sin,
+  step,
+  type ColorBinding,
+  type PlanExpr,
+} from '../../render/scene-plan';
 
 const TAU = 2 * Math.PI;
 
@@ -81,6 +92,49 @@ export function gradientColorBinding(hexFrom: string, hexTo: string, t: PlanExpr
   const c1 = hexToOklab(hexTo);
   const lerp = (from: number, to: number): PlanExpr => add(konst(from), mul(konst(to - from), t));
   return { space: 'oklab', l: lerp(c0.l, c1.l), a: lerp(c0.a, c1.a), b: lerp(c0.b, c1.b) };
+}
+
+/**
+ * An opaque base color shown or hidden per instance by a threshold: an `rgba`
+ * `ColorBinding` whose `a` channel is a boolean `step` over a per-instance
+ * field. The field is a `rank`-spread, `time`-drifting sine remapped to `[0,1]`;
+ * `step(threshold, field)` yields exactly `1` (shown) or `0` (hidden), so a
+ * single global `threshold` scalar controls apparent density — show/hide is a
+ * material decision, never a domain operation.
+ *
+ * The base rgb is the opaque authored color decoded to linear light (the
+ * realizer hands `rgb` straight through, unlike the `oklab` ops); `rgba` carries
+ * no perceptual space, so this seam is the one place that layout is minted.
+ *
+ * [LAW:dataflow-not-control-flow] Visibility is the *value* of `a` (0 or 1), not
+ *   a branch that skips drawing an instance; every instance runs one expression.
+ * [LAW:one-source-of-truth] The threshold/visibility channel layout lives here at
+ *   the seam, never on the block API — the block hands an opaque color + scalars.
+ */
+export function thresholdVisibilityBinding(
+  hex: string,
+  threshold: number,
+  frequency: number,
+  speed: number,
+): ColorBinding {
+  const channel = (start: number): number =>
+    srgbToLinear(parseInt(hex.slice(start, start + 2), 16) / CHANNEL_MAX);
+  // A per-instance field in [0,1]: rank spreads it across the field, time drifts
+  // which instances clear the threshold, so the visible set sweeps over time.
+  const field = mul(
+    add(
+      sin(add(mul(intrinsic('rank'), konst(frequency)), mul(input('time'), konst(speed)))),
+      konst(1),
+    ),
+    konst(0.5),
+  );
+  return {
+    space: 'rgba',
+    r: konst(channel(1)),
+    g: konst(channel(3)),
+    b: konst(channel(5)),
+    a: step(konst(threshold), field),
+  };
 }
 
 /**

--- a/src/render/scene-plan/__tests__/capability-matrix.test.ts
+++ b/src/render/scene-plan/__tests__/capability-matrix.test.ts
@@ -44,6 +44,7 @@ import {
   mul,
   div,
   mod,
+  step,
   type PlanExpr,
   type PlanUnaryOp,
   type PlanBinaryOp,
@@ -118,7 +119,8 @@ function buildCapabilityCoveragePlan(): ScenePlan {
         },
         [matRgba]: {
           kind: 'unlitColor',
-          color: { space: 'rgba', r: konst(1), g: konst(0), b: konst(0), a: konst(0.5) },
+          // binary: step — a per-instance boolean opacity (rank past a threshold).
+          color: { space: 'rgba', r: konst(1), g: konst(0), b: konst(0), a: step(konst(0.5), rank) },
         },
         [matOklab]: {
           kind: 'unlitColor',
@@ -256,7 +258,7 @@ describe('ScenePlan capability matrix — representative coverage', () => {
     const { kinds, unary, binary } = collectExprVocabulary(plan);
     expect(kinds).toEqual(new Set(['const', 'input', 'intrinsic', 'unary', 'binary']));
     expect(unary).toEqual(new Set<PlanUnaryOp>(['floor', 'sin', 'cos', 'negate']));
-    expect(binary).toEqual(new Set<PlanBinaryOp>(['add', 'sub', 'mul', 'div', 'mod']));
+    expect(binary).toEqual(new Set<PlanBinaryOp>(['add', 'sub', 'mul', 'div', 'mod', 'step']));
   });
 
   it('frames with an orthographic camera and draws to the preview canvas', () => {

--- a/src/render/scene-plan/expr.ts
+++ b/src/render/scene-plan/expr.ts
@@ -53,8 +53,17 @@ export type PlanIntrinsic = 'index' | 'rank';
 /** Single-operand math operators. */
 export type PlanUnaryOp = 'floor' | 'sin' | 'cos' | 'negate';
 
-/** Two-operand math operators. */
-export type PlanBinaryOp = 'add' | 'sub' | 'mul' | 'div' | 'mod';
+/**
+ * Two-operand math operators.
+ *
+ * `step` is the threshold primitive: `step(edge, x)` is `1` when `x >= edge`,
+ * else `0`. It is what turns a smooth per-instance field into a boolean
+ * show/hide decision — the Conditional Visibility demo's "opacity is a material
+ * binding" claim is unrepresentable without it, and a smooth fade would be a
+ * dishonest stand-in. [LAW:no-mode-explosion] One operator, every consumer kept
+ * exhaustive; no flag selects "threshold mode".
+ */
+export type PlanBinaryOp = 'add' | 'sub' | 'mul' | 'div' | 'mod' | 'step';
 
 /**
  * A backend-neutral scalar expression.
@@ -99,3 +108,5 @@ export const sub = binary('sub');
 export const mul = binary('mul');
 export const div = binary('div');
 export const mod = binary('mod');
+/** `step(edge, x)` → `1` when `x >= edge`, else `0`. */
+export const step = binary('step');

--- a/src/render/scene-plan/index.ts
+++ b/src/render/scene-plan/index.ts
@@ -50,6 +50,7 @@ export {
   mul,
   div,
   mod,
+  step,
 } from './expr';
 
 // Plan structure.

--- a/src/render/webgpu/three/plan-expr-tsl.ts
+++ b/src/render/webgpu/three/plan-expr-tsl.ts
@@ -25,7 +25,7 @@
  */
 
 import type { Node } from 'three/webgpu';
-import { add, cos, div, floor, instanceIndex, mod, mul, negate, sin, sub, float } from 'three/tsl';
+import { add, cos, div, floor, instanceIndex, mod, mul, negate, sin, step, sub, float } from 'three/tsl';
 
 import type {
   PlanBinaryOp,
@@ -76,6 +76,8 @@ const BINARY_OPS: Record<PlanBinaryOp, (lhs: TSLNode, rhs: TSLNode) => TSLNode> 
   mul: (lhs, rhs) => mul(lhs, rhs),
   div: (lhs, rhs) => div(lhs, rhs),
   mod: (lhs, rhs) => mod(lhs, rhs),
+  // TSL `step(edge, x)` → 1 when x >= edge, else 0; lhs is the edge.
+  step: (lhs, rhs) => step(lhs, rhs),
 };
 
 function intrinsicToTSL(name: PlanIntrinsic, ctx: PlanExprContext): TSLNode {


### PR DESCRIPTION
Closes the active-backlog top ticket **oscilla-pillars-scene-nt56.8** — recreate the target demo animations as ScenePlan-native fixtures built **only** from native scene blocks, rendering through `ThreeForkRenderer`.

## Approach
Per the ticket's law-cited guidance (and the brkm.2 investigation), layouts are authored as composable **modifiers over a bare count source** — never new fused per-demo source blocks. `InstanceGrid` welds count+layout+rotation into one block that serves one demo; the new library cuts those apart so every layout composes.

### New foundational source + layout modifiers (pure index/rank → transform)
- **`InstanceCount`** — bare count source (identity transform, neutral white): the composable base the whole "layouts are modifiers" architecture rests on. `[LAW:composability]`
- **`RingLayout`** — circular placement by rank with optional orbital spin (`angularSpeed 0` is a static ring; nonzero orbits). Same expression, different value. `[LAW:dataflow-not-control-flow]`
- **`Spirograph`** — Lissajous trace from rank-as-phase + two oscillators (`freqA:freqB`).
- **`Kaleidoscope`** — N-fold rotation from index math; N is the *upstream count*, read from the bundle (no per-fold config).

### Conditional Visibility — show/hide as a material decision
- Added one principled **`step`** binary `PlanExpr` op (threshold → boolean), threaded exhaustively through `expr.ts` / `index.ts` / `plan-expr-tsl.ts` and the capability matrix + doc — the same type-enforced ripple the existing operators follow. `[LAW:types-are-the-program]`
- **`ThresholdVisibility`** color modifier emits an rgba binding whose per-instance `a = step(threshold, field)`. The renderer already realizes per-instance opacity (`opacityNode` + `transparent`).

### Fixtures (bootable via `?scenePlan=<id>`)
`ring-orbit`, `spirograph`, `kaleidoscope`, `conditional-visibility`, registered in `SCENE_PLAN_DEMOS`. The pre-existing native demos already cover grid+clock-motion (`grid-of-squares`), multi-block modifier chain (`instance-wave`), color source (`instance-gradient`), and asset-backed rendering (`textured-tiles`).

## Verification
- `npx vitest run src/pillars/scene/` green; **full suite 2338 passed**; `typecheck` + `lint` clean.
- New `demo-fixtures.test.ts` asserts each fixture's user-visible behavior + ScenePlan contracts and **sweeps the whole `SCENE_PLAN_DEMOS` registry for compile-ok** `[LAW:verifiable-goals]`.
- **Visual gate** (real-GPU headless Chrome, `?scenePlan=<id>`, 3-frame motion bursts through `ThreeForkRenderer`):
  - ring-orbit: 64-dot rainbow ring whose color pattern rotates → orbital motion ✓
  - spirograph: 600-dot rank-colored 3:2 Lissajous, morphing over time ✓
  - kaleidoscope: 12-fold pinwheel of index-rotated squares, slowly drifting ✓
  - conditional-visibility: threshold-gated teal arcs of a 240-point ring sweeping as `time` advances (hidden instances at opacity 0, **not** removed) ✓

## Documented gaps → child tickets
- **nt56.23** — hash/fract `PlanExpr` operator + Scatter layout modifier (noise/density layouts). The faithful threshold-opacity Conditional Visibility is delivered; the original's *noise-driven density over a scatter* needs hash/fract + ScatterUV, explicitly out of this slice's vocabulary.
- **nt56.24** — size-correct point primitive + non-square geometry (the dots are small rectangles today; `point` realizes as a placeholder 1-unit quad).
- Richer asset-backed native blocks remain the already-open **nt56.6**.

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7