### PR TITLE
feat(pillars-scene nt56.16.3): native editor perspective rotation at pivot blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ coverage/
 playwright-report/
 test-results/
 artifacts/three-migration/renderer-shell-baseline/
+artifacts/three-migration/nt56.16.2-chain-focus/
+artifacts/three-migration/nt56.16.3-perspective-rotation/
 
 # Vite cache
 node_modules/.vite/

--- a/src/ui/nativeEditor/NativeGraphCanvas.tsx
+++ b/src/ui/nativeEditor/NativeGraphCanvas.tsx
@@ -12,8 +12,9 @@
  *   render; the canvas stores only the ELK-resolved positions, never block truth.
  * [LAW:no-ambient-temporal-coupling] Relayout is owned by one effect keyed on the
  *   patch topology; config edits (which never change topology) do not reflow it.
- *   Selection/dimming is a SECOND, independent derivation that reads positions but
- *   never writes them — focusing a chain must not reflow the graph.
+ *   Selection/dimming/perspective-rotation is a SECOND, independent derivation that
+ *   reads positions but never writes them — focusing or re-rooting a path must not
+ *   reflow the graph.
  */
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { observer } from 'mobx-react-lite';
@@ -33,7 +34,14 @@ import { useStores } from '../../stores';
 import type { SceneRegistry } from '../../pillars/scene';
 import type { PillarPatch } from '../../pillars/types';
 import { layoutGraphLeftToRight } from './graphLayout';
-import { computeChainSet, stepChain, type ChainDirection } from './chainFocus';
+import {
+  computeFocusPath,
+  rotatePerspective,
+  stepChain,
+  DEFAULT_PERSPECTIVE,
+  type ChainDirection,
+  type PerspectiveChoices,
+} from './chainFocus';
 import { SceneBlockNode, computeNodeSize, type SceneBlockNodeData } from './SceneBlockNode';
 
 const nodeTypes: NodeTypes = { sceneBlock: SceneBlockNode };
