### PR TITLE
feat(pillars-scene nt56.6): pre-install asset-reference validation for ScenePlan textures

### DIFF
--- a/src/assets/asset.ts
+++ b/src/assets/asset.ts
@@ -38,6 +38,8 @@ import type { AssetId } from '../core/ids';
  *   first texture proof). `geometry`/`model`/`material`/`nodeMaterial` are
  *   nameable references whose decoders land with the ticket that first needs
  *   them — the bridge fails loudly on an unimplemented kind, never silently.
+ *   The canonical machine-readable form of this coverage is
+ *   {@link TEXTURE_DECODABLE_KINDS} below.
  */
 export type AssetKind =
   | 'image'
@@ -46,6 +48,24 @@ export type AssetKind =
   | 'model'
   | 'material'
   | 'nodeMaterial';
+
+/**
+ * The asset kinds the texture loading bridge can decode into a Three `Texture`
+ * today. This is the single declaration of texture-decode coverage: the pure
+ * pre-install plan validator and the effectful Three decoder both consult it, so
+ * "can this asset back a texture handle?" has one answer that cannot drift.
+ *
+ * [LAW:one-source-of-truth] The decodable set lives here, at the asset boundary,
+ *   not duplicated as a literal in the validator and again in the decoder.
+ * [LAW:single-enforcer] Growing texture coverage (e.g. a compressed-texture
+ *   decoder) is a one-line edit here; every consumer follows automatically.
+ */
+export const TEXTURE_DECODABLE_KINDS = ['image', 'texture'] as const satisfies readonly AssetKind[];
+
+/** Whether an asset of this kind can be decoded into a texture (see {@link TEXTURE_DECODABLE_KINDS}). */
+export function isTextureDecodable(kind: AssetKind): boolean {
+  return (TEXTURE_DECODABLE_KINDS as readonly AssetKind[]).includes(kind);
+}
 
 /**
  * Where an asset's bytes come from.

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -11,6 +11,7 @@
  */
 
 export type { AssetKind, AssetSource, AssetMetadata } from './asset';
+export { TEXTURE_DECODABLE_KINDS, isTextureDecodable } from './asset';
 export type { AssetRegistry } from './registry';
 export { createAssetRegistry } from './registry';
 export type { AssetVariant, AssetCacheKey } from './cache-key';

