### PR TITLE
feat(pillars-scene nt56.14): Modulation Table — spreadsheet routing view

### DIFF
--- a/src/ui/nativeEditor/ModulationTablePanel.tsx
+++ b/src/ui/nativeEditor/ModulationTablePanel.tsx
@@ -1,0 +1,199 @@
+/**
+ * src/ui/nativeEditor/ModulationTablePanel.tsx
+ *
+ * The Modulation Table: a spreadsheet-style projection of all patch routing. Rows
+ * are input ports, columns are output ports, and each cell is the connection at
+ * that crossing. Clicking a cell connects, disconnects, or retargets — mutating
+ * the SAME `PillarPatchStore` the graph canvas edits, so the two views stay in
+ * lockstep by construction (one patch, two views).
+ *
+ * [LAW:one-way-deps] Reads/writes `PillarPatchStore` through the pure model in
+ *   `modulationTable.ts`; it touches no renderer and no Three object.
+ * [LAW:effects-at-boundaries] The grid and per-cell action are computed purely;
+ *   this component only performs the resolved action against the store.
+ * [LAW:dataflow-not-control-flow] Each cell renders from its (edge, connectable)
+ *   value through one presentation map — no per-block-type branching.
+ */
+
+import React from 'react';
+import { observer } from 'mobx-react-lite';
+
+import { useStores } from '../../stores';
+import type { PillarPatchStore } from '../../stores/PillarPatchStore';
+import {
+  buildModulationTable,
+  cellAction,
+  type ModulationAction,
+  type ModulationCell,
+  type ModulationPortRef,
+} from './modulationTable';
+
+const styles = {
+  panel: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    background: '#0f0f17',
+    color: '#e6e6ef',
+    fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+    fontSize: 12,
+    overflow: 'auto',
+  },
+  intro: { padding: '10px 12px', color: '#8a8aa0', fontSize: 11, borderBottom: '1px solid #2a2a38' },
+  empty: { padding: 20, color: '#6f6f88' },
+  table: { borderCollapse: 'collapse', margin: 12 },
+  corner: {
+    padding: '6px 10px',
+    textAlign: 'left',
+    color: '#6f6f88',
+    fontSize: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 0.6,
+    position: 'sticky',
+    left: 0,
+    background: '#0f0f17',
+  },
+  colHead: {
+    padding: '6px 10px',
+    textAlign: 'center',
+    color: '#d7caff',
+    borderBottom: '1px solid #2a2a38',
+    whiteSpace: 'nowrap',
+  },
+  colPort: { color: '#7a7a95', fontWeight: 400, fontSize: 10 },
+  rowHead: {
+    padding: '6px 10px',
+    textAlign: 'right',
+    color: '#b7b7c8',
+    borderRight: '1px solid #2a2a38',
+    whiteSpace: 'nowrap',
+    position: 'sticky',
+    left: 0,
+    background: '#0f0f17',
+  },
+  rowPort: { color: '#7a7a95', fontSize: 10 },
+  cell: {
+    width: 36,
+    height: 30,
+    textAlign: 'center',
+    verticalAlign: 'middle',
+    border: '1px solid #1c1c2a',
+  },
+  cellConnected: {
+    cursor: 'pointer',
+    color: '#6fcf97',
+    background: '#16241c',
+    fontSize: 15,
+  },
+  cellOpen: {
+    cursor: 'pointer',
+    color: '#4a4a60',
+    background: 'transparent',
+  },
+  cellInert: {
+    color: '#26263a',
+    background: '#0c0c14',
+    cursor: 'default',
+  },
+} as const;
+
+/** Apply a resolved cell action to the store. The one effectful step. */
+function applyAction(store: PillarPatchStore, action: ModulationAction): void {
+  switch (action.kind) {
+    case 'connect':
+      store.addEdge(action.source, action.target, action.inputSlot);
+      return;
+    case 'disconnect':
+      store.removeEdge(action.edgeId);
+      return;
+  }
+}
+
+export const ModulationTablePanel: React.FC = observer(() => {
+  const { pillarPatch } = useStores();
+  const model = buildModulationTable(pillarPatch.patch, pillarPatch.registry);
+
+  if (model.rows.length === 0 || model.columns.length === 0) {
+    return (
+      <div style={styles.panel as React.CSSProperties} data-testid="modulation-table">
+        <div style={styles.empty as React.CSSProperties}>
+          No routable ports yet — add blocks with inputs and outputs to see the modulation grid.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.panel as React.CSSProperties} data-testid="modulation-table">
+      <div style={styles.intro as React.CSSProperties}>
+        Rows are inputs, columns are outputs. Click a cell to connect, disconnect, or retarget.
+      </div>
+      <table style={styles.table as React.CSSProperties}>
+        <thead>
+          <tr>
+            <th style={styles.corner as React.CSSProperties}>input \ output</th>
+            {model.columns.map((column) => (
+              <th key={`${column.blockId}:${column.portId}`} style={styles.colHead as React.CSSProperties}>
+                {column.blockLabel}
+                <div style={styles.colPort as React.CSSProperties}>{column.portLabel}</div>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {model.rows.map((row, rowIndex) => (
+            <tr key={`${row.blockId}:${row.portId}`}>
+              <th style={styles.rowHead as React.CSSProperties}>
+                {row.blockLabel}
+                <div style={styles.rowPort as React.CSSProperties}>◄ {row.portLabel}</div>
+              </th>
+              {model.columns.map((column, colIndex) => (
+                <CellView
+                  key={`${column.blockId}:${column.portId}`}
+                  cell={model.cells[rowIndex][colIndex]}
+                  row={row}
+                  column={column}
+                  store={pillarPatch}
+                />
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+});
+
+const CellView: React.FC<{
+  cell: ModulationCell;
+  row: ModulationPortRef;
+  column: ModulationPortRef;
+  store: PillarPatchStore;
+}> = ({ cell, row, column, store }) => {
+  const action = cellAction(cell, row, column);
+  const connected = cell.edge !== null;
+  const stateStyle = connected
+    ? styles.cellConnected
+    : action !== null
+      ? styles.cellOpen
+      : styles.cellInert;
+  const glyph = connected ? '●' : action !== null ? '+' : '';
+
+  return (
+    <td
+      style={{ ...styles.cell, ...stateStyle } as React.CSSProperties}
+      data-testid={`mod-cell-${row.blockId}:${row.portId}--${column.blockId}`}
+      data-connected={connected}
+      title={
+        connected
+          ? `${column.blockLabel} → ${row.blockLabel}.${row.portLabel} (click to disconnect)`
+          : action !== null
+            ? `Connect ${column.blockLabel} → ${row.blockLabel}.${row.portLabel}`
+            : 'Incompatible'
+      }
+      onClick={action === null ? undefined : () => applyAction(store, action)}
+    >
+      {glyph}
+    </td>
+  );
+};

--- a/src/ui/nativeEditor/NativeEditorLayout.tsx
+++ b/src/ui/nativeEditor/NativeEditorLayout.tsx
@@ -12,10 +12,11 @@
  *   boundary — and the graph canvas reads the same authored patch independently.
  */
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import { NativeEditorPanel } from './NativeEditorPanel';
 import { NativeGraphCanvas } from './NativeGraphCanvas';
+import { ModulationTablePanel } from './ModulationTablePanel';
 
 interface NativeEditorLayoutProps {
   onCanvasReady?: (canvas: HTMLCanvasElement) => void;
@@ -35,13 +36,73 @@ export const NativeEditorLayout: React.FC<NativeEditorLayoutProps> = ({ onCanvas
       <div style={{ width: 360, flexShrink: 0, borderRight: '1px solid #2a2a38' }}>
         <NativeEditorPanel />
       </div>
-      <div style={{ flex: 1, minWidth: 0, borderRight: '1px solid #2a2a38' }}>
-        <NativeGraphCanvas />
-      </div>
+      <CenterPane />
       <PreviewCanvas onCanvasReady={onCanvasReady} />
     </div>
   );
 };
+
+/**
+ * The center pane offers the two views onto the authored patch: the node graph
+ * and the modulation table. Both read the same `PillarPatchStore`, so switching
+ * is purely a presentation choice — no patch state moves with the toggle.
+ * [LAW:one-source-of-truth] The graph and table are alternate projections; the
+ *   toggle picks a projection, it does not fork the patch.
+ */
+type CenterView = 'graph' | 'table';
+
+const CenterPane: React.FC = () => {
+  const [view, setView] = useState<CenterView>('graph');
+  return (
+    <div
+      style={{
+        flex: 1,
+        minWidth: 0,
+        borderRight: '1px solid #2a2a38',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          gap: 4,
+          padding: '6px 8px',
+          borderBottom: '1px solid #2a2a38',
+          background: '#16161f',
+        }}
+      >
+        <ViewTab label="Graph" active={view === 'graph'} onSelect={() => setView('graph')} />
+        <ViewTab label="Table" active={view === 'table'} onSelect={() => setView('table')} />
+      </div>
+      <div style={{ flex: 1, minHeight: 0 }}>
+        {view === 'graph' ? <NativeGraphCanvas /> : <ModulationTablePanel />}
+      </div>
+    </div>
+  );
+};
+
+const ViewTab: React.FC<{ label: string; active: boolean; onSelect: () => void }> = ({
+  label,
+  active,
+  onSelect,
+}) => (
+  <button
+    data-testid={`native-view-${label.toLowerCase()}`}
+    onClick={onSelect}
+    style={{
+      background: active ? '#2a2350' : 'transparent',
+      color: active ? '#d7caff' : '#8a8aa0',
+      border: '1px solid #33334a',
+      borderRadius: 6,
+      padding: '3px 12px',
+      cursor: 'pointer',
+      fontSize: 12,
+    }}
+  >
+    {label}
+  </button>
+);
 
 const PreviewCanvas: React.FC<NativeEditorLayoutProps> = ({ onCanvasReady }) => {
   const containerRef = useRef<HTMLDivElement>(null);

--- a/src/ui/nativeEditor/NativeEditorPanel.tsx
+++ b/src/ui/nativeEditor/NativeEditorPanel.tsx
@@ -18,7 +18,6 @@ import { observer } from 'mobx-react-lite';
 
 import { useStores } from '../../stores';
 import {
-  compareScenePorts,
   type SceneCatalogConfigField,
   type SceneConfigControl,
   type ScenePortDeclaration,
@@ -26,6 +25,7 @@ import {
 } from '../../pillars/scene';
 import type { PillarBlock } from '../../pillars/types';
 import type { PillarPatchStore } from '../../stores/PillarPatchStore';
+import { kindsConnectable } from './modulationTable';
 
 const styles = {
   panel: {
@@ -186,7 +186,7 @@ const ConnectionRow: React.FC<{
     if (candidate.id === block.id) return false;
     const outputs = registry.get(candidate.type)?.catalog.ports.filter((p) => p.direction === 'output') ?? [];
     if (outputs.length !== 1) return false;
-    return compareScenePorts(outputs[0].value, port.value).kind === 'compatible';
+    return kindsConnectable(outputs[0].value, port.value);
   });
 
   const onChange = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/src/ui/nativeEditor/__tests__/ModulationTablePanel.test.tsx
+++ b/src/ui/nativeEditor/__tests__/ModulationTablePanel.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * The Modulation Table view wires a cell click to the SAME `PillarPatchStore`
+ * mutation the graph editor performs. These DOM tests prove the wiring end to
+ * end: rendering the seed patch, clicking a cell, and observing the store's
+ * authored edges change — the compiled-plan / preview follows from that store,
+ * which the runtime observes elsewhere.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { autorun } from 'mobx';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import { ModulationTablePanel } from '../ModulationTablePanel';
+import { RootStore, StoreProvider } from '../../../stores';
+
+function readComputed<T>(reader: () => T): T {
+  let value!: T;
+  const disposer = autorun(() => {
+    value = reader();
+  });
+  disposer();
+  return value;
+}
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+let store: RootStore;
+
+beforeEach(() => {
+  localStorageMock.clear(); // empty storage → default grid-of-squares seed
+  store = new RootStore();
+});
+
+function renderTable() {
+  return render(
+    <StoreProvider store={store}>
+      <ModulationTablePanel />
+    </StoreProvider>,
+  );
+}
+
+describe('ModulationTablePanel', () => {
+  it('renders a connected cell for each existing edge in the seed patch', () => {
+    renderTable();
+    // grid → color.primary (e0) and color → draw.primary (e1) are connected.
+    expect(screen.getByTestId('mod-cell-color:primary--grid')).toHaveAttribute('data-connected', 'true');
+    expect(screen.getByTestId('mod-cell-draw:primary--color')).toHaveAttribute('data-connected', 'true');
+    // grid → draw.primary is an open (empty) crossing.
+    expect(screen.getByTestId('mod-cell-draw:primary--grid')).toHaveAttribute('data-connected', 'false');
+  });
+
+  it('clicking a connected cell disconnects it in the store', () => {
+    renderTable();
+    expect(readComputed(() => store.pillarPatch.patch.edges.some((e) => e.id === 'e0'))).toBe(true);
+
+    fireEvent.click(screen.getByTestId('mod-cell-color:primary--grid'));
+
+    expect(readComputed(() => store.pillarPatch.patch.edges.some((e) => e.id === 'e0'))).toBe(false);
+    // The cell now reads as open, live.
+    expect(screen.getByTestId('mod-cell-color:primary--grid')).toHaveAttribute('data-connected', 'false');
+  });
+
+  it('clicking an empty compatible cell retargets the row to the new source', () => {
+    renderTable();
+    // DrawInstances.primary starts fed by color; click its grid column.
+    fireEvent.click(screen.getByTestId('mod-cell-draw:primary--grid'));
+
+    const feeders = readComputed(() =>
+      store.pillarPatch.patch.edges.filter((e) => e.target === 'draw' && e.inputSlot === 'primary'),
+    );
+    expect(feeders.map((e) => e.source)).toEqual(['grid']);
+    expect(screen.getByTestId('mod-cell-draw:primary--grid')).toHaveAttribute('data-connected', 'true');
+    expect(screen.getByTestId('mod-cell-draw:primary--color')).toHaveAttribute('data-connected', 'false');
+  });
+
+  it('an incompatible cell is inert (clicking does nothing)', () => {
+    renderTable();
+    const before = readComputed(() => store.pillarPatch.patch.edges.length);
+    // DrawInstances (materialShell) → ColorCycle.primary (instanceBundle) is a mismatch.
+    fireEvent.click(screen.getByTestId('mod-cell-color:primary--draw'));
+    expect(readComputed(() => store.pillarPatch.patch.edges.length)).toBe(before);
+  });
+});

--- a/src/ui/nativeEditor/__tests__/modulationTable.test.ts
+++ b/src/ui/nativeEditor/__tests__/modulationTable.test.ts
@@ -1,0 +1,167 @@
+/**
+ * The Modulation Table is a second projection of the authored patch, not a second
+ * copy of it. These tests pin the two claims the ticket rests on:
+ *
+ *  1. The grid renders one cell per existing connection over the authored patch.
+ *  2. Adding / removing / retargeting a connection through a cell updates the SAME
+ *     patch the graph edits — a table edit and the equivalent graph edit converge
+ *     on one patch, because both reduce to the same `PillarPatchStore` operation.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { PillarPatchStore } from '../../../stores/PillarPatchStore';
+import { makeGridOfSquaresPatch } from '../../../pillars/fixtures/grid-of-squares';
+import type { PillarEdge } from '../../../pillars/types';
+import { buildModulationTable, cellAction } from '../modulationTable';
+
+/** Locate a cell by its row (target input) and column (source output) block ids. */
+function locate(
+  store: PillarPatchStore,
+  rowBlockId: string,
+  rowPortId: string,
+  colBlockId: string,
+) {
+  const model = buildModulationTable(store.patch, store.registry);
+  const rowIndex = model.rows.findIndex((r) => r.blockId === rowBlockId && r.portId === rowPortId);
+  const colIndex = model.columns.findIndex((c) => c.blockId === colBlockId);
+  expect(rowIndex).toBeGreaterThanOrEqual(0);
+  expect(colIndex).toBeGreaterThanOrEqual(0);
+  return {
+    model,
+    row: model.rows[rowIndex],
+    column: model.columns[colIndex],
+    cell: model.cells[rowIndex][colIndex],
+  };
+}
+
+/** Edges sorted by id — order-insensitive comparison of two patches' routing. */
+function edgesById(edges: readonly PillarEdge[]): PillarEdge[] {
+  return [...edges].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+describe('buildModulationTable', () => {
+  it('projects the seed patch into input rows and output columns', () => {
+    const store = new PillarPatchStore(makeGridOfSquaresPatch());
+    const model = buildModulationTable(store.patch, store.registry);
+
+    // Rows = every input port: ColorCycle.primary and DrawInstances.primary.
+    expect(model.rows.map((r) => `${r.blockId}.${r.portId}`)).toEqual([
+      'color.primary',
+      'draw.primary',
+    ]);
+    // Columns = every single-output block: grid, color, draw.
+    expect(model.columns.map((c) => c.blockId)).toEqual(['grid', 'color', 'draw']);
+  });
+
+  it('renders exactly one cell per existing connection', () => {
+    const store = new PillarPatchStore(makeGridOfSquaresPatch());
+    const model = buildModulationTable(store.patch, store.registry);
+
+    const connectedCells = model.cells.flat().filter((cell) => cell.edge !== null);
+    expect(connectedCells).toHaveLength(store.patch.edges.length);
+    expect(connectedCells.map((c) => c.edge?.id).sort()).toEqual(['e0', 'e1']);
+  });
+
+  it('marks a block feeding itself and type-incompatible crossings as not connectable', () => {
+    const store = new PillarPatchStore(makeGridOfSquaresPatch());
+
+    // ColorCycle → ColorCycle.primary: a block cannot feed its own input.
+    expect(locate(store, 'color', 'primary', 'color').cell.connectable).toBe(false);
+    // DrawInstances (materialShell output) → ColorCycle.primary (instanceBundle): mismatch.
+    expect(locate(store, 'color', 'primary', 'draw').cell.connectable).toBe(false);
+    // InstanceGrid (instanceBundle) → ColorCycle.primary (instanceBundle): compatible.
+    expect(locate(store, 'color', 'primary', 'grid').cell.connectable).toBe(true);
+  });
+});
+
+describe('cellAction', () => {
+  it('resolves an occupied cell to a disconnect of its edge', () => {
+    const store = new PillarPatchStore(makeGridOfSquaresPatch());
+    const { cell, row, column } = locate(store, 'color', 'primary', 'grid');
+    expect(cellAction(cell, row, column)).toEqual({ kind: 'disconnect', edgeId: 'e0' });
+  });
+
+  it('resolves an empty compatible cell to a connect', () => {
+    const store = new PillarPatchStore(makeGridOfSquaresPatch());
+    store.removeEdge('e1'); // free DrawInstances.primary
+    const { cell, row, column } = locate(store, 'draw', 'primary', 'grid');
+    expect(cellAction(cell, row, column)).toEqual({
+      kind: 'connect',
+      source: 'grid',
+      target: 'draw',
+      inputSlot: 'primary',
+    });
+  });
+
+  it('resolves an inert (incompatible / self) cell to no action', () => {
+    const store = new PillarPatchStore(makeGridOfSquaresPatch());
+    const { cell, row, column } = locate(store, 'color', 'primary', 'draw');
+    expect(cellAction(cell, row, column)).toBeNull();
+  });
+});
+
+describe('table edits mutate the same patch the graph edits', () => {
+  it('remove: a table disconnect equals the graph removeEdge', () => {
+    const viaTable = new PillarPatchStore(makeGridOfSquaresPatch());
+    const viaGraph = new PillarPatchStore(makeGridOfSquaresPatch());
+
+    // Table path: click the connected (color.primary × grid) cell.
+    const { cell, row, column } = locate(viaTable, 'color', 'primary', 'grid');
+    const action = cellAction(cell, row, column);
+    expect(action).toEqual({ kind: 'disconnect', edgeId: 'e0' });
+    if (action?.kind === 'disconnect') viaTable.removeEdge(action.edgeId);
+
+    // Graph path: the same intent expressed as the store call the graph makes.
+    viaGraph.removeEdge('e0');
+
+    expect(edgesById(viaTable.patch.edges)).toEqual(edgesById(viaGraph.patch.edges));
+    expect(viaTable.patch.edges.some((e) => e.id === 'e0')).toBe(false);
+  });
+
+  it('add: a table connect equals the graph addEdge', () => {
+    const viaTable = new PillarPatchStore(makeGridOfSquaresPatch());
+    const viaGraph = new PillarPatchStore(makeGridOfSquaresPatch());
+    viaTable.removeEdge('e1');
+    viaGraph.removeEdge('e1');
+
+    const { cell, row, column } = locate(viaTable, 'draw', 'primary', 'grid');
+    const action = cellAction(cell, row, column);
+    if (action?.kind === 'connect') viaTable.addEdge(action.source, action.target, action.inputSlot);
+
+    viaGraph.addEdge('grid', 'draw', 'primary');
+
+    expect(edgesById(viaTable.patch.edges)).toEqual(edgesById(viaGraph.patch.edges));
+    const drawFeeders = viaTable.patch.edges.filter((e) => e.target === 'draw' && e.inputSlot === 'primary');
+    expect(drawFeeders.map((e) => e.source)).toEqual(['grid']);
+  });
+
+  it('retarget: connecting into an occupied row replaces the old feeder (one feeder per input slot)', () => {
+    const viaTable = new PillarPatchStore(makeGridOfSquaresPatch());
+    const viaGraph = new PillarPatchStore(makeGridOfSquaresPatch());
+
+    // DrawInstances.primary is fed by color (e1). Click the grid column in that row.
+    const { cell, row, column } = locate(viaTable, 'draw', 'primary', 'grid');
+    const action = cellAction(cell, row, column);
+    if (action?.kind === 'connect') viaTable.addEdge(action.source, action.target, action.inputSlot);
+
+    viaGraph.addEdge('grid', 'draw', 'primary');
+
+    expect(edgesById(viaTable.patch.edges)).toEqual(edgesById(viaGraph.patch.edges));
+    // Exactly one feeder remains, and it is the new source.
+    const drawFeeders = viaTable.patch.edges.filter((e) => e.target === 'draw' && e.inputSlot === 'primary');
+    expect(drawFeeders.map((e) => e.source)).toEqual(['grid']);
+  });
+
+  it('a graph edit is visible in the table projection (one patch, two views)', () => {
+    const store = new PillarPatchStore(makeGridOfSquaresPatch());
+
+    // Graph path retargets DrawInstances.primary from color to grid.
+    store.addEdge('grid', 'draw', 'primary');
+
+    // The table, rebuilt from the same patch, reflects it: grid→draw is now
+    // connected and color→draw is empty.
+    expect(locate(store, 'draw', 'primary', 'grid').cell.edge).not.toBeNull();
+    expect(locate(store, 'draw', 'primary', 'color').cell.edge).toBeNull();
+  });
+});

--- a/src/ui/nativeEditor/modulationTable.ts
+++ b/src/ui/nativeEditor/modulationTable.ts
@@ -1,0 +1,161 @@
+/**
+ * src/ui/nativeEditor/modulationTable.ts
+ *
+ * The Modulation Table's pure model: the authored patch viewed as a routing
+ * grid. Rows are input ports (things that receive a value), columns are output
+ * ports (things that produce one, one per source block under the editor's
+ * sole-output model), and each cell is the connection at that crossing — or an
+ * empty, possibly-connectable slot.
+ *
+ * This is the SAME data the graph view reads (`PillarPatchStore.patch`); the
+ * table is a second projection of it, never a second copy. A cell click resolves
+ * to a description of a store operation (`ModulationAction`); the React view
+ * performs it against the store. So a table edit and a graph edit are literally
+ * the same mutation on the same source of truth.
+ *
+ * [LAW:one-source-of-truth] The grid is derived from the authored patch on every
+ *   read; it stores no connection truth of its own.
+ * [LAW:effects-at-boundaries] This module is pure — it computes the grid and the
+ *   action to take, but never touches the store; the view applies the action.
+ * [LAW:dataflow-not-control-flow] A cell carries its edge (or null) and whether it
+ *   is connectable as VALUES; `cellAction` maps those values to one of a fixed set
+ *   of operations rather than the view branching on block type or wiring state.
+ */
+
+import {
+  compareScenePorts,
+  type SceneRegistry,
+  type SceneValueKind,
+} from '../../pillars/scene';
+import type { PillarBlock, PillarEdge, PillarPatch } from '../../pillars/types';
+
+/**
+ * Whether a value produced with kind `from` may feed a port of kind `to` as a
+ * route the editor OFFERS. This is the single owner of that policy: both the
+ * graph's per-port connection picker and this table read it, so the two views
+ * can never disagree on which routes are legal. An adapter-bridgeable pair
+ * (`adaptationNeeded`) is deliberately not offered here — only a direct match is.
+ *
+ * [LAW:single-enforcer] One predicate decides "is this route offerable".
+ */
+export function kindsConnectable(from: SceneValueKind, to: SceneValueKind): boolean {
+  return compareScenePorts(from, to).kind === 'compatible';
+}
+
+/** One port of one block — a row (an input) or a column (an output). */
+export interface ModulationPortRef {
+  readonly blockId: string;
+  readonly blockLabel: string;
+  readonly portId: string;
+  readonly portLabel: string;
+  readonly value: SceneValueKind;
+}
+
+/**
+ * One crossing of a row (input) and a column (output). `edge` is the connection
+ * there, or null when the slot is empty. `connectable` says whether an empty slot
+ * would accept a wire (compatible kinds, not the block feeding itself). An
+ * existing `edge` is shown regardless of `connectable`: a persisted patch can hold
+ * a type-invalid route, and the table must let the user see and delete it.
+ */
+export interface ModulationCell {
+  readonly edge: PillarEdge | null;
+  readonly connectable: boolean;
+}
+
+/** The whole grid: input rows, output columns, and the cell at every crossing. */
+export interface ModulationTableModel {
+  readonly rows: readonly ModulationPortRef[];
+  readonly columns: readonly ModulationPortRef[];
+  /** `cells[rowIndex][colIndex]`. */
+  readonly cells: readonly (readonly ModulationCell[])[];
+}
+
+/** The store operation a cell click performs. */
+export type ModulationAction =
+  | { readonly kind: 'connect'; readonly source: string; readonly target: string; readonly inputSlot: string }
+  | { readonly kind: 'disconnect'; readonly edgeId: string };
+
+/**
+ * Derive the routing grid from the authored patch. Rows are every input port of
+ * every block; columns are every block that has exactly one output port (the
+ * sole-output model the whole editor assumes — a zero-output sink is no column, a
+ * multi-output block is skipped rather than silently anchored to one output).
+ *
+ * [LAW:no-silent-failure] A multi-output block is omitted from the columns, not
+ *   collapsed to its first output behind the user's back.
+ */
+export function buildModulationTable(
+  patch: PillarPatch,
+  registry: SceneRegistry,
+): ModulationTableModel {
+  const labelOf = (block: PillarBlock): string =>
+    registry.get(block.type)?.catalog.displayName ?? block.type;
+  const portsOf = (block: PillarBlock) => registry.get(block.type)?.catalog.ports ?? [];
+
+  const rows: ModulationPortRef[] = patch.blocks.flatMap((block) =>
+    portsOf(block)
+      .filter((port) => port.direction === 'input')
+      .map((port) => ({
+        blockId: block.id,
+        blockLabel: labelOf(block),
+        portId: port.id,
+        portLabel: port.label,
+        value: port.value,
+      })),
+  );
+
+  const columns: ModulationPortRef[] = patch.blocks.flatMap((block) => {
+    const outputs = portsOf(block).filter((port) => port.direction === 'output');
+    if (outputs.length !== 1) return [];
+    const output = outputs[0];
+    return [
+      {
+        blockId: block.id,
+        blockLabel: labelOf(block),
+        portId: output.id,
+        portLabel: output.label,
+        value: output.value,
+      },
+    ];
+  });
+
+  const cells: ModulationCell[][] = rows.map((row) =>
+    columns.map((column) => ({
+      edge:
+        patch.edges.find(
+          (edge) =>
+            edge.source === column.blockId &&
+            edge.target === row.blockId &&
+            edge.inputSlot === row.portId,
+        ) ?? null,
+      connectable:
+        column.blockId !== row.blockId && kindsConnectable(column.value, row.value),
+    })),
+  );
+
+  return { rows, columns, cells };
+}
+
+/**
+ * The store operation a click on this cell performs, or null when the cell is
+ * inert (an empty, type-incompatible crossing). An occupied cell always
+ * disconnects — a route can always be deleted, even a type-invalid one. An empty
+ * connectable cell connects.
+ *
+ * Retarget is NOT a third case: connecting into a row that already has a feeder
+ * relies on the store replacing the old wire (its one-feeder-per-input-slot
+ * invariant), so "move a connection to a different source" is just a connect into
+ * an occupied row. [LAW:dataflow-not-control-flow]
+ */
+export function cellAction(
+  cell: ModulationCell,
+  row: ModulationPortRef,
+  column: ModulationPortRef,
+): ModulationAction | null {
+  if (cell.edge !== null) return { kind: 'disconnect', edgeId: cell.edge.id };
+  if (cell.connectable) {
+    return { kind: 'connect', source: column.blockId, target: row.blockId, inputSlot: row.portId };
+  }
+  return null;
+}


### PR DESCRIPTION
## What

Implements the **Modulation Table** (nt56.14): a spreadsheet-style projection of all patch modulation, an alternative to the graph view.

- **Rows** = input ports `(block, inputSlot)`
- **Columns** = output ports — one per single-output source block (the editor's sole-output model)
- **Cells** = the connection at each crossing, or an empty (possibly-connectable) slot

Clicking a cell connects / disconnects / retargets — mutating the **same `PillarPatchStore`** the graph editor edits. The two views are alternate projections of one patch, never two copies, so they stay in lockstep by construction. `[LAW:one-source-of-truth]`

## How it stays simple

- **`modulationTable.ts`** is a pure model: `buildModulationTable(patch, registry)` derives rows/columns/cells; `cellAction()` resolves a click to a *description* of a store op. The React view performs the effect at the boundary. `[LAW:effects-at-boundaries]`
- **All three edit ops collapse to the store's existing two calls**: add = `addEdge`, remove = `removeEdge`. **Retarget falls out for free** — `addEdge` already enforces one-feeder-per-input-slot (it filters the old wire before inserting), so connecting into an occupied row retargets with no new code. `[LAW:composability]` `[LAW:dataflow-not-control-flow]`
- **`kindsConnectable()`** is extracted as the single owner of the "offerable route" policy; the graph's connection picker (`NativeEditorPanel`) now consumes it too, so the two views can never disagree on which routes are legal. `[LAW:single-enforcer]`
- `NativeEditorLayout` gains a **Graph / Table toggle** over the center pane — a view switch, not a patch fork.

## Scope

**Transform chains (scale/offset/clamp per cell) are deferred.** The `PillarEdge` model is `{id, source, target, inputSlot, role}` — no transform field — so per-cell transforms are unrepresentable without an edge-schema change (its own ticket). The handoff flagged this as a stretch beyond the core round-trip acceptance. `[LAW:carrying-cost]`

> Note: the ticket's scope-authority path `src/ui/reactFlowEditor/` predates the Three-native default boot. The live editor is `src/ui/nativeEditor/` over `PillarPatchStore`; built there.

## Verification

- **14 new tests** — 10 pure model/round-trip (incl. add/remove/**retarget convergence** and one-patch-two-views), 4 DOM panel wiring — all pass.
- Acceptance met: the table renders one cell per existing connection, and a table edit ↔ graph edit converge on one patch (verified by round-trip test).
- `typecheck` clean · `eslint` clean · full `vitest` suite exit 0.

Closes oscilla-pillars-scene-nt56.14.

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7