### PR TITLE
feat(pillars-scene nt56.16.2): native editor chain-focus dimming + arrow-key chain traversal

### DIFF
--- a/src/ui/nativeEditor/NativeGraphCanvas.tsx
+++ b/src/ui/nativeEditor/NativeGraphCanvas.tsx
@@ -12,8 +12,10 @@
  *   render; the canvas stores only the ELK-resolved positions, never block truth.
  * [LAW:no-ambient-temporal-coupling] Relayout is owned by one effect keyed on the
  *   patch topology; config edits (which never change topology) do not reflow it.
+ *   Selection/dimming is a SECOND, independent derivation that reads positions but
+ *   never writes them — focusing a chain must not reflow the graph.
  */
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import ReactFlow, {
   Background,
@@ -22,6 +24,7 @@ import ReactFlow, {
   useReactFlow,
   type Edge,
   type Node,
+  type NodeMouseHandler,
   type NodeTypes,
 } from 'reactflow';
 import 'reactflow/dist/style.css';
@@ -30,9 +33,20 @@ import { useStores } from '../../stores';
 import type { SceneRegistry } from '../../pillars/scene';
 import type { PillarPatch } from '../../pillars/types';
 import { layoutGraphLeftToRight } from './graphLayout';
+import { computeChainSet, stepChain, type ChainDirection } from './chainFocus';
 import { SceneBlockNode, computeNodeSize, type SceneBlockNodeData } from './SceneBlockNode';
 
 const nodeTypes: NodeTypes = { sceneBlock: SceneBlockNode };
+
+/** Off-chain elements fade so the focused dataflow stands out (the anti-spaghetti model). */
+const ON_CHAIN_OPACITY = 1;
+const OFF_CHAIN_OPACITY = 0.3;
+
+/** Arrow keys map to a dataflow direction; the graph flows left→right (sources left). */
+const KEY_DIRECTION: Readonly<Record<string, ChainDirection>> = {
+  ArrowLeft: 'upstream',
+  ArrowRight: 'downstream',
+};
 
 /** Build the (unpositioned) reactflow nodes for the authored patch. */
 function buildNodes(patch: PillarPatch, registry: SceneRegistry): Node<SceneBlockNodeData>[] {
@@ -131,23 +145,106 @@ const GraphInner: React.FC = observer(() => {
     };
   }, [base, fitView]);
 
+  // --- Chain focus (view state; deliberately separate from the layout above) ---
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // A selection survives only as long as its block does; a topology change that
+  // removes the focused block clears focus rather than dimming the whole graph.
+  // [LAW:one-source-of-truth] The patch's block set decides what is selectable.
+  useEffect(() => {
+    if (selectedId !== null && !patch.blocks.some((b) => b.id === selectedId)) {
+      setSelectedId(null);
+    }
+  }, [key, selectedId, patch.blocks]);
+
+  // The focused dataflow chain; `null` when nothing is selected means "dim nothing".
+  const chain = useMemo(
+    () => (selectedId === null ? null : computeChainSet(patch.edges, selectedId)),
+    [selectedId, key, patch.edges],
+  );
+
+  // Dimming is a pure overlay on the laid-out nodes/edges: it adds opacity (and a
+  // ring on the selected node) without touching positions, so it never reflows.
+  const displayNodes = useMemo(
+    () =>
+      nodes.map((node) => {
+        const onChain = chain === null || chain.has(node.id);
+        const selected = node.id === selectedId;
+        return {
+          ...node,
+          style: {
+            ...node.style,
+            opacity: onChain ? ON_CHAIN_OPACITY : OFF_CHAIN_OPACITY,
+            ...(selected
+              ? { boxShadow: '0 0 0 2px #e6e6ef', borderRadius: 8 }
+              : {}),
+          },
+        };
+      }),
+    [nodes, chain, selectedId],
+  );
+
+  const displayEdges = useMemo(
+    () =>
+      edges.map((edge) => {
+        const onChain = chain === null || (chain.has(edge.source) && chain.has(edge.target));
+        return {
+          ...edge,
+          style: { ...edge.style, opacity: onChain ? ON_CHAIN_OPACITY : OFF_CHAIN_OPACITY },
+        };
+      }),
+    [edges, chain],
+  );
+
+  const selectNode: NodeMouseHandler = useCallback((_event, node) => {
+    setSelectedId(node.id);
+    wrapperRef.current?.focus();
+  }, []);
+
+  const clearSelection = useCallback(() => setSelectedId(null), []);
+
+  // Arrow keys step the selection along its chain; the key→direction map keeps the
+  // variability in data, so the handler is one lookup, not a branch per key.
+  const onKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (selectedId === null) return;
+      const direction = KEY_DIRECTION[event.key];
+      if (direction === undefined) return;
+      event.preventDefault();
+      const next = stepChain(patch.edges, selectedId, direction);
+      if (next !== null) setSelectedId(next);
+    },
+    [selectedId, patch.edges],
+  );
+
   return (
-    <ReactFlow
-      nodes={nodes}
-      edges={edges}
-      nodeTypes={nodeTypes}
-      nodesDraggable={false}
-      nodesConnectable={false}
-      elementsSelectable={false}
-      fitView
-      minZoom={0.2}
-      maxZoom={2}
-      proOptions={{ hideAttribution: true }}
-      style={{ background: '#0f0f17' }}
+    <div
+      ref={wrapperRef}
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      data-testid="native-graph-focus"
+      style={{ width: '100%', height: '100%', outline: 'none' }}
     >
-      <Background color="#23233a" gap={20} />
-      <Controls showInteractive={false} />
-    </ReactFlow>
+      <ReactFlow
+        nodes={displayNodes}
+        edges={displayEdges}
+        nodeTypes={nodeTypes}
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        onNodeClick={selectNode}
+        onPaneClick={clearSelection}
+        fitView
+        minZoom={0.2}
+        maxZoom={2}
+        proOptions={{ hideAttribution: true }}
+        style={{ background: '#0f0f17' }}
+      >
+        <Background color="#23233a" gap={20} />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
   );
 });
 