--- a/src/render/scene-plan/__tests__/asset-validation.test.ts
+++ b/src/render/scene-plan/__tests__/asset-validation.test.ts
@@ -1,0 +1,93 @@
+/**
+ * Contract for the pre-install asset-reference validator. These assert what the
+ * validator *means* — which plans are installable against which registry — not
+ * how the renderer realizes them. Pure data in, issue list out; no decode, no
+ * Three. [LAW:behavior-not-structure]
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { assetId } from '../../../core/ids';
+import { createAssetRegistry, type AssetMetadata } from '../../../assets';
+import {
+  SCENE_PLAN_VERSION,
+  textureRef,
+  validatePlanAssets,
+  formatPlanAssetIssues,
+  type ScenePlan,
+  type TextureDef,
+  type TextureRef,
+} from '..';
+
+function planWithTextures(textures: Record<TextureRef, TextureDef>): ScenePlan {
+  return {
+    version: SCENE_PLAN_VERSION,
+    resources: { geometries: {}, materials: {}, textures, computeResources: {}, postChains: {} },
+    objects: {},
+    render: { camera: { kind: 'orthographic', halfExtentX: 1, halfExtentY: 1 }, inputs: [], draws: [], postChain: null },
+  } as ScenePlan;
+}
+
+const asset = (id: string, kind: AssetMetadata['kind']): AssetMetadata => ({
+  id: assetId(id),
+  kind,
+  label: id,
+  source: { kind: 'url', url: `data:,${id}` },
+});
+
+describe('validatePlanAssets', () => {
+  it('reports no issues for a plan with no textures', () => {
+    const plan = planWithTextures({});
+    expect(validatePlanAssets(plan, createAssetRegistry([]))).toEqual([]);
+  });
+
+  it('reports no issues when every texture asset is registered and decodable', () => {
+    const plan = planWithTextures({
+      [textureRef('a')]: { kind: 'asset', assetId: assetId('img') },
+      [textureRef('b')]: { kind: 'asset', assetId: assetId('tex') },
+    });
+    const registry = createAssetRegistry([asset('img', 'image'), asset('tex', 'texture')]);
+    expect(validatePlanAssets(plan, registry)).toEqual([]);
+  });
+
+  it('flags a texture whose asset is not registered as missing', () => {
+    const plan = planWithTextures({ [textureRef('a')]: { kind: 'asset', assetId: assetId('ghost') } });
+    const issues = validatePlanAssets(plan, createAssetRegistry([]));
+    expect(issues).toEqual([{ reason: 'missing', ref: textureRef('a'), assetId: assetId('ghost') }]);
+  });
+
+  it('flags a registered asset whose kind has no texture decoder', () => {
+    const plan = planWithTextures({ [textureRef('a')]: { kind: 'asset', assetId: assetId('mesh') } });
+    const registry = createAssetRegistry([asset('mesh', 'model')]);
+    const issues = validatePlanAssets(plan, registry);
+    expect(issues).toEqual([
+      { reason: 'undecodableKind', ref: textureRef('a'), assetId: assetId('mesh'), kind: 'model' },
+    ]);
+  });
+
+  it('reports every bad reference, not just the first', () => {
+    const plan = planWithTextures({
+      [textureRef('good')]: { kind: 'asset', assetId: assetId('img') },
+      [textureRef('gone')]: { kind: 'asset', assetId: assetId('ghost') },
+      [textureRef('wrong')]: { kind: 'asset', assetId: assetId('mesh') },
+    });
+    const registry = createAssetRegistry([asset('img', 'image'), asset('mesh', 'material')]);
+    const issues = validatePlanAssets(plan, registry);
+    expect(issues.map((i) => i.reason)).toEqual(['missing', 'undecodableKind']);
+  });
+});
+
+describe('formatPlanAssetIssues', () => {
+  it('renders each issue as a readable line naming ref, asset, and cause', () => {
+    const plan = planWithTextures({
+      [textureRef('gone')]: { kind: 'asset', assetId: assetId('ghost') },
+      [textureRef('wrong')]: { kind: 'asset', assetId: assetId('mesh') },
+    });
+    const registry = createAssetRegistry([asset('mesh', 'nodeMaterial')]);
+    const text = formatPlanAssetIssues(validatePlanAssets(plan, registry));
+    expect(text).toContain("'ghost'");
+    expect(text).toContain('not registered');
+    expect(text).toContain("'mesh'");
+    expect(text).toContain('no texture decoder');
+  });
+});

--- a/src/render/scene-plan/asset-validation.ts
+++ b/src/render/scene-plan/asset-validation.ts
@@ -1,0 +1,77 @@
+/**
+ * src/render/scene-plan/asset-validation.ts
+ *
+ * Pre-install validation of a ScenePlan's asset references against the registry
+ * that will resolve them. A plan names textures by {@link TextureRef} into a
+ * {@link TextureDef} that carries an {@link AssetId}; this checks — *before* any
+ * decode — that every such id resolves in the registry and names a texture-
+ * decodable asset, returning the complete set of problems.
+ *
+ * Scope source: ticket oscilla-pillars-scene-nt56.6 ("a diagnostic for a
+ *   missing/unsupported asset reference before renderer install").
+ *
+ * [LAW:effects-at-boundaries] Pure data → data: no decode, no IO, no Three. The
+ *   effectful decode stays in the loading bridge; this is the computation that
+ *   decides whether that decode can possibly succeed.
+ * [LAW:single-enforcer] Asset-reference validity is decided here, once, at the
+ *   install seam both the demo and editor paths share — not re-checked ad hoc.
+ * [LAW:types-are-the-program] An issue is a discriminated union: `undecodableKind`
+ *   carries the offending kind, `missing` has none — so "undecodable without a
+ *   kind" is unrepresentable and the human message is derived, never stored.
+ */
+
+import type { AssetId } from '../../core/ids';
+import type { AssetKind, AssetRegistry } from '../../assets';
+import { isTextureDecodable } from '../../assets';
+import type { ScenePlan } from './plan';
+import type { TextureRef } from './refs';
+
+/** One unresolvable/unsupported texture-asset reference found in a plan. */
+export type PlanAssetIssue =
+  | { readonly reason: 'missing'; readonly ref: TextureRef; readonly assetId: AssetId }
+  | {
+      readonly reason: 'undecodableKind';
+      readonly ref: TextureRef;
+      readonly assetId: AssetId;
+      readonly kind: AssetKind;
+    };
+
+/**
+ * Every texture-asset reference in `plan` that cannot be resolved+decoded by
+ * `registry`, in the plan's texture-table order. An empty array means the plan's
+ * assets are installable.
+ *
+ * [LAW:dataflow-not-control-flow] Every texture entry is examined the same way;
+ *   variability lives in the returned issue list, not in whether a check runs.
+ */
+export function validatePlanAssets(plan: ScenePlan, registry: AssetRegistry): readonly PlanAssetIssue[] {
+  const issues: PlanAssetIssue[] = [];
+  for (const [refKey, def] of Object.entries(plan.resources.textures)) {
+    const ref = refKey as TextureRef;
+    const { assetId } = def;
+    if (!registry.has(assetId)) {
+      issues.push({ reason: 'missing', ref, assetId });
+      continue;
+    }
+    const { kind } = registry.getMetadata(assetId);
+    if (!isTextureDecodable(kind)) {
+      issues.push({ reason: 'undecodableKind', ref, assetId, kind });
+    }
+  }
+  return issues;
+}
+
+/** A one-line human description of a single issue (derived from its fields). */
+export function formatPlanAssetIssue(issue: PlanAssetIssue): string {
+  switch (issue.reason) {
+    case 'missing':
+      return `texture '${issue.ref}' references asset '${issue.assetId}', which is not registered`;
+    case 'undecodableKind':
+      return `texture '${issue.ref}' references asset '${issue.assetId}' of kind '${issue.kind}', which has no texture decoder`;
+  }
+}
+
+/** A newline-joined description of every issue, for a single aggregated failure. */
+export function formatPlanAssetIssues(issues: readonly PlanAssetIssue[]): string {
+  return issues.map((issue) => `  - ${formatPlanAssetIssue(issue)}`).join('\n');
+}