@@ -147,6 +155,9 @@ const GraphInner: React.FC = observer(() => {
 
   // --- Chain focus (view state; deliberately separate from the layout above) ---
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // The perspective: which branch is followed at each pivot. Resets with a fresh
+  // selection and accumulates as right-clicks rotate pivots; the lit path is derived.
+  const [choices, setChoices] = useState<PerspectiveChoices>(DEFAULT_PERSPECTIVE);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
   // A selection survives only as long as its block does; a topology change that
@@ -155,13 +166,14 @@ const GraphInner: React.FC = observer(() => {
   useEffect(() => {
     if (selectedId !== null && !patch.blocks.some((b) => b.id === selectedId)) {
       setSelectedId(null);
+      setChoices(DEFAULT_PERSPECTIVE);
     }
   }, [key, selectedId, patch.blocks]);
 
-  // The focused dataflow chain; `null` when nothing is selected means "dim nothing".
-  const chain = useMemo(
-    () => (selectedId === null ? null : computeChainSet(patch.edges, selectedId)),
-    [selectedId, key, patch.edges],
+  // The focused dataflow path; `null` when nothing is selected means "dim nothing".
+  const focusPath = useMemo(
+    () => (selectedId === null ? null : computeFocusPath(patch.edges, selectedId, choices)),
+    [selectedId, choices, key, patch.edges],
   );
 
   // Dimming is a pure overlay on the laid-out nodes/edges: it adds opacity (and a
@@ -169,7 +181,7 @@ const GraphInner: React.FC = observer(() => {
   const displayNodes = useMemo(
     () =>
       nodes.map((node) => {
-        const onChain = chain === null || chain.has(node.id);
+        const onChain = focusPath === null || focusPath.has(node.id);
         const selected = node.id === selectedId;
         return {
           ...node,
@@ -182,40 +194,60 @@ const GraphInner: React.FC = observer(() => {
           },
         };
       }),
-    [nodes, chain, selectedId],
+    [nodes, focusPath, selectedId],
   );
 
   const displayEdges = useMemo(
     () =>
       edges.map((edge) => {
-        const onChain = chain === null || (chain.has(edge.source) && chain.has(edge.target));
+        const onChain =
+          focusPath === null || (focusPath.has(edge.source) && focusPath.has(edge.target));
         return {
           ...edge,
           style: { ...edge.style, opacity: onChain ? ON_CHAIN_OPACITY : OFF_CHAIN_OPACITY },
         };
       }),
-    [edges, chain],
+    [edges, focusPath],
   );
 
+  // A fresh selection starts from the default perspective — clicking a block is "show
+  // me this block's path following first branches", and rotation builds from there.
   const selectNode: NodeMouseHandler = useCallback((_event, node) => {
     setSelectedId(node.id);
+    setChoices(DEFAULT_PERSPECTIVE);
     wrapperRef.current?.focus();
   }, []);
 
-  const clearSelection = useCallback(() => setSelectedId(null), []);
+  const clearSelection = useCallback(() => {
+    setSelectedId(null);
+    setChoices(DEFAULT_PERSPECTIVE);
+  }, []);
 
-  // Arrow keys step the selection along its chain; the key→direction map keeps the
-  // variability in data, so the handler is one lookup, not a branch per key.
+  // Right-click rotates the perspective at a pivot to follow a different branch. The
+  // selection holds; only the followed branch changes, so the lit path re-roots
+  // without reflowing the graph. A non-pivot returns the same choices (a no-op).
+  const rotateAt: NodeMouseHandler = useCallback(
+    (event, node) => {
+      event.preventDefault();
+      if (selectedId === null) return;
+      setChoices((current) => rotatePerspective(patch.edges, selectedId, current, node.id));
+    },
+    [selectedId, patch.edges],
+  );
+
+  // Arrow keys step the selection along the followed path; the key→direction map keeps
+  // the variability in data, so the handler is one lookup, not a branch per key. The
+  // perspective is preserved so arrowing walks exactly the path that is lit.
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
       if (selectedId === null) return;
       const direction = KEY_DIRECTION[event.key];
       if (direction === undefined) return;
       event.preventDefault();
-      const next = stepChain(patch.edges, selectedId, direction);
+      const next = stepChain(patch.edges, selectedId, direction, choices);
       if (next !== null) setSelectedId(next);
     },
-    [selectedId, patch.edges],
+    [selectedId, choices, patch.edges],
   );
 
   return (
@@ -234,6 +266,7 @@ const GraphInner: React.FC = observer(() => {
         nodesConnectable={false}
         elementsSelectable={false}
         onNodeClick={selectNode}
+        onNodeContextMenu={rotateAt}
         onPaneClick={clearSelection}
         fitView
         minZoom={0.2}

--- a/src/ui/nativeEditor/__tests__/chainFocus.test.ts
+++ b/src/ui/nativeEditor/__tests__/chainFocus.test.ts
@@ -1,19 +1,27 @@
 /**
- * Unit tests for the pure chain-focus model: transitive reachability and the
- * deterministic single-step traversal. These assert the *contract* (which blocks
- * are on a selection's chain, where one arrow step lands), never the rendering.
+ * Unit tests for the pure focus model: the single-path derivation, the deterministic
+ * single-step traversal, and perspective rotation at pivots. These assert the
+ * *contract* (which blocks are on a selection's focused path, where one arrow step
+ * lands, how rotating a pivot re-roots the path), never the rendering.
  */
 import { describe, expect, it } from 'vitest';
 
-import { computeChainSet, stepChain } from '../chainFocus';
+import {
+  computeFocusPath,
+  rotatePerspective,
+  stepChain,
+  DEFAULT_PERSPECTIVE,
+} from '../chainFocus';
 import type { PillarEdge } from '../../../pillars/types/graph';
 
-/** Terse edge builder; role is irrelevant to chain membership but required by the type. */
+/** Terse edge builder; role is irrelevant to path membership but required by the type. */
 function edge(id: string, source: string, target: string): PillarEdge {
   return { id, source, target, inputSlot: 'primary', role: 'primary' };
 }
 
-// a → b → c (linear), with a side branch a → d → c and a leaf e → b.
+// a → b → c (linear), with a side branch a → d → c and a second feeder e → b.
+// b is a fan-in pivot (feeders a, e); a is a fan-out pivot (consumers b, d);
+// c is a fan-in pivot (feeders b, d).
 const edges: readonly PillarEdge[] = [
   edge('e0', 'a', 'b'),
   edge('e1', 'b', 'c'),
@@ -22,40 +30,94 @@ const edges: readonly PillarEdge[] = [
   edge('e4', 'e', 'b'),
 ];
 
-describe('computeChainSet', () => {
-  it('includes the selected block, all transitive feeders, and all transitive consumers', () => {
-    // From b: upstream {a, e}, self {b}, downstream {c}. d is on neither side of b.
-    expect(computeChainSet(edges, 'b')).toEqual(new Set(['a', 'e', 'b', 'c']));
+describe('computeFocusPath', () => {
+  it('follows the first branch at each pivot by default', () => {
+    // From b: upstream picks the first feeder (a, edge e0 before e4); downstream
+    // reaches c. The other feeder e is NOT on the followed path.
+    expect(computeFocusPath(edges, 'b', DEFAULT_PERSPECTIVE)).toEqual(new Set(['a', 'b', 'c']));
   });
 
-  it('reaches across multiple branch paths to a shared sink', () => {
-    // From a: downstream fans out through both b and d to c. e feeds b but is a
-    // feeder-of-a-consumer, not on a's own up/downstream chain, so it stays off.
-    expect(computeChainSet(edges, 'a')).toEqual(new Set(['a', 'b', 'd', 'c']));
+  it('follows one downstream branch from a fan-out, not both', () => {
+    // From a: downstream picks the first consumer (b, edge e0 before e2), then c.
+    // The d branch is off the followed path.
+    expect(computeFocusPath(edges, 'a', DEFAULT_PERSPECTIVE)).toEqual(new Set(['a', 'b', 'c']));
   });
 
   it('returns just the block itself when it has no edges', () => {
-    expect(computeChainSet([edge('e0', 'a', 'b')], 'lonely')).toEqual(new Set(['lonely']));
+    expect(computeFocusPath([edge('e0', 'a', 'b')], 'lonely', DEFAULT_PERSPECTIVE)).toEqual(
+      new Set(['lonely']),
+    );
   });
 
   it('terminates on a cycle', () => {
     const cyclic = [edge('e0', 'x', 'y'), edge('e1', 'y', 'x')];
-    expect(computeChainSet(cyclic, 'x')).toEqual(new Set(['x', 'y']));
+    expect(computeFocusPath(cyclic, 'x', DEFAULT_PERSPECTIVE)).toEqual(new Set(['x', 'y']));
+  });
+});
+
+describe('rotatePerspective', () => {
+  it('re-roots the upstream branch at a fan-in selection', () => {
+    // b's default focus follows feeder a. Rotating b (a fan-in pivot, b is the
+    // selection) advances to the next feeder, e.
+    const rotated = rotatePerspective(edges, 'b', DEFAULT_PERSPECTIVE, 'b');
+    expect(computeFocusPath(edges, 'b', rotated)).toEqual(new Set(['e', 'b', 'c']));
+  });
+
+  it('re-roots the downstream branch at a fan-out selection', () => {
+    // a's default focus follows consumer b→c. Rotating a (a fan-out pivot) advances
+    // to the next consumer, d→c.
+    const rotated = rotatePerspective(edges, 'a', DEFAULT_PERSPECTIVE, 'a');
+    expect(computeFocusPath(edges, 'a', rotated)).toEqual(new Set(['a', 'd', 'c']));
+  });
+
+  it('rotates a downstream pivot reached along the path, not just the selection', () => {
+    // Select a source feeding a fan-out mid; rotating mid flips which leaf is lit.
+    const fan = [
+      edge('e0', 'src', 'mid'),
+      edge('e1', 'mid', 'leafA'),
+      edge('e2', 'mid', 'leafB'),
+    ];
+    expect(computeFocusPath(fan, 'src', DEFAULT_PERSPECTIVE)).toEqual(
+      new Set(['src', 'mid', 'leafA']),
+    );
+    const rotated = rotatePerspective(fan, 'src', DEFAULT_PERSPECTIVE, 'mid');
+    expect(computeFocusPath(fan, 'src', rotated)).toEqual(new Set(['src', 'mid', 'leafB']));
+  });
+
+  it('wraps back to the first branch after the last', () => {
+    const rotatedOnce = rotatePerspective(edges, 'a', DEFAULT_PERSPECTIVE, 'a');
+    const rotatedTwice = rotatePerspective(edges, 'a', rotatedOnce, 'a');
+    expect(computeFocusPath(edges, 'a', rotatedTwice)).toEqual(
+      computeFocusPath(edges, 'a', DEFAULT_PERSPECTIVE),
+    );
+  });
+
+  it('is a no-op (same reference) when the block is not a pivot on the path', () => {
+    // c is a fan-in, but with b selected c is reached downstream — its other feeder d
+    // is not part of b's followed walk, so right-clicking c rotates nothing.
+    const result = rotatePerspective(edges, 'b', DEFAULT_PERSPECTIVE, 'c');
+    expect(result).toBe(DEFAULT_PERSPECTIVE);
   });
 });
 
 describe('stepChain', () => {
   it('steps downstream to the consumer', () => {
-    expect(stepChain(edges, 'b', 'downstream')).toBe('c');
+    expect(stepChain(edges, 'b', 'downstream', DEFAULT_PERSPECTIVE)).toBe('c');
   });
 
   it('steps upstream to the first feeder in edge order', () => {
-    // b is fed by a (e0) and e (e4); edge order picks a.
-    expect(stepChain(edges, 'b', 'upstream')).toBe('a');
+    // b is fed by a (e0) and e (e4); the default perspective picks a.
+    expect(stepChain(edges, 'b', 'upstream', DEFAULT_PERSPECTIVE)).toBe('a');
+  });
+
+  it('follows the rotated branch under a non-default perspective', () => {
+    const rotated = rotatePerspective(edges, 'a', DEFAULT_PERSPECTIVE, 'a');
+    // a's downstream choice is now its second consumer, d.
+    expect(stepChain(edges, 'a', 'downstream', rotated)).toBe('d');
   });
 
   it('returns null at the end of the chain', () => {
-    expect(stepChain(edges, 'c', 'downstream')).toBeNull();
-    expect(stepChain(edges, 'a', 'upstream')).toBeNull();
+    expect(stepChain(edges, 'c', 'downstream', DEFAULT_PERSPECTIVE)).toBeNull();
+    expect(stepChain(edges, 'a', 'upstream', DEFAULT_PERSPECTIVE)).toBeNull();
   });
 });

--- a/src/ui/nativeEditor/chainFocus.ts
+++ b/src/ui/nativeEditor/chainFocus.ts
@@ -1,22 +1,25 @@
 /**
  * src/ui/nativeEditor/chainFocus.ts
  *
- * The dataflow-chain focus model for the native editor canvas. Selecting a block
- * focuses its chain: the block plus everything that feeds it (upstream, transitively)
- * and everything it feeds (downstream, transitively). Off-chain blocks dim — the
- * 'anti-spaghetti' navigation model from the spec. Arrow keys step the selection
- * along that chain.
+ * The dataflow-focus model for the native editor canvas. Selecting a block focuses
+ * a single PATH through it: a linear walk from a source, through the selected block,
+ * to a sink. At each pivot (a block with more than one feeder upstream or more than
+ * one consumer downstream) exactly one branch is followed; everything off the path
+ * dims — the 'anti-spaghetti' navigation model from the spec. Arrow keys step the
+ * selection along that path; right-click rotates the perspective at a pivot to follow
+ * a different branch.
  *
- * [LAW:one-source-of-truth] Chain membership is DERIVED from `patch.edges` by a
- *   transitive reachability walk — there is no per-block "on chain" flag to keep in
- *   sync. The edge graph is the sole authority; the chain set is a pure function of
- *   it and the selected id.
+ * [LAW:one-source-of-truth] The focused path is DERIVED from `patch.edges` and the
+ *   current selection by a directed walk — there is no per-block "on path" flag to
+ *   keep in sync. The only stored focus state besides the selection is the
+ *   `PerspectiveChoices`: which branch index is followed at each pivot. The path is a
+ *   pure function of (edges, selection, choices).
  * [LAW:effects-at-boundaries] These are pure functions over plain edge data. They
  *   touch no store, no reactflow node, no DOM — the canvas performs the rendering
- *   effect at its boundary using the sets/ids these return.
- * [LAW:dataflow-not-control-flow] Variability lives in the derived chain set and the
- *   neighbor list, not in branches: dimming is `chain.has(id) ? full : dim` over a
- *   set this module computes, and traversal is "the first neighbor in a direction".
+ *   effect at its boundary using the set/ids/choices these return.
+ * [LAW:dataflow-not-control-flow] Variability lives in the choices map and the
+ *   neighbor list, not in branches: the walk is "follow the chosen neighbor" with the
+ *   choice carried as a value, and dimming is `path.has(id) ? full : dim`.
  */
 import type { PillarEdge } from '../../pillars/types/graph';
 
@@ -25,6 +28,22 @@ import type { PillarEdge } from '../../pillars/types/graph';
  * sinks right), so `upstream` walks toward sources and `downstream` toward sinks.
  */
 export type ChainDirection = 'upstream' | 'downstream';
+
+/**
+ * Which neighbor index is followed at each pivot, keyed by block id, per direction.
+ * A pivot absent from a map follows index 0 (the first neighbor in edge order). This
+ * is the "perspective": rotation advances one entry; the lit path is derived from it.
+ */
+export interface PerspectiveChoices {
+  readonly upstream: ReadonlyMap<string, number>;
+  readonly downstream: ReadonlyMap<string, number>;
+}
+
+/** The perspective before any rotation: every pivot follows its first branch. */
+export const DEFAULT_PERSPECTIVE: PerspectiveChoices = {
+  upstream: new Map(),
+  downstream: new Map(),
+};
 
 /** The block ids directly adjacent to `blockId` in one dataflow direction, in edge order. */
 function neighbors(
@@ -37,51 +56,100 @@ function neighbors(
     .map((e) => (direction === 'upstream' ? e.source : e.target));
 }
 
-/** Block ids reachable from `start` by repeatedly following `direction`, excluding `start`. */
-function reachable(
-  edges: readonly PillarEdge[],
-  start: string,
-  direction: ChainDirection,
-): Set<string> {
-  const found = new Set<string>();
-  const frontier = [start];
-  while (frontier.length > 0) {
-    const id = frontier.pop() as string;
-    for (const next of neighbors(edges, id, direction)) {
-      if (!found.has(next)) {
-        found.add(next);
-        frontier.push(next);
-      }
-    }
-  }
-  return found;
-}
-
 /**
- * The full dataflow chain of `selectedId`: the block itself, all transitive feeders
- * (upstream) and all transitive consumers (downstream). A cycle terminates because
- * the reachability walk records visited ids.
- */
-export function computeChainSet(
-  edges: readonly PillarEdge[],
-  selectedId: string,
-): ReadonlySet<string> {
-  const chain = new Set<string>([selectedId]);
-  for (const id of reachable(edges, selectedId, 'upstream')) chain.add(id);
-  for (const id of reachable(edges, selectedId, 'downstream')) chain.add(id);
-  return chain;
-}
-
-/**
- * The block one step from `selectedId` along `direction`, or `null` if the chain
- * ends there. When a block branches (several neighbors in one direction) the first
- * in edge order is chosen — deterministic, and unambiguous on the linear chains the
- * layout produces; branch navigation is the perspective-rotation behavior, not this.
+ * The block one step from `blockId` along `direction` under the current perspective,
+ * or `null` when the chain ends there. At a pivot (several neighbors) the chosen
+ * index is followed — defaulting to the first in edge order — so the same single
+ * decision drives the lit path, the arrow-key walk, and rotation. The index is taken
+ * modulo the neighbor count, so it stays valid even if the topology shrinks.
  */
 export function stepChain(
   edges: readonly PillarEdge[],
-  selectedId: string,
+  blockId: string,
   direction: ChainDirection,
+  choices: PerspectiveChoices,
 ): string | null {
-  return neighbors(edges, selectedId, direction)[0] ?? null;
+  const options = neighbors(edges, blockId, direction);
+  if (options.length === 0) return null;
+  const index = (choices[direction].get(blockId) ?? 0) % options.length;
+  return options[index];
+}
+
+/**
+ * The block ids on the path from `start` following `direction` under `choices`,
+ * excluding `start`. A cycle terminates because visited ids stop the walk.
+ */
+function walkPath(
+  edges: readonly PillarEdge[],
+  start: string,
+  direction: ChainDirection,
+  choices: PerspectiveChoices,
+): string[] {
+  const path: string[] = [];
+  const seen = new Set<string>([start]);
+  let current = start;
+  for (;;) {
+    const next = stepChain(edges, current, direction, choices);
+    if (next === null || seen.has(next)) break;
+    seen.add(next);
+    path.push(next);
+    current = next;
+  }
+  return path;
+}
+
+/**
+ * The focused path of `selectedId` under `choices`: the block itself, the chosen
+ * feeder chain upstream, and the chosen consumer chain downstream. Off-path blocks
+ * dim. Rotating a pivot's choice re-roots which branch this path follows.
+ */
+export function computeFocusPath(
+  edges: readonly PillarEdge[],
+  selectedId: string,
+  choices: PerspectiveChoices,
+): ReadonlySet<string> {
+  const path = new Set<string>([selectedId]);
+  for (const id of walkPath(edges, selectedId, 'upstream', choices)) path.add(id);
+  for (const id of walkPath(edges, selectedId, 'downstream', choices)) path.add(id);
+  return path;
+}
+
+/**
+ * The direction whose walk from `selectedId` passes through `pivotId` AND has more
+ * than one branch to choose there — `null` if `pivotId` is not a rotatable pivot on
+ * the current path. Downstream takes precedence: the only block that can branch both
+ * ways on one simple path is the selection itself, so a both-ways selection rotates
+ * its consumer branch first (deterministic).
+ */
+function pivotRotationDirection(
+  edges: readonly PillarEdge[],
+  selectedId: string,
+  choices: PerspectiveChoices,
+  pivotId: string,
+): ChainDirection | null {
+  const onWalk = (direction: ChainDirection): boolean =>
+    pivotId === selectedId || walkPath(edges, selectedId, direction, choices).includes(pivotId);
+  if (onWalk('downstream') && neighbors(edges, pivotId, 'downstream').length > 1) return 'downstream';
+  if (onWalk('upstream') && neighbors(edges, pivotId, 'upstream').length > 1) return 'upstream';
+  return null;
+}
+
+/**
+ * Advance the branch followed at `pivotId`, re-rooting the focused path to its next
+ * branch. When `pivotId` is not a rotatable pivot on the current path the perspective
+ * is returned unchanged (same reference) — right-clicking a non-pivot has nothing to
+ * rotate, which is the correct no-op, not a swallowed failure. // [LAW:no-silent-failure]
+ */
+export function rotatePerspective(
+  edges: readonly PillarEdge[],
+  selectedId: string,
+  choices: PerspectiveChoices,
+  pivotId: string,
+): PerspectiveChoices {
+  const direction = pivotRotationDirection(edges, selectedId, choices, pivotId);
+  if (direction === null) return choices;
+  const count = neighbors(edges, pivotId, direction).length;
+  const next = new Map(choices[direction]);
+  next.set(pivotId, ((choices[direction].get(pivotId) ?? 0) + 1) % count);
+  return { ...choices, [direction]: next };
 }

--- a/tests/e2e/native-editor-chain-focus.spec.ts
+++ b/tests/e2e/native-editor-chain-focus.spec.ts
@@ -21,12 +21,14 @@ import { mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { expect, test, type Page } from '@playwright/test';
 
-const ARTIFACT_DIR = resolve('artifacts/three-migration/nt56.16.2-chain-focus');
+// [LAW:one-source-of-truth] The persisted envelope (storage key + versioned wire
+// format) has exactly one home; the test seeds it through that home rather than
+// re-declaring the key, version, or `{version, patch}` shape.
+import { serializePillarPatch } from '../../src/pillars/persistence';
+import type { PillarPatch } from '../../src/pillars/types';
+import { PILLAR_PATCH_STORAGE_KEY } from '../../src/services/PillarPatchPersistence';
 
-// Mirrors src/pillars/persistence.ts PILLAR_PATCH_FORMAT_VERSION and the
-// PillarPatchPersistence storage key — the persisted envelope the store reads.
-const PILLAR_PATCH_STORAGE_KEY = 'oscilla-pillar-patch-v1';
-const PILLAR_PATCH_FORMAT_VERSION = 1;
+const ARTIFACT_DIR = resolve('artifacts/three-migration/nt56.16.2-chain-focus');
 
 const BRANCHY_PATCH = {
   blocks: [
@@ -41,7 +43,7 @@ const BRANCHY_PATCH = {
     { id: 'e1', source: 'color', target: 'draw', inputSlot: 'primary', role: 'primary' },
     { id: 'e2', source: 'gridB', target: 'colorB', inputSlot: 'primary', role: 'primary' },
   ],
-};
+} satisfies PillarPatch;
 
 /** Computed opacity of a block's `.react-flow__node` wrapper (where node.style lands). */
 function nodeOpacity(page: Page, blockId: string): Promise<number> {
@@ -71,10 +73,7 @@ test.describe('Native editor chain focus', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(
       ([key, blob]) => window.localStorage.setItem(key, blob),
-      [
-        PILLAR_PATCH_STORAGE_KEY,
-        JSON.stringify({ version: PILLAR_PATCH_FORMAT_VERSION, patch: BRANCHY_PATCH }),
-      ] as const,
+      [PILLAR_PATCH_STORAGE_KEY, serializePillarPatch(BRANCHY_PATCH)] as const,
     );
     await page.goto('/?scenePlan=editor', { waitUntil: 'domcontentloaded' });
     // All five seeded blocks must lay out before we probe focus behavior.

--- a/tests/e2e/native-editor-perspective-rotation.spec.ts
+++ b/tests/e2e/native-editor-perspective-rotation.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * tests/e2e/native-editor-perspective-rotation.spec.ts
+ *
+ * Proof for oscilla-pillars-scene-nt56.16.3: right-clicking a pivot block (one with
+ * more than one downstream consumer or upstream feeder) re-roots the focused/
+ * highlighted path to follow a DIFFERENT branch — without reflowing the graph.
+ *
+ * Builds on the chain-focus model (nt56.16.2): the lit path is now a single walk
+ * through the selection following one branch at each pivot, and the perspective
+ * (which branch) rotates on right-click. The canvas is a pure DOM/SVG surface
+ * independent of the WebGPU preview, so this runs headless and asserts the contract
+ * by reading each node's rendered opacity from the DOM. // [LAW:behavior-not-structure]
+ *
+ * The seeded patch fans out at `grid` so there are two distinct paths to walk:
+ *
+ *   grid → color  → draw    (the first branch, followed by default)
+ *   grid → colorB → drawB   (the second branch, reached by rotating `grid`)
+ */
+
+import { mkdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { expect, test, type Page } from '@playwright/test';
+
+const ARTIFACT_DIR = resolve('artifacts/three-migration/nt56.16.3-perspective-rotation');
+
+// Mirrors src/pillars/persistence.ts PILLAR_PATCH_FORMAT_VERSION and the
+// PillarPatchPersistence storage key — the persisted envelope the store reads.
+const PILLAR_PATCH_STORAGE_KEY = 'oscilla-pillar-patch-v1';
+const PILLAR_PATCH_FORMAT_VERSION = 1;
+
+const COLOR_CONFIG = { spread: 1, cycleSpeed: 0.2, vividness: 0.8, brightness: 0.6 };
+const DRAW_CONFIG = { size: 0.08, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 };
+const GRID_CONFIG = { rows: 4, cols: 4, spacing: 0.1, rotationPerIndex: 0.5, rotationPerTime: 2 };
+
+// `grid` fans out to two parallel chains. Edge order makes `color` the first branch.
+const FAN_OUT_PATCH = {
+  blocks: [
+    { id: 'grid', kind: 'generator', type: 'InstanceGrid', config: GRID_CONFIG },
+    { id: 'color', kind: 'modifier', type: 'ColorCycle', config: COLOR_CONFIG },
+    { id: 'draw', kind: 'intent', type: 'DrawInstances', config: DRAW_CONFIG },
+    { id: 'colorB', kind: 'modifier', type: 'ColorCycle', config: COLOR_CONFIG },
+    { id: 'drawB', kind: 'intent', type: 'DrawInstances', config: DRAW_CONFIG },
+  ],
+  edges: [
+    { id: 'e0', source: 'grid', target: 'color', inputSlot: 'primary', role: 'primary' },
+    { id: 'e1', source: 'color', target: 'draw', inputSlot: 'primary', role: 'primary' },
+    { id: 'e2', source: 'grid', target: 'colorB', inputSlot: 'primary', role: 'primary' },
+    { id: 'e3', source: 'colorB', target: 'drawB', inputSlot: 'primary', role: 'primary' },
+  ],
+};
+
+/** Computed opacity of a block's `.react-flow__node` wrapper (where node.style lands). */
+function nodeOpacity(page: Page, blockId: string): Promise<number> {
+  return page.evaluate((id) => {
+    const inner = document.querySelector(`[data-testid="native-graph-node-${id}"]`);
+    const wrapper = inner?.closest('.react-flow__node');
+    if (!wrapper) throw new Error(`node wrapper for '${id}' not found`);
+    return Number.parseFloat(getComputedStyle(wrapper).opacity);
+  }, blockId);
+}
+
+/** The laid-out left position of a block's wrapper — used to prove rotation never reflows. */
+function nodeLeft(page: Page, blockId: string): Promise<number> {
+  return page.evaluate((id) => {
+    const inner = document.querySelector(`[data-testid="native-graph-node-${id}"]`);
+    const wrapper = inner?.closest('.react-flow__node') as HTMLElement | null;
+    if (!wrapper) throw new Error(`node wrapper for '${id}' not found`);
+    return wrapper.getBoundingClientRect().left;
+  }, blockId);
+}
+
+async function clickNode(page: Page, blockId: string): Promise<void> {
+  await page.getByTestId(`native-graph-node-${blockId}`).click();
+}
+
+async function rightClickNode(page: Page, blockId: string): Promise<void> {
+  await page.getByTestId(`native-graph-node-${blockId}`).click({ button: 'right' });
+}
+
+test.describe('Native editor perspective rotation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(
+      ([key, blob]) => window.localStorage.setItem(key, blob),
+      [
+        PILLAR_PATCH_STORAGE_KEY,
+        JSON.stringify({ version: PILLAR_PATCH_FORMAT_VERSION, patch: FAN_OUT_PATCH }),
+      ] as const,
+    );
+    await page.goto('/?scenePlan=editor', { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('native-graph-node-draw')).toBeVisible();
+    await expect(page.getByTestId('native-graph-node-drawB')).toBeVisible();
+  });
+
+  test('right-clicking the fan-out pivot re-roots the lit path to the other branch', async ({
+    page,
+  }) => {
+    mkdirSync(ARTIFACT_DIR, { recursive: true });
+
+    // Select the fan-out source. Its default focused path follows the first branch
+    // (grid → color → draw); the second branch (colorB → drawB) dims.
+    await clickNode(page, 'grid');
+    expect(await nodeOpacity(page, 'grid'), 'selected source dimmed').toBeCloseTo(1, 1);
+    expect(await nodeOpacity(page, 'color'), 'first branch dimmed before rotation').toBeCloseTo(1, 1);
+    expect(await nodeOpacity(page, 'draw'), 'first branch sink dimmed before rotation').toBeCloseTo(1, 1);
+    expect(await nodeOpacity(page, 'colorB'), 'second branch lit before rotation').toBeCloseTo(0.3, 1);
+    expect(await nodeOpacity(page, 'drawB'), 'second branch sink lit before rotation').toBeCloseTo(0.3, 1);
+    await page.getByTestId('native-graph-canvas').screenshot({ path: resolve(ARTIFACT_DIR, '01-first-branch.png') });
+
+    // Capture positions before rotating so we can prove the overlay never reflows.
+    const colorLeftBefore = await nodeLeft(page, 'color');
+    const colorBLeftBefore = await nodeLeft(page, 'colorB');
+
+    // Right-click the pivot: the perspective rotates to the second branch
+    // (grid → colorB → drawB); the first branch now dims.
+    await rightClickNode(page, 'grid');
+    expect(await nodeOpacity(page, 'colorB'), 'second branch not lit after rotation').toBeCloseTo(1, 1);
+    expect(await nodeOpacity(page, 'drawB'), 'second branch sink not lit after rotation').toBeCloseTo(1, 1);
+    expect(await nodeOpacity(page, 'color'), 'first branch not dimmed after rotation').toBeCloseTo(0.3, 1);
+    expect(await nodeOpacity(page, 'draw'), 'first branch sink not dimmed after rotation').toBeCloseTo(0.3, 1);
+    expect(await nodeOpacity(page, 'grid'), 'pivot dimmed after rotation').toBeCloseTo(1, 1);
+    await page.getByTestId('native-graph-canvas').screenshot({ path: resolve(ARTIFACT_DIR, '02-second-branch.png') });
+
+    // Rotation is a pure overlay: positions are unchanged (no reflow).
+    expect(await nodeLeft(page, 'color'), 'color reflowed on rotation').toBeCloseTo(colorLeftBefore, 0);
+    expect(await nodeLeft(page, 'colorB'), 'colorB reflowed on rotation').toBeCloseTo(colorBLeftBefore, 0);
+
+    // Rotating again wraps back to the first branch.
+    await rightClickNode(page, 'grid');
+    expect(await nodeOpacity(page, 'color'), 'rotation did not wrap to first branch').toBeCloseTo(1, 1);
+    expect(await nodeOpacity(page, 'colorB'), 'second branch still lit after wrap').toBeCloseTo(0.3, 1);
+  });
+});

--- a/tests/e2e/native-editor-perspective-rotation.spec.ts
+++ b/tests/e2e/native-editor-perspective-rotation.spec.ts
@@ -21,12 +21,14 @@ import { mkdirSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { expect, test, type Page } from '@playwright/test';
 
-const ARTIFACT_DIR = resolve('artifacts/three-migration/nt56.16.3-perspective-rotation');
+// [LAW:one-source-of-truth] The persisted envelope (storage key + versioned wire
+// format) has exactly one home; the test seeds it through that home rather than
+// re-declaring the key, version, or `{version, patch}` shape.
+import { serializePillarPatch } from '../../src/pillars/persistence';
+import type { PillarPatch } from '../../src/pillars/types';
+import { PILLAR_PATCH_STORAGE_KEY } from '../../src/services/PillarPatchPersistence';
 
-// Mirrors src/pillars/persistence.ts PILLAR_PATCH_FORMAT_VERSION and the
-// PillarPatchPersistence storage key — the persisted envelope the store reads.
-const PILLAR_PATCH_STORAGE_KEY = 'oscilla-pillar-patch-v1';
-const PILLAR_PATCH_FORMAT_VERSION = 1;
+const ARTIFACT_DIR = resolve('artifacts/three-migration/nt56.16.3-perspective-rotation');
 
 const COLOR_CONFIG = { spread: 1, cycleSpeed: 0.2, vividness: 0.8, brightness: 0.6 };
 const DRAW_CONFIG = { size: 0.08, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 };
@@ -47,7 +49,7 @@ const FAN_OUT_PATCH = {
     { id: 'e2', source: 'grid', target: 'colorB', inputSlot: 'primary', role: 'primary' },
     { id: 'e3', source: 'colorB', target: 'drawB', inputSlot: 'primary', role: 'primary' },
   ],
-};
+} satisfies PillarPatch;
 
 /** Computed opacity of a block's `.react-flow__node` wrapper (where node.style lands). */
 function nodeOpacity(page: Page, blockId: string): Promise<number> {
@@ -81,10 +83,7 @@ test.describe('Native editor perspective rotation', () => {
   test.beforeEach(async ({ page }) => {
     await page.addInitScript(
       ([key, blob]) => window.localStorage.setItem(key, blob),
-      [
-        PILLAR_PATCH_STORAGE_KEY,
-        JSON.stringify({ version: PILLAR_PATCH_FORMAT_VERSION, patch: FAN_OUT_PATCH }),
-      ] as const,
+      [PILLAR_PATCH_STORAGE_KEY, serializePillarPatch(FAN_OUT_PATCH)] as const,
     );
     await page.goto('/?scenePlan=editor', { waitUntil: 'domcontentloaded' });
     await expect(page.getByTestId('native-graph-node-draw')).toBeVisible();


### PR DESCRIPTION
Behavior 3 of 3 of the anti-spaghetti editor UX (parent **nt56.16**; siblings .1 and .2 closed). Right-clicking a **pivot block** (one with more than one feeder upstream or consumer downstream) re-roots the focused/highlighted path to follow a **different branch** — without reflowing the graph.

## What changed

`.2` lit the *full transitive reachability set* of a selection. `.3` refines focus to a **single path** through the selection: at each pivot, exactly one branch is followed. The followed branch is the **perspective** — the only stored focus state besides the selection — and the lit path is *derived* from `(edges, selection, choices)` every render. `[LAW:one-source-of-truth]`

- **`chainFocus.ts`**: `computeChainSet` → `computeFocusPath` (single-path walk); add `PerspectiveChoices` (`{ upstream, downstream }` sparse `pivot→index` maps), `DEFAULT_PERSPECTIVE`, and `rotatePerspective`. `stepChain` now follows the chosen branch, so arrow-key traversal walks exactly the lit path. One neighbor-choice function drives the path walk, arrow keys, and rotation.
- **`NativeGraphCanvas.tsx`**: `onNodeContextMenu` rotates the perspective (selection holds, positions unchanged). Choices reset on a fresh click, preserved across arrow-steps. Rotation rides the **pure overlay lane** — never the layout path. `[LAW:no-ambient-temporal-coupling]`

## Why single-path doesn't break `.2`

`.2`'s e2e seeds a *linear* chain (no pivots on the selected chain), so the followed path equals the full reachable set there — the contract is preserved exactly where it was specified. `[LAW:behavior-not-structure]`

## Verification

- 13 `chainFocus` unit tests (single-path derivation, rotation re-roots branch, wrap-around, non-pivot no-op, choice-aware `stepChain`).
- New e2e `tests/e2e/native-editor-perspective-rotation.spec.ts`: seeds a fan-out patch, asserts the lit branch flips on right-click, asserts block positions never reflow, asserts wrap-around. `.2` e2e still green.
- `typecheck` + `lint` clean; full suite **2351 passed**.
- **Visual gate** confirmed: right-click flips the lit branch (top→bottom), grid stays selected, no reflow.

| Default (first branch) | After right-click (rotated) |
|---|---|
| top Color/Draw lit, bottom dimmed | bottom Color/Draw lit, top dimmed — same positions |

Closes **oscilla-pillars-scene-nt56.16.3**. Parent **nt56.16** can close once this lands (last of the three behaviors).

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7