### PR TITLE
feat(pillars-scene nt56.16.1): native editor node-graph canvas with automatic linear layout

### DIFF
--- a/src/ui/nativeEditor/NativeEditorLayout.tsx
+++ b/src/ui/nativeEditor/NativeEditorLayout.tsx
@@ -1,18 +1,21 @@
 /**
  * src/ui/nativeEditor/NativeEditorLayout.tsx
  *
- * The native ScenePlan editor surface: the authoring panel on the left, the live
- * Three preview canvas on the right. Selected by `?scenePlan=editor`. The canvas
- * is handed to `RuntimeService` via `onCanvasReady`; the runtime drives it from
- * the authored patch in `PillarPatchStore` (see `startNativeEditorThread`).
+ * The native ScenePlan editor surface: the authoring panel on the left, the
+ * auto-laid-out node-graph canvas in the center, and the live Three preview on
+ * the right. Selected by `?scenePlan=editor`. The preview canvas is handed to
+ * `RuntimeService` via `onCanvasReady`; the runtime drives it from the authored
+ * patch in `PillarPatchStore` (see `startNativeEditorThread`).
  *
- * [LAW:locality-or-seam] This layout owns only DOM composition + canvas sizing.
- *   It does not compile or install anything — that is the runtime's boundary.
+ * [LAW:locality-or-seam] This layout owns only DOM composition + preview-canvas
+ *   sizing. It does not compile or install anything — that is the runtime's
+ *   boundary — and the graph canvas reads the same authored patch independently.
  */
 
 import React, { useEffect, useRef } from 'react';
 
 import { NativeEditorPanel } from './NativeEditorPanel';
+import { NativeGraphCanvas } from './NativeGraphCanvas';
 
 interface NativeEditorLayoutProps {
   onCanvasReady?: (canvas: HTMLCanvasElement) => void;
@@ -29,8 +32,11 @@ export const NativeEditorLayout: React.FC<NativeEditorLayoutProps> = ({ onCanvas
         background: '#0f0f17',
       }}
     >
-      <div style={{ width: 380, flexShrink: 0, borderRight: '1px solid #2a2a38' }}>
+      <div style={{ width: 360, flexShrink: 0, borderRight: '1px solid #2a2a38' }}>
         <NativeEditorPanel />
+      </div>
+      <div style={{ flex: 1, minWidth: 0, borderRight: '1px solid #2a2a38' }}>
+        <NativeGraphCanvas />
       </div>
       <PreviewCanvas onCanvasReady={onCanvasReady} />
     </div>

--- a/src/ui/nativeEditor/NativeGraphCanvas.tsx
+++ b/src/ui/nativeEditor/NativeGraphCanvas.tsx
@@ -1,0 +1,146 @@
+/**
+ * src/ui/nativeEditor/NativeGraphCanvas.tsx
+ *
+ * The native ScenePlan editor's node-graph canvas. It reads the authored patch
+ * from `PillarPatchStore` and draws it as a node graph laid out automatically
+ * left-to-right (sources left, sinks right). Blocks are NOT hand-draggable — the
+ * editor positions them algorithmically, the anti-spaghetti model from the spec.
+ *
+ * [LAW:one-way-deps] Reads `PillarPatchStore` + the scene catalog only. It does
+ *   not touch a renderer, a Three object, or V1's editor contracts.
+ * [LAW:one-source-of-truth] Nodes/edges are derived from the authored patch every
+ *   render; the canvas stores only the ELK-resolved positions, never block truth.
+ * [LAW:no-ambient-temporal-coupling] Relayout is owned by one effect keyed on the
+ *   patch topology; config edits (which never change topology) do not reflow it.
+ */
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { observer } from 'mobx-react-lite';
+import ReactFlow, {
+  Background,
+  Controls,
+  ReactFlowProvider,
+  useReactFlow,
+  type Edge,
+  type Node,
+  type NodeTypes,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+
+import { useStores } from '../../stores';
+import type { SceneRegistry } from '../../pillars/scene';
+import type { PillarPatch } from '../../pillars/types';
+import { layoutGraphLeftToRight } from './graphLayout';
+import { SceneBlockNode, computeNodeSize, type SceneBlockNodeData } from './SceneBlockNode';
+
+const nodeTypes: NodeTypes = { sceneBlock: SceneBlockNode };
+
+/** Build the (unpositioned) reactflow nodes for the authored patch. */
+function buildNodes(patch: PillarPatch, registry: SceneRegistry): Node<SceneBlockNodeData>[] {
+  return patch.blocks.map((block) => {
+    const ports = registry.get(block.type)?.catalog.ports ?? [];
+    const data: SceneBlockNodeData = {
+      displayName: registry.get(block.type)?.catalog.displayName ?? block.type,
+      category: registry.get(block.type)?.catalog.category ?? 'modifier',
+      blockId: block.id,
+      inputs: ports.filter((p) => p.direction === 'input'),
+      outputs: ports.filter((p) => p.direction === 'output'),
+    };
+    const { width, height } = computeNodeSize(data);
+    return {
+      id: block.id,
+      type: 'sceneBlock',
+      position: { x: 0, y: 0 },
+      width,
+      height,
+      data,
+    };
+  });
+}
+
+/** Build the reactflow edges, anchoring each to the source block's sole output. */
+function buildEdges(patch: PillarPatch, registry: SceneRegistry): Edge[] {
+  return patch.edges.map((edge) => {
+    const sourceOutput = registry
+      .get(patch.blocks.find((b) => b.id === edge.source)?.type ?? '')
+      ?.catalog.ports.find((p) => p.direction === 'output');
+    return {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      sourceHandle: sourceOutput?.id,
+      targetHandle: edge.inputSlot,
+      style: { stroke: '#5a5a72', strokeWidth: 1.5 },
+    };
+  });
+}
+
+/** A stable signature of the patch *topology* — changes only on add/remove/wire. */
+function topologyKey(patch: PillarPatch): string {
+  const blocks = patch.blocks.map((b) => `${b.id}:${b.type}`).join(',');
+  const edges = patch.edges
+    .map((e) => `${e.id}:${e.source}>${e.target}.${e.inputSlot}`)
+    .join(',');
+  return `${blocks}|${edges}`;
+}
+
+const GraphInner: React.FC = observer(() => {
+  const { pillarPatch } = useStores();
+  const { patch, registry } = pillarPatch;
+  const { fitView } = useReactFlow();
+
+  const key = topologyKey(patch);
+  // Rebuild base graph whenever topology changes; positions come from ELK below.
+  const base = useMemo(
+    () => ({ nodes: buildNodes(patch, registry), edges: buildEdges(patch, registry) }),
+    [key],
+  );
+
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [edges, setEdges] = useState<Edge[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void layoutGraphLeftToRight(base.nodes, base.edges).then((positioned) => {
+      if (cancelled) return;
+      setNodes(positioned);
+      setEdges(base.edges);
+      // Fit after the new positions paint so the whole graph is visible.
+      requestAnimationFrame(() => {
+        if (!cancelled) fitView({ padding: 0.15, duration: 200 });
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [base, fitView]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={nodeTypes}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable={false}
+      fitView
+      minZoom={0.2}
+      maxZoom={2}
+      proOptions={{ hideAttribution: true }}
+      style={{ background: '#0f0f17' }}
+    >
+      <Background color="#23233a" gap={20} />
+      <Controls showInteractive={false} />
+    </ReactFlow>
+  );
+});
+
+export const NativeGraphCanvas: React.FC = () => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  return (
+    <div ref={containerRef} data-testid="native-graph-canvas" style={{ width: '100%', height: '100%' }}>
+      <ReactFlowProvider>
+        <GraphInner />
+      </ReactFlowProvider>
+    </div>
+  );
+};

--- a/src/ui/nativeEditor/NativeGraphCanvas.tsx
+++ b/src/ui/nativeEditor/NativeGraphCanvas.tsx
@@ -57,21 +57,32 @@ function buildNodes(patch: PillarPatch, registry: SceneRegistry): Node<SceneBloc
   });
 }
 
-/** Build the reactflow edges, anchoring each to the source block's sole output. */
+/**
+ * Build the reactflow edges, anchoring each to the source block's sole output.
+ *
+ * The store invariant guarantees every edge references existing blocks
+ * (`PillarPatchStore.removeBlock` prunes edges with their blocks; `addEdge` only
+ * wires existing sources), so the source block is always present — the handle map
+ * is keyed by block id with no missing-block coercion. The one optionality that
+ * legitimately remains is a block whose *type* is unregistered (a stale persisted
+ * patch): its output handle is absent, which renders as an unanchored edge and is
+ * reported by the validation/diagnostics boundary, not swallowed here.
+ */
 function buildEdges(patch: PillarPatch, registry: SceneRegistry): Edge[] {
-  return patch.edges.map((edge) => {
-    const sourceOutput = registry
-      .get(patch.blocks.find((b) => b.id === edge.source)?.type ?? '')
-      ?.catalog.ports.find((p) => p.direction === 'output');
-    return {
-      id: edge.id,
-      source: edge.source,
-      target: edge.target,
-      sourceHandle: sourceOutput?.id,
-      targetHandle: edge.inputSlot,
-      style: { stroke: '#5a5a72', strokeWidth: 1.5 },
-    };
-  });
+  const outputHandleByBlock = new Map<string, string | undefined>(
+    patch.blocks.map((b) => [
+      b.id,
+      registry.get(b.type)?.catalog.ports.find((p) => p.direction === 'output')?.id,
+    ]),
+  );
+  return patch.edges.map((edge) => ({
+    id: edge.id,
+    source: edge.source,
+    target: edge.target,
+    sourceHandle: outputHandleByBlock.get(edge.source),
+    targetHandle: edge.inputSlot,
+    style: { stroke: '#5a5a72', strokeWidth: 1.5 },
+  }));
 }
 
 /** A stable signature of the patch *topology* — changes only on add/remove/wire. */
@@ -100,15 +111,21 @@ const GraphInner: React.FC = observer(() => {
 
   useEffect(() => {
     let cancelled = false;
-    void layoutGraphLeftToRight(base.nodes, base.edges).then((positioned) => {
-      if (cancelled) return;
-      setNodes(positioned);
-      setEdges(base.edges);
-      // Fit after the new positions paint so the whole graph is visible.
-      requestAnimationFrame(() => {
-        if (!cancelled) fitView({ padding: 0.15, duration: 200 });
+    layoutGraphLeftToRight(base.nodes, base.edges)
+      .then((positioned) => {
+        if (cancelled) return;
+        setNodes(positioned);
+        setEdges(base.edges);
+        // Fit after the new positions paint so the whole graph is visible.
+        requestAnimationFrame(() => {
+          if (!cancelled) fitView({ padding: 0.15, duration: 200 });
+        });
+      })
+      // [LAW:no-silent-failure] An ELK rejection must surface, not vanish — a
+      // swallowed layout error would leave the graph blank with no signal.
+      .catch((err: unknown) => {
+        console.error('Native graph layout failed:', err);
       });
-    });
     return () => {
       cancelled = true;
     };

--- a/src/ui/nativeEditor/SceneBlockNode.tsx
+++ b/src/ui/nativeEditor/SceneBlockNode.tsx
@@ -1,0 +1,161 @@
+/**
+ * src/ui/nativeEditor/SceneBlockNode.tsx
+ *
+ * The reactflow node renderer for one authored scene block. It draws the block's
+ * display name, its category accent, and a typed handle for each catalog port —
+ * inputs on the left, outputs on the right, each colored by its SceneValueKind.
+ *
+ * [LAW:types-are-the-program] The node is driven entirely by catalog data
+ *   (displayName, category, typed ports). It does NOT depend on V1's port
+ *   contract (combineMode + InferenceCanonicalType), which scene ports — typed by
+ *   SceneValueKind — do not have. Forcing PillarBlock through that contract would
+ *   be a false type; this node speaks the scene vocabulary directly.
+ * [LAW:one-source-of-truth] Node geometry lives in the constants below and is
+ *   exported via `computeNodeSize`, so the canvas hands ELK the same dimensions
+ *   the node actually renders at — handle anchors and layout spacing cannot drift.
+ */
+import React from 'react';
+import { Handle, Position, type NodeProps } from 'reactflow';
+
+import type {
+  SceneBlockCategory,
+  ScenePortDeclaration,
+  SceneValueKind,
+} from '../../pillars/scene';
+
+export const HEADER_HEIGHT = 28;
+export const ROW_HEIGHT = 22;
+const V_PADDING = 8;
+export const NODE_WIDTH = 184;
+
+/** The data a `SceneBlockNode` reads — derived from the catalog, never authored. */
+export interface SceneBlockNodeData {
+  readonly displayName: string;
+  readonly category: SceneBlockCategory;
+  readonly blockId: string;
+  readonly inputs: readonly ScenePortDeclaration[];
+  readonly outputs: readonly ScenePortDeclaration[];
+}
+
+/** Node height fits the busier side (inputs vs outputs); at least one row. */
+export function computeNodeSize(data: SceneBlockNodeData): {
+  width: number;
+  height: number;
+} {
+  const rows = Math.max(data.inputs.length, data.outputs.length, 1);
+  return { width: NODE_WIDTH, height: HEADER_HEIGHT + rows * ROW_HEIGHT + V_PADDING };
+}
+
+/** Vertical center of the i-th port row, measured from the node's top. */
+function rowCenter(index: number): number {
+  return HEADER_HEIGHT + index * ROW_HEIGHT + ROW_HEIGHT / 2;
+}
+
+const CATEGORY_ACCENT: Record<SceneBlockCategory, string> = {
+  instance: '#7c5cff',
+  modifier: '#3a9bdc',
+  draw: '#e06c4f',
+  material: '#2bb3a3',
+  asset: '#d9a441',
+  color: '#d65db1',
+};
+
+const VALUE_KIND_COLOR: Record<SceneValueKind, string> = {
+  instanceBundle: '#9b7cff',
+  geometry: '#5bb0ec',
+  materialShell: '#3fd0bd',
+  texture: '#e0a64f',
+  camera: '#9aa0b5',
+  color: '#ef8fd0',
+  scalar: '#7fd98a',
+  mask: '#e8d055',
+};
+
+export const SceneBlockNode: React.FC<NodeProps<SceneBlockNodeData>> = ({ data }) => {
+  const { width, height } = computeNodeSize(data);
+  const accent = CATEGORY_ACCENT[data.category];
+
+  return (
+    <div
+      data-testid={`native-graph-node-${data.blockId}`}
+      style={{
+        width,
+        height,
+        background: '#1d1d29',
+        border: `1px solid ${accent}`,
+        borderRadius: 8,
+        boxShadow: '0 1px 4px rgba(0,0,0,0.4)',
+        color: '#e6e6ef',
+        fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+        fontSize: 11,
+        position: 'relative',
+        overflow: 'hidden',
+      }}
+    >
+      <div
+        style={{
+          height: HEADER_HEIGHT,
+          lineHeight: `${HEADER_HEIGHT}px`,
+          padding: '0 10px',
+          fontWeight: 600,
+          fontSize: 12,
+          borderBottom: '1px solid #2a2a38',
+          background: `${accent}22`,
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+        }}
+        title={`${data.displayName} (${data.blockId})`}
+      >
+        {data.displayName}
+      </div>
+
+      {data.inputs.map((port, i) => (
+        <PortRow key={`in-${port.id}`} port={port} side="left" top={rowCenter(i)} blockId={data.blockId} />
+      ))}
+      {data.outputs.map((port, i) => (
+        <PortRow key={`out-${port.id}`} port={port} side="right" top={rowCenter(i)} blockId={data.blockId} />
+      ))}
+    </div>
+  );
+};
+
+const PortRow: React.FC<{
+  port: ScenePortDeclaration;
+  side: 'left' | 'right';
+  top: number;
+  blockId: string;
+}> = ({ port, side, top, blockId }) => {
+  const color = VALUE_KIND_COLOR[port.value];
+  const isLeft = side === 'left';
+  return (
+    <>
+      <Handle
+        type={isLeft ? 'target' : 'source'}
+        position={isLeft ? Position.Left : Position.Right}
+        id={port.id}
+        data-testid={`native-graph-handle-${blockId}-${port.id}`}
+        style={{ top, background: color, border: '1px solid #11111a', width: 9, height: 9 }}
+        isConnectable={false}
+      />
+      <span
+        style={{
+          position: 'absolute',
+          top: top - ROW_HEIGHT / 2,
+          [isLeft ? 'left' : 'right']: 10,
+          height: ROW_HEIGHT,
+          lineHeight: `${ROW_HEIGHT}px`,
+          color: '#b7b7c8',
+          maxWidth: NODE_WIDTH / 2 - 6,
+          whiteSpace: 'nowrap',
+          textOverflow: 'ellipsis',
+          overflow: 'hidden',
+          textAlign: isLeft ? 'left' : 'right',
+        }}
+        title={`${port.label}: ${port.value}`}
+      >
+        {port.label}
+      </span>
+    </>
+  );
+};

--- a/src/ui/nativeEditor/graphLayout.ts
+++ b/src/ui/nativeEditor/graphLayout.ts
@@ -1,0 +1,69 @@
+/**
+ * src/ui/nativeEditor/graphLayout.ts
+ *
+ * Automatic left-to-right layered layout for the native editor's node graph,
+ * computed with ELK. The native editor positions blocks algorithmically — the
+ * user never drags a node — so this is the single owner of node placement.
+ *
+ * [LAW:effects-at-boundaries] A pure transform `(nodes, edges) -> positioned
+ *   nodes`. The one effect (`elk.layout`) is awaited; the caller performs it at
+ *   its boundary and feeds the positioned result to the renderer.
+ * [LAW:one-way-deps] The native editor owns its layout. It deliberately does NOT
+ *   import the V1 `reactFlowEditor` layout helper: that module is deprecated and
+ *   slated for deletion, and the live native editor must not dangle on dead code.
+ */
+import ELK from 'elkjs/lib/elk.bundled.js';
+import type { Node, Edge } from 'reactflow';
+
+const elk = new ELK();
+
+/** Fallback box used only when a node has not been measured yet. */
+const FALLBACK_NODE_WIDTH = 180;
+const FALLBACK_NODE_HEIGHT = 90;
+
+/**
+ * Position `nodes` in a compact left-to-right layered graph (sources left,
+ * sinks right) and return a new node array with `position` filled in. Edges are
+ * unchanged — they are read only to derive the layering.
+ */
+export async function layoutGraphLeftToRight(
+  nodes: Node[],
+  edges: Edge[],
+): Promise<Node[]> {
+  const elkGraph = {
+    id: 'root',
+    layoutOptions: {
+      'elk.algorithm': 'layered',
+      'elk.direction': 'RIGHT',
+      'elk.spacing.nodeNode': '36',
+      'elk.layered.spacing.nodeNodeBetweenLayers': '110',
+      'elk.padding': '[top=24,left=24,bottom=24,right=24]',
+      'elk.layered.nodePlacement.strategy': 'NETWORK_SIMPLEX',
+      'elk.layered.nodePlacement.favorStraightEdges': 'true',
+      'elk.edgeRouting': 'POLYLINE',
+      'elk.layered.thoroughness': '10',
+      'elk.aspectRatio': '2.0',
+    },
+    children: nodes.map((node) => ({
+      id: node.id,
+      width: node.width ?? FALLBACK_NODE_WIDTH,
+      height: node.height ?? FALLBACK_NODE_HEIGHT,
+    })),
+    edges: edges.map((edge) => ({
+      id: edge.id,
+      sources: [edge.source],
+      targets: [edge.target],
+    })),
+  };
+
+  const laidOut = await elk.layout(elkGraph);
+  const positionById = new Map(
+    (laidOut.children ?? []).map((child) => [child.id, child]),
+  );
+
+  return nodes.map((node) => {
+    const placed = positionById.get(node.id);
+    if (placed === undefined) return node;
+    return { ...node, position: { x: placed.x ?? 0, y: placed.y ?? 0 } };
+  });
+}

--- a/src/ui/nativeEditor/index.ts
+++ b/src/ui/nativeEditor/index.ts
@@ -6,3 +6,4 @@
 
 export { NativeEditorLayout } from './NativeEditorLayout';
 export { NativeEditorPanel } from './NativeEditorPanel';
+export { NativeGraphCanvas } from './NativeGraphCanvas';


### PR DESCRIPTION
## What

Behavior 1 of the anti-spaghetti editor UX (`oscilla-pillars-scene-nt56.16`, split into three behavior tickets at pull time; this is the foundational one). The native ScenePlan editor (`src/ui/nativeEditor/`) previously had **no node-graph canvas** — only a card-list authoring panel. This PR adds the visual node graph that the other two behaviors (chain-focus dimming `nt56.16.2`, perspective rotation `nt56.16.3`) build on.

- **`graphLayout.ts`** — self-contained ELK layered left-to-right layout (sources left, sinks right), owned by the native editor. Deliberately does **not** import the V1 `reactFlowEditor` layout helper: that module is deprecated and slated for deletion, so the live editor must not dangle on dead code. `[LAW:one-way-deps]` `[LAW:carrying-cost]`
- **`SceneBlockNode.tsx`** — catalog-driven reactflow node: display name, category accent, and a typed handle per port colored by `SceneValueKind`. Speaks the scene port vocabulary directly rather than forcing `PillarBlock` through V1's `combineMode + InferenceCanonicalType` contract (which scene ports do not have — a false type). `[LAW:types-are-the-program]`
- **`NativeGraphCanvas.tsx`** — derives nodes/edges from `PillarPatchStore` every render and stores only ELK-resolved positions; relayout is owned by one effect keyed on patch *topology*, so config edits never reflow the graph. Nodes are not hand-draggable. `[LAW:one-source-of-truth]` `[LAW:no-ambient-temporal-coupling]` `[LAW:dataflow-not-control-flow]`
- **`NativeEditorLayout`** — now three columns: authoring panel | graph canvas | live preview.

## Verification

- `npm run typecheck` clean, `eslint` clean, full suite **2338 passed** / 1 skipped / 3 todo.
- Visual gate (`?scenePlan=editor`, headless metal-WebGPU): the starter patch renders as an auto-arranged left→right node graph (Instance Grid → Color Cycle → Draw Instances) with the live preview unaffected.

Acceptance ("blocks auto-arrange without manual dragging; verified in browser") met.

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7