--- a/src/render/scene-plan/index.ts
+++ b/src/render/scene-plan/index.ts
@@ -72,3 +72,7 @@ export type {
   PostChainDef,
 } from './plan';
 export { SCENE_PLAN_VERSION, defineScenePlan } from './plan';
+
+// Pre-install asset-reference validation.
+export type { PlanAssetIssue } from './asset-validation';
+export { validatePlanAssets, formatPlanAssetIssue, formatPlanAssetIssues } from './asset-validation';

--- a/src/render/webgpu/three/ThreeForkRenderer.ts
+++ b/src/render/webgpu/three/ThreeForkRenderer.ts
@@ -26,6 +26,7 @@ import { WebGPURenderer as ThreeWebGPURenderer } from 'three/webgpu';
 
 import type { AssetRegistry } from '../../../assets';
 import type { ScenePlan } from '../../scene-plan';
+import { validatePlanAssets, formatPlanAssetIssues } from '../../scene-plan';
 import { reconcileScenePlan, type RealizedScene } from './scene-plan-realizer';
 import { ThreeLoadingBridge } from './asset-bridge';
 import type {
@@ -63,6 +64,17 @@ export class ThreeForkRenderer implements WebGPURenderer {
 
   async installScenePlan(plan: ScenePlan, registry: AssetRegistry): Promise<void> {
     this.assertNotDisposed('installing a ScenePlan');
+    // [LAW:single-enforcer] Validate the plan's asset references once, here,
+    //   before any decode. A missing or undecodable asset is a complete, named
+    //   pre-install failure rather than a deep loader throw partway through
+    //   decoding — the editor surfaces it as a diagnostic, the steel thread as a
+    //   loud boot failure. [LAW:no-silent-failure]
+    const assetIssues = validatePlanAssets(plan, registry);
+    if (assetIssues.length > 0) {
+      throw new Error(
+        `ThreeForkRenderer: cannot install ScenePlan — unresolved asset references:\n${formatPlanAssetIssues(assetIssues)}`,
+      );
+    }
     // [LAW:effects-at-boundaries] Decode the plan's texture assets here (the
     //   effect), then realize purely from the already-resolved textures.
     const resolvedTextures = await this.bridge.resolveTextures(plan, registry);

--- a/src/render/webgpu/three/__tests__/ThreeForkRenderer.test.ts
+++ b/src/render/webgpu/three/__tests__/ThreeForkRenderer.test.ts
@@ -23,9 +23,11 @@ import {
   konst,
   materialRef,
   sceneObjectRef,
+  textureRef,
   type ScenePlan,
 } from '../../../scene-plan';
-import { createAssetRegistry } from '../../../../assets';
+import { assetId } from '../../../../core/ids';
+import { createAssetRegistry, type AssetMetadata } from '../../../../assets';
 import { createWebGPURenderer } from '../../index';
 import { ThreeForkRenderer } from '../ThreeForkRenderer';
 
@@ -71,6 +73,44 @@ function buildStaticPlan(version: number = SCENE_PLAN_VERSION): ScenePlan {
   } as ScenePlan;
 }
 
+/** A static plan whose single textured object references one texture asset. */
+function buildTexturedPlan(referencedAssetId: string): ScenePlan {
+  const square = geometryRef('o:square');
+  const tex = textureRef('o:tex');
+  const textured = materialRef('o:textured');
+  const object = sceneObjectRef('o:object');
+  return {
+    version: SCENE_PLAN_VERSION,
+    resources: {
+      geometries: { [square]: { kind: 'rectangle', width: 1, height: 1 } },
+      materials: { [textured]: { kind: 'texturedUnlit', texture: tex } },
+      textures: { [tex]: { kind: 'asset', assetId: assetId(referencedAssetId) } },
+      computeResources: {},
+      postChains: {},
+    },
+    objects: {
+      [object]: {
+        geometry: square,
+        material: textured,
+        instancing: { count: 1, transform: { positionX: konst(0), positionY: konst(0), rotation: konst(0) } },
+      },
+    },
+    render: {
+      camera: { kind: 'orthographic', halfExtentX: 1, halfExtentY: 1 },
+      inputs: [],
+      draws: [{ target: 'previewCanvas', object }],
+      postChain: null,
+    },
+  } as ScenePlan;
+}
+
+const modelAsset = (id: string): AssetMetadata => ({
+  id: assetId(id),
+  kind: 'model',
+  label: id,
+  source: { kind: 'url', url: `data:,${id}` },
+});
+
 describe('ThreeForkRenderer — lifecycle and seam', () => {
   it('constructs idle without acquiring a GPU device', () => {
     const renderer = new ThreeForkRenderer(fakeCanvas);
@@ -88,6 +128,21 @@ describe('ThreeForkRenderer — lifecycle and seam', () => {
     await expect(renderer.installScenePlan(buildStaticPlan(2), emptyRegistry)).rejects.toThrow(
       /incompatible ScenePlan version/,
     );
+  });
+
+  it('rejects a plan whose texture references an unregistered asset, before any decode', async () => {
+    const renderer = new ThreeForkRenderer(fakeCanvas);
+    await expect(
+      renderer.installScenePlan(buildTexturedPlan('ghost'), emptyRegistry),
+    ).rejects.toThrow(/cannot install ScenePlan — unresolved asset references[\s\S]*'ghost'[\s\S]*not registered/);
+  });
+
+  it('rejects a plan whose texture asset has an undecodable kind, before any decode', async () => {
+    const renderer = new ThreeForkRenderer(fakeCanvas);
+    const registry = createAssetRegistry([modelAsset('mesh')]);
+    await expect(
+      renderer.installScenePlan(buildTexturedPlan('mesh'), registry),
+    ).rejects.toThrow(/cannot install ScenePlan — unresolved asset references[\s\S]*'mesh'[\s\S]*no texture decoder/);
   });
 
   it('refuses to render before a plan is installed', async () => {

--- a/src/render/webgpu/three/asset-bridge.ts
+++ b/src/render/webgpu/three/asset-bridge.ts
@@ -36,7 +36,7 @@ import {
 } from 'three/webgpu';
 
 import type { AssetMetadata, AssetRegistry, AssetVariant } from '../../../assets';
-import { assetCacheKey, DEFAULT_ASSET_VARIANT } from '../../../assets';
+import { assetCacheKey, DEFAULT_ASSET_VARIANT, isTextureDecodable } from '../../../assets';
 import type { ScenePlan, TextureDef, TextureRef } from '../../scene-plan';
 
 /**
@@ -63,7 +63,10 @@ function colorSpaceFor(variant: AssetVariant): typeof SRGBColorSpace | typeof Li
 export function createDefaultTextureDecoder(manager: LoadingManager = new LoadingManager()): TextureDecoder {
   const loader = new TextureLoader(manager);
   return (metadata, variant) => {
-    if (metadata.kind !== 'image' && metadata.kind !== 'texture') {
+    // [LAW:one-source-of-truth] Decode coverage is declared once at the asset
+    //   boundary (isTextureDecodable); this guard enforces it rather than
+    //   repeating the kind literals, so it cannot disagree with the validator.
+    if (!isTextureDecodable(metadata.kind)) {
       return Promise.reject(
         new Error(
           `ThreeLoadingBridge: asset '${metadata.id}' has kind '${metadata.kind}', which has no texture decoder (only image/texture decode to a Texture)`,

--- a/src/services/RuntimeService.ts
+++ b/src/services/RuntimeService.ts
@@ -542,9 +542,11 @@ export class RuntimeService {
 
   private async installEditorPlan(plan: ScenePlan): Promise<void> {
     const runtime = this.requireActiveRuntimeResources('installing an editor ScenePlan');
-    // [LAW:one-source-of-truth] Editor patches reference no decoded assets yet
-    //   (asset-backed native blocks are a later ticket); a plan with no textures
-    //   resolves through an empty registry.
+    // [LAW:one-source-of-truth] The editor has no asset-authoring surface yet, so
+    //   its registry is empty. A texture-free patch (the starter) installs; a
+    //   patch that does reference a texture is rejected by installScenePlan's
+    //   pre-install asset validation with a named diagnostic (drainEditorInstalls
+    //   routes it to the diagnostics boundary), never a silent or deep failure.
     await runtime.renderer.installScenePlan(plan, createAssetRegistry([]));
   }
 


### PR DESCRIPTION
## What & why

Closes the rescoped **oscilla-pillars-scene-nt56.6**. The brkm.4 investigation found the texture authoring + render path already ships end-to-end (via ulu.4 — registry, loading bridge, `texturedUnlit` material, `optionalAssetId` catalog control, `textured-tiles` proof). The one genuine gap was the acceptance's **"diagnostic for a missing/unsupported asset reference _before_ renderer install"** — today an unresolved/undecodable asset throws deep inside `asset-bridge.resolveTextures` (the registry's `getMetadata` or the decoder), i.e. *during* the install effect, not before it.

This adds that pre-install diagnostic, texture-only per the cut. It does **not** rebuild the proven texture path.

## Design (through the laws)

- **`src/assets`** — lift the texture-decode coverage rule (`image`/`texture`) to the asset boundary as `TEXTURE_DECODABLE_KINDS` + `isTextureDecodable`. Single declaration both the pure validator and the Three decoder consult, so they cannot drift. The bridge decoder now enforces via the predicate instead of repeating the kind literals. `[LAW:one-source-of-truth]`
- **`src/render/scene-plan/asset-validation.ts`** — `validatePlanAssets(plan, registry)` returns the **complete** set of bad texture refs as a discriminated `PlanAssetIssue` union (`missing` | `undecodableKind`, the latter carrying the offending kind); pure data→data, no decode. `[LAW:effects-at-boundaries]` `[LAW:types-are-the-program]`
- **`ThreeForkRenderer.installScenePlan`** — validates once at the install seam both the demo and editor paths share, throwing one aggregated message before any decode. The editor's empty registry now rejects a textured patch with a clean diagnostic (routed to the diagnostics boundary), never a deep throw. `[LAW:single-enforcer]` `[LAW:no-silent-failure]`

Geometry/material/model asset *decoders* remain nameable + fail-loud, deferred to the first importer-driven ticket (per the brkm.4 cut).

## Verification

- `npm run typecheck` clean; `npm run lint` clean.
- Full vitest: **2359 passed** (+8 new — 6 validator unit, 2 install-seam).
- Acceptance suites `src/pillars/scene` + `src/render/scene-plan` pass.
- WebGPU visual gates green: `three-textured-tiles` (proven texture path renders unchanged through the validator), `three-grid-of-squares` + `three-native-editor` (empty-registry boot unaffected).

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7