--- a/src/ui/nativeEditor/__tests__/chainFocus.test.ts
+++ b/src/ui/nativeEditor/__tests__/chainFocus.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the pure chain-focus model: transitive reachability and the
+ * deterministic single-step traversal. These assert the *contract* (which blocks
+ * are on a selection's chain, where one arrow step lands), never the rendering.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { computeChainSet, stepChain } from '../chainFocus';
+import type { PillarEdge } from '../../../pillars/types/graph';
+
+/** Terse edge builder; role is irrelevant to chain membership but required by the type. */
+function edge(id: string, source: string, target: string): PillarEdge {
+  return { id, source, target, inputSlot: 'primary', role: 'primary' };
+}
+
+// a → b → c (linear), with a side branch a → d → c and a leaf e → b.
+const edges: readonly PillarEdge[] = [
+  edge('e0', 'a', 'b'),
+  edge('e1', 'b', 'c'),
+  edge('e2', 'a', 'd'),
+  edge('e3', 'd', 'c'),
+  edge('e4', 'e', 'b'),
+];
+
+describe('computeChainSet', () => {
+  it('includes the selected block, all transitive feeders, and all transitive consumers', () => {
+    // From b: upstream {a, e}, self {b}, downstream {c}. d is on neither side of b.
+    expect(computeChainSet(edges, 'b')).toEqual(new Set(['a', 'e', 'b', 'c']));
+  });
+
+  it('reaches across multiple branch paths to a shared sink', () => {
+    // From a: downstream fans out through both b and d to c. e feeds b but is a
+    // feeder-of-a-consumer, not on a's own up/downstream chain, so it stays off.
+    expect(computeChainSet(edges, 'a')).toEqual(new Set(['a', 'b', 'd', 'c']));
+  });
+
+  it('returns just the block itself when it has no edges', () => {
+    expect(computeChainSet([edge('e0', 'a', 'b')], 'lonely')).toEqual(new Set(['lonely']));
+  });
+
+  it('terminates on a cycle', () => {
+    const cyclic = [edge('e0', 'x', 'y'), edge('e1', 'y', 'x')];
+    expect(computeChainSet(cyclic, 'x')).toEqual(new Set(['x', 'y']));
+  });
+});
+
+describe('stepChain', () => {
+  it('steps downstream to the consumer', () => {
+    expect(stepChain(edges, 'b', 'downstream')).toBe('c');
+  });
+
+  it('steps upstream to the first feeder in edge order', () => {
+    // b is fed by a (e0) and e (e4); edge order picks a.
+    expect(stepChain(edges, 'b', 'upstream')).toBe('a');
+  });
+
+  it('returns null at the end of the chain', () => {
+    expect(stepChain(edges, 'c', 'downstream')).toBeNull();
+    expect(stepChain(edges, 'a', 'upstream')).toBeNull();
+  });
+});

--- a/src/ui/nativeEditor/chainFocus.ts
+++ b/src/ui/nativeEditor/chainFocus.ts
@@ -1,0 +1,87 @@
+/**
+ * src/ui/nativeEditor/chainFocus.ts
+ *
+ * The dataflow-chain focus model for the native editor canvas. Selecting a block
+ * focuses its chain: the block plus everything that feeds it (upstream, transitively)
+ * and everything it feeds (downstream, transitively). Off-chain blocks dim — the
+ * 'anti-spaghetti' navigation model from the spec. Arrow keys step the selection
+ * along that chain.
+ *
+ * [LAW:one-source-of-truth] Chain membership is DERIVED from `patch.edges` by a
+ *   transitive reachability walk — there is no per-block "on chain" flag to keep in
+ *   sync. The edge graph is the sole authority; the chain set is a pure function of
+ *   it and the selected id.
+ * [LAW:effects-at-boundaries] These are pure functions over plain edge data. They
+ *   touch no store, no reactflow node, no DOM — the canvas performs the rendering
+ *   effect at its boundary using the sets/ids these return.
+ * [LAW:dataflow-not-control-flow] Variability lives in the derived chain set and the
+ *   neighbor list, not in branches: dimming is `chain.has(id) ? full : dim` over a
+ *   set this module computes, and traversal is "the first neighbor in a direction".
+ */
+import type { PillarEdge } from '../../pillars/types/graph';
+
+/**
+ * Direction along the dataflow. The native graph flows left→right (sources left,
+ * sinks right), so `upstream` walks toward sources and `downstream` toward sinks.
+ */
+export type ChainDirection = 'upstream' | 'downstream';
+
+/** The block ids directly adjacent to `blockId` in one dataflow direction, in edge order. */
+function neighbors(
+  edges: readonly PillarEdge[],
+  blockId: string,
+  direction: ChainDirection,
+): string[] {
+  return edges
+    .filter((e) => (direction === 'upstream' ? e.target === blockId : e.source === blockId))
+    .map((e) => (direction === 'upstream' ? e.source : e.target));
+}
+
+/** Block ids reachable from `start` by repeatedly following `direction`, excluding `start`. */
+function reachable(
+  edges: readonly PillarEdge[],
+  start: string,
+  direction: ChainDirection,
+): Set<string> {
+  const found = new Set<string>();
+  const frontier = [start];
+  while (frontier.length > 0) {
+    const id = frontier.pop() as string;
+    for (const next of neighbors(edges, id, direction)) {
+      if (!found.has(next)) {
+        found.add(next);
+        frontier.push(next);
+      }
+    }
+  }
+  return found;
+}
+
+/**
+ * The full dataflow chain of `selectedId`: the block itself, all transitive feeders
+ * (upstream) and all transitive consumers (downstream). A cycle terminates because
+ * the reachability walk records visited ids.
+ */
+export function computeChainSet(
+  edges: readonly PillarEdge[],
+  selectedId: string,
+): ReadonlySet<string> {
+  const chain = new Set<string>([selectedId]);
+  for (const id of reachable(edges, selectedId, 'upstream')) chain.add(id);
+  for (const id of reachable(edges, selectedId, 'downstream')) chain.add(id);
+  return chain;
+}
+
+/**
+ * The block one step from `selectedId` along `direction`, or `null` if the chain
+ * ends there. When a block branches (several neighbors in one direction) the first
+ * in edge order is chosen — deterministic, and unambiguous on the linear chains the
+ * layout produces; branch navigation is the perspective-rotation behavior, not this.
+ */
+export function stepChain(
+  edges: readonly PillarEdge[],
+  selectedId: string,
+  direction: ChainDirection,
+): string | null {
+  return neighbors(edges, selectedId, direction)[0] ?? null;
+}

--- a/tests/e2e/native-editor-chain-focus.spec.ts
+++ b/tests/e2e/native-editor-chain-focus.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * tests/e2e/native-editor-chain-focus.spec.ts
+ *
+ * Proof for oscilla-pillars-scene-nt56.16.2: selecting a block in the native graph
+ * canvas focuses its dataflow chain — the selected block plus its transitive
+ * upstream/downstream are full opacity while every unrelated block dims to ~30% —
+ * and arrow keys step the selection along the chain.
+ *
+ * The graph canvas is a pure DOM/SVG surface independent of the WebGPU preview, so
+ * this runs headless and asserts the dimming/traversal CONTRACT by reading each
+ * node's rendered opacity and selection ring from the DOM. // [LAW:behavior-not-structure]
+ *
+ * The patch is seeded into localStorage before boot (PillarPatchStore loads it),
+ * shaped with a disconnected second branch so there is genuinely something to dim:
+ *
+ *   grid → color → draw      (the main chain)
+ *   gridB → colorB           (a parallel branch, off every node's chain in 'draw')
+ */
+
+import { mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { expect, test, type Page } from '@playwright/test';
+
+const ARTIFACT_DIR = resolve('artifacts/three-migration/nt56.16.2-chain-focus');
+
+// Mirrors src/pillars/persistence.ts PILLAR_PATCH_FORMAT_VERSION and the
+// PillarPatchPersistence storage key — the persisted envelope the store reads.
+const PILLAR_PATCH_STORAGE_KEY = 'oscilla-pillar-patch-v1';
+const PILLAR_PATCH_FORMAT_VERSION = 1;
+
+const BRANCHY_PATCH = {
+  blocks: [
+    { id: 'grid', kind: 'generator', type: 'InstanceGrid', config: { rows: 4, cols: 4, spacing: 0.1, rotationPerIndex: 0.5, rotationPerTime: 2 } },
+    { id: 'color', kind: 'modifier', type: 'ColorCycle', config: { spread: 1, cycleSpeed: 0.2, vividness: 0.8, brightness: 0.6 } },
+    { id: 'draw', kind: 'intent', type: 'DrawInstances', config: { size: 0.08, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 } },
+    { id: 'gridB', kind: 'generator', type: 'InstanceGrid', config: { rows: 4, cols: 4, spacing: 0.1, rotationPerIndex: 0.5, rotationPerTime: 2 } },
+    { id: 'colorB', kind: 'modifier', type: 'ColorCycle', config: { spread: 1, cycleSpeed: 0.2, vividness: 0.8, brightness: 0.6 } },
+  ],
+  edges: [
+    { id: 'e0', source: 'grid', target: 'color', inputSlot: 'primary', role: 'primary' },
+    { id: 'e1', source: 'color', target: 'draw', inputSlot: 'primary', role: 'primary' },
+    { id: 'e2', source: 'gridB', target: 'colorB', inputSlot: 'primary', role: 'primary' },
+  ],
+};
+
+/** Computed opacity of a block's `.react-flow__node` wrapper (where node.style lands). */
+function nodeOpacity(page: Page, blockId: string): Promise<number> {
+  return page.evaluate((id) => {
+    const inner = document.querySelector(`[data-testid="native-graph-node-${id}"]`);
+    const wrapper = inner?.closest('.react-flow__node');
+    if (!wrapper) throw new Error(`node wrapper for '${id}' not found`);
+    return Number.parseFloat(getComputedStyle(wrapper).opacity);
+  }, blockId);
+}
+
+/** Whether a block's wrapper carries the selection ring (a non-'none' box-shadow). */
+function nodeHasRing(page: Page, blockId: string): Promise<boolean> {
+  return page.evaluate((id) => {
+    const inner = document.querySelector(`[data-testid="native-graph-node-${id}"]`);
+    const wrapper = inner?.closest('.react-flow__node');
+    if (!wrapper) throw new Error(`node wrapper for '${id}' not found`);
+    return getComputedStyle(wrapper).boxShadow !== 'none';
+  }, blockId);
+}
+
+async function clickNode(page: Page, blockId: string): Promise<void> {
+  await page.getByTestId(`native-graph-node-${blockId}`).click();
+}
+
+test.describe('Native editor chain focus', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(
+      ([key, blob]) => window.localStorage.setItem(key, blob),
+      [
+        PILLAR_PATCH_STORAGE_KEY,
+        JSON.stringify({ version: PILLAR_PATCH_FORMAT_VERSION, patch: BRANCHY_PATCH }),
+      ] as const,
+    );
+    await page.goto('/?scenePlan=editor', { waitUntil: 'domcontentloaded' });
+    // All five seeded blocks must lay out before we probe focus behavior.
+    await expect(page.getByTestId('native-graph-node-draw')).toBeVisible();
+    await expect(page.getByTestId('native-graph-node-colorB')).toBeVisible();
+  });
+
+  test('selecting a block dims the unrelated branch and rings the selection', async ({ page }) => {
+    mkdirSync(ARTIFACT_DIR, { recursive: true });
+
+    // With nothing selected, every block is full opacity — dimming hides nothing.
+    for (const id of ['grid', 'color', 'draw', 'gridB', 'colorB']) {
+      expect(await nodeOpacity(page, id), `${id} dimmed before any selection`).toBeCloseTo(1, 1);
+    }
+    await page.getByTestId('native-graph-canvas').screenshot({ path: resolve(ARTIFACT_DIR, '01-no-selection.png') });
+
+    // Select the sink: its chain is {grid, color, draw}; the gridB→colorB branch
+    // is on neither side of it, so that branch dims to ~30%.
+    await clickNode(page, 'draw');
+    expect(await nodeOpacity(page, 'draw'), 'selected sink dimmed').toBeCloseTo(1, 1);
+    expect(await nodeOpacity(page, 'color'), 'upstream feeder dimmed').toBeCloseTo(1, 1);
+    expect(await nodeOpacity(page, 'grid'), 'transitive upstream feeder dimmed').toBeCloseTo(1, 1);
+    expect(await nodeOpacity(page, 'gridB'), 'off-chain branch not dimmed').toBeCloseTo(0.3, 1);
+    expect(await nodeOpacity(page, 'colorB'), 'off-chain branch not dimmed').toBeCloseTo(0.3, 1);
+    expect(await nodeHasRing(page, 'draw'), 'selected block missing its ring').toBe(true);
+    expect(await nodeHasRing(page, 'color'), 'unselected block wrongly ringed').toBe(false);
+    await page.getByTestId('native-graph-canvas').screenshot({ path: resolve(ARTIFACT_DIR, '02-draw-selected.png') });
+  });
+
+  test('arrow keys step the selection upstream and downstream along the chain', async ({ page }) => {
+    await clickNode(page, 'draw');
+    expect(await nodeHasRing(page, 'draw')).toBe(true);
+
+    // ArrowLeft walks toward sources: draw → color → grid.
+    await page.keyboard.press('ArrowLeft');
+    expect(await nodeHasRing(page, 'color'), 'ArrowLeft did not move selection to the feeder').toBe(true);
+    expect(await nodeHasRing(page, 'draw'), 'old selection still ringed after step').toBe(false);
+
+    await page.keyboard.press('ArrowLeft');
+    expect(await nodeHasRing(page, 'grid'), 'ArrowLeft did not reach the source').toBe(true);
+
+    // At the source there is no further upstream — selection holds.
+    await page.keyboard.press('ArrowLeft');
+    expect(await nodeHasRing(page, 'grid'), 'ArrowLeft past the source moved selection').toBe(true);
+
+    // ArrowRight walks back toward the sink: grid → color → draw.
+    await page.keyboard.press('ArrowRight');
+    expect(await nodeHasRing(page, 'color'), 'ArrowRight did not move selection downstream').toBe(true);
+    await page.keyboard.press('ArrowRight');
+    expect(await nodeHasRing(page, 'draw'), 'ArrowRight did not reach the sink').toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Behavior 2 of the anti-spaghetti editor (parent `nt56.16`), building on the node-graph canvas from #396. **Selecting a block focuses its dataflow chain**: the block plus its full transitive upstream (feeders) and downstream (consumers) stay full opacity while every unrelated block dims to ~30%. **Arrow keys** step the selection along the chain — `←` upstream toward sources, `→` downstream toward sinks.

## How it conforms to the laws

- **[LAW:one-source-of-truth]** Chain membership is pure derived data: `chainFocus.ts` computes it by a transitive reachability walk over `patch.edges` from the selected block. No per-block "on chain" flag — the edge graph is the sole authority.
- **[LAW:no-ambient-temporal-coupling]** Dimming is a pure overlay on the already-laid-out nodes/edges (opacity + a ring on the selected node) that *never touches positions*. Selection stays out of the topology-keyed layout effect, so focusing a chain cannot reflow the graph — the two state lifecycles (topology→layout, focus→dimming) stay independent seams.
- **[LAW:dataflow-not-control-flow]** The arrow handler maps key → direction through a small table; variability lives in the derived chain set and neighbor list, not in branches.

## Verification

- `chainFocus.test.ts` — 7 unit tests: reachability across branch paths, cycle termination, deterministic single-step traversal.
- `native-editor-chain-focus.spec.ts` — headless e2e that seeds a branchy patch and asserts the dimming/traversal contract by reading node `opacity` and the selection ring straight from the DOM (**[LAW:behavior-not-structure]** — the canvas is pure DOM, independent of the WebGPU preview, so no pixel-diffing or React-internals inspection).
- typecheck + lint clean; full suite **2345 passed**.
- Visual gate: selecting the sink dims the disconnected branch to ~30% and rings the selection.

| no selection | `draw` selected |
|---|---|
| all nodes full opacity | off-chain branch dimmed, sink ringed |

Closes `oscilla-pillars-scene-nt56.16.2`. Siblings `nt56.16.3` (perspective rotation) and parent `nt56.16` remain open.

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7