### PR TITLE
feat(pillars-scene nt56.25): scalar-valued ports + scalar edge routing in ScenePlan compiler

### DIFF
--- a/src/pillars/fixtures/scalar-route.ts
+++ b/src/pillars/fixtures/scalar-route.ts
@@ -1,0 +1,67 @@
+/**
+ * src/pillars/fixtures/scalar-route.ts
+ *
+ * The scalar-routing proof target (oscilla-pillars-scene-nt56.25): a grid fed
+ * through a `WaveOffset` whose `amplitude` knob is *routed* from a `Constant`
+ * scalar source, not left to its config default. The routed value (0.45) is far
+ * larger than the knob's default (0.15), so the wave the compiler builds is
+ * visibly taller — the render is driven by the value crossing the scalar edge.
+ *
+ * This is the substrate a routed scalar folds onto: the `amplitude` PlanExpr in
+ * the compiled plan is the Constant's `konst(0.45)`, reached through the scalar
+ * edge, in place of the synthesized config default.
+ *
+ * [LAW:one-source-of-truth] The authored intent is these blocks + the scalar
+ *   edge; `compileScenePlan` derives the ScenePlan, never a hand-authored copy.
+ * [LAW:dataflow-not-control-flow] The routed value replaces a config leaf with no
+ *   branch — the modifier reads `inputs.amplitude` whether wired or defaulted.
+ */
+
+import type { PillarPatch } from '../types';
+
+export function makeScalarRoutePatch(): PillarPatch {
+  return {
+    blocks: [
+      {
+        id: 'grid',
+        kind: 'generator',
+        type: 'InstanceGrid',
+        config: {
+          rows: 10,
+          cols: 10,
+          spacing: 0.1,
+          rotationPerIndex: 0,
+          rotationPerTime: 0,
+        },
+      },
+      // The scalar source: a Constant whose value drives the wave's amplitude.
+      { id: 'amp', kind: 'generator', type: 'Constant', config: { value: 0.45 } },
+      {
+        id: 'wave',
+        kind: 'modifier',
+        type: 'WaveOffset',
+        // frequency/speed keep their knob defaults; amplitude is routed below.
+        config: {},
+      },
+      {
+        id: 'color',
+        kind: 'modifier',
+        type: 'SolidColor',
+        config: { color: '#39d0ff' },
+      },
+      {
+        id: 'draw',
+        kind: 'intent',
+        type: 'DrawInstances',
+        config: { size: 0.05, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 },
+      },
+    ],
+    edges: [
+      { id: 'e0', source: 'grid', target: 'wave', inputSlot: 'primary', role: 'primary' },
+      // The scalar route: Constant.value → WaveOffset.amplitude.
+      { id: 'e1', source: 'amp', target: 'wave', inputSlot: 'amplitude', role: 'secondary' },
+      { id: 'e2', source: 'wave', target: 'color', inputSlot: 'primary', role: 'primary' },
+      { id: 'e3', source: 'color', target: 'draw', inputSlot: 'primary', role: 'primary' },
+    ],
+  };
+}

--- a/src/pillars/fixtures/scene-demos.ts
+++ b/src/pillars/fixtures/scene-demos.ts
@@ -34,6 +34,7 @@ import { makeConditionalVisibilityPatch } from './conditional-visibility';
 import { makeScatterCloudPatch } from './scatter-cloud';
 import { makeColorPalettePatch } from './color-palette';
 import { makePointDotsPatch } from './point-dots';
+import { makeScalarRoutePatch } from './scalar-route';
 
 /** An authored ScenePlan proof target plus the assets its patch references. */
 export interface ScenePlanDemo {
@@ -75,4 +76,8 @@ export const SCENE_PLAN_DEMOS: Readonly<Record<string, ScenePlanDemo>> = {
   // ring of large, separated round dots proving `GeometryDef.point` realizes as a
   // sized disc, not a placeholder quad or a faked square. No assets.
   'point-dots': { makePatch: makePointDotsPatch, assets: [] },
+  // Scalar-routing proof target (oscilla-pillars-scene-nt56.25): a WaveOffset whose
+  // amplitude knob is routed from a Constant scalar source, so the routed value
+  // (not the config default) drives a visibly taller wave. No assets.
+  'scalar-route': { makePatch: makeScalarRoutePatch, assets: [] },
 };

--- a/src/pillars/scene/__tests__/authoring.test.ts
+++ b/src/pillars/scene/__tests__/authoring.test.ts
@@ -48,4 +48,12 @@ describe('defaultSceneConfig', () => {
     const config = defaultSceneConfig(draw);
     expect('textureAssetId' in config).toBe(false);
   });
+
+  it('seeds a knob with its authored default, not the control-generic 1', () => {
+    // A freshly-added WaveOffset must start with the knob defaults, so a placed
+    // block renders as intended rather than at amplitude 1 (6.7x too tall).
+    const wave = registry.get('WaveOffset')!.catalog;
+    const config = defaultSceneConfig(wave);
+    expect(config).toMatchObject({ amplitude: 0.15, frequency: 6, speed: 2 });
+  });
 });

--- a/src/pillars/scene/__tests__/compile.test.ts
+++ b/src/pillars/scene/__tests__/compile.test.ts
@@ -218,6 +218,8 @@ describe('scene block contract — catalog and registration', () => {
     const catalog = registry.catalog;
 
     expect(catalog.map((block) => block.displayName)).toEqual([
+      'Constant',
+      'Time',
       'Instance Grid',
       'Instance Count',
       'Ring Layout',
@@ -235,6 +237,8 @@ describe('scene block contract — catalog and registration', () => {
       'Draw Instances',
     ]);
     expect(catalog.flatMap((block) => block.ports.map((port) => port.value))).toEqual([
+      'scalar', // Constant output
+      'scalar', // Time output
       'instanceBundle', // InstanceGrid output
       'instanceBundle', // InstanceCount output
       'instanceBundle', // RingLayout input
@@ -247,6 +251,9 @@ describe('scene block contract — catalog and registration', () => {
       'instanceBundle', // Scatter output
       'instanceBundle', // WaveOffset input
       'instanceBundle', // WaveOffset output
+      'scalar', // WaveOffset amplitude knob
+      'scalar', // WaveOffset frequency knob
+      'scalar', // WaveOffset speed knob
       'instanceBundle', // SolidColor input
       'instanceBundle', // SolidColor output
       'instanceBundle', // Gradient input
@@ -265,6 +272,7 @@ describe('scene block contract — catalog and registration', () => {
       'materialShell', // DrawInstances output
     ]);
     expect(catalog.flatMap((block) => block.configFields.map((field) => field.key))).toEqual([
+      'value', // Constant (Time has no config fields)
       'rows',
       'cols',
       'spacing',

--- a/src/pillars/scene/__tests__/insertability.test.ts
+++ b/src/pillars/scene/__tests__/insertability.test.ts
@@ -23,7 +23,9 @@ function port(
   direction: 'input' | 'output',
   value: SceneValueKind,
 ): ScenePortDeclaration {
-  return { id, label: id, direction, value };
+  return direction === 'input'
+    ? { id, label: id, direction, value, default: { kind: 'required' } }
+    : { id, label: id, direction, value };
 }
 
 function catalogOf(
@@ -69,8 +71,21 @@ describe('connectableScenePorts — over the native block set', () => {
     expect(connectableScenePorts(registry, { value: 'materialShell', direction: 'output' })).toEqual([]);
   });
 
-  it('excludes a hard mismatch — a scalar output finds no instanceBundle input', () => {
-    expect(connectableScenePorts(registry, { value: 'scalar', direction: 'output' })).toEqual([]);
+  it('a selected scalar output offers the routable scalar knob inputs, and only those', () => {
+    const matches = connectableScenePorts(registry, { value: 'scalar', direction: 'output' });
+    // A scalar source (Constant/Time) offers every routable knob — here WaveOffset's
+    // amplitude/frequency/speed — and nothing that is not a scalar input.
+    expect(matches.length).toBeGreaterThan(0);
+    for (const match of matches) {
+      expect(match.port).toMatchObject({ direction: 'input', value: 'scalar' });
+      expect(match.compatibility).toMatchObject({ kind: 'compatible' });
+    }
+    expect(matches).toContainEqual(
+      expect.objectContaining({
+        blockType: 'WaveOffset',
+        port: expect.objectContaining({ id: 'amplitude', value: 'scalar' }),
+      }),
+    );
   });
 });
 

--- a/src/pillars/scene/__tests__/scalar-routing.test.ts
+++ b/src/pillars/scene/__tests__/scalar-routing.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for scalar-valued ports + scalar edge routing (oscilla-pillars-scene-nt56.25).
+ *
+ * A modifier's routable *knob* reads a scalar `PlanExpr` — a wired scalar source's
+ * value, or the synthesized config default when unwired. These pin the behavior
+ * the substrate rests on: the routed value replaces the default in the compiled
+ * plan, an unwired knob equals routing its own config constant, and a knob wired
+ * to a non-scalar source is a loud error.
+ *
+ * [LAW:behavior-not-structure] Assertions target what the plan *means* — which
+ *   constants and inputs the amplitude expression reads — not the exact tree shape.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { compileScenePlan } from '../index';
+import { makeScalarRoutePatch } from '../../fixtures/scalar-route';
+import { sceneObjectRef, type PlanExpr, type ScenePlan } from '../../../render/scene-plan';
+import type { PillarPatch } from '../../types';
+
+function compileOk(patch: PillarPatch): ScenePlan {
+  const result = compileScenePlan(patch);
+  if (result.kind !== 'ok') {
+    throw new Error(`Expected ok ScenePlan, got errors: ${result.errors.join('; ')}`);
+  }
+  return result.plan;
+}
+
+function compileErr(patch: PillarPatch): readonly string[] {
+  const result = compileScenePlan(patch);
+  if (result.kind !== 'error') throw new Error('Expected an error ScenePlan, got ok');
+  return result.errors;
+}
+
+/** The per-instance Y expression of the single draw — where WaveOffset writes. */
+function positionY(plan: ScenePlan): PlanExpr {
+  return plan.objects[sceneObjectRef('draw')].instancing.transform.positionY;
+}
+
+/** Every `const` leaf value anywhere in an expression tree. */
+function constLeaves(expr: PlanExpr): number[] {
+  switch (expr.kind) {
+    case 'const':
+      return [expr.value];
+    case 'input':
+    case 'intrinsic':
+      return [];
+    case 'unary':
+      return constLeaves(expr.arg);
+    case 'binary':
+      return [...constLeaves(expr.lhs), ...constLeaves(expr.rhs)];
+  }
+}
+
+/** How many times an expression tree reads the given runtime input channel. */
+function countInput(expr: PlanExpr, channel: string): number {
+  switch (expr.kind) {
+    case 'input':
+      return expr.channel === channel ? 1 : 0;
+    case 'const':
+    case 'intrinsic':
+      return 0;
+    case 'unary':
+      return countInput(expr.arg, channel);
+    case 'binary':
+      return countInput(expr.lhs, channel) + countInput(expr.rhs, channel);
+  }
+}
+
+/** A grid → WaveOffset → draw patch, with optional scalar sources + knob edges. */
+function wavePatch(sources: PillarPatch['blocks'], knobEdges: PillarPatch['edges']): PillarPatch {
+  return {
+    blocks: [
+      { id: 'grid', kind: 'generator', type: 'InstanceGrid',
+        config: { rows: 8, cols: 8, spacing: 0.1, rotationPerIndex: 0, rotationPerTime: 0 } },
+      { id: 'wave', kind: 'modifier', type: 'WaveOffset', config: {} },
+      { id: 'draw', kind: 'intent', type: 'DrawInstances',
+        config: { size: 0.05, cameraHalfExtentX: 0.6, cameraHalfExtentY: 0.6 } },
+      ...sources,
+    ],
+    edges: [
+      { id: 'e0', source: 'grid', target: 'wave', inputSlot: 'primary', role: 'primary' },
+      { id: 'e1', source: 'wave', target: 'draw', inputSlot: 'primary', role: 'primary' },
+      ...knobEdges,
+    ],
+  };
+}
+
+describe('scalar routing — a routed Constant drives a modifier knob', () => {
+  it('the fixture compiles and the routed value (0.45) appears in the wave amplitude', () => {
+    const plan = compileOk(makeScalarRoutePatch());
+    // The routed Constant value drives amplitude — it is a const leaf of positionY.
+    expect(constLeaves(positionY(plan))).toContain(0.45);
+  });
+
+  it('routing replaces the config default: the routed value is present, the default is not', () => {
+    const routed = compileOk(
+      wavePatch(
+        [{ id: 'amp', kind: 'generator', type: 'Constant', config: { value: 0.9 } }],
+        [{ id: 'k', source: 'amp', target: 'wave', inputSlot: 'amplitude', role: 'secondary' }],
+      ),
+    );
+    const leaves = constLeaves(positionY(routed));
+    expect(leaves).toContain(0.9); // the routed value
+    expect(leaves).not.toContain(0.15); // the amplitude knob default is overridden
+  });
+});
+
+describe('scalar routing — the canonical default source', () => {
+  it('an unwired knob equals routing a Constant carrying its config value', () => {
+    // Unwired: amplitude falls to its synthesized default source.
+    const defaulted = compileOk(wavePatch([], []));
+    // Wired to a Constant holding the same default value (0.15).
+    const routedDefault = compileOk(
+      wavePatch(
+        [{ id: 'amp', kind: 'generator', type: 'Constant', config: { value: 0.15 } }],
+        [{ id: 'k', source: 'amp', target: 'wave', inputSlot: 'amplitude', role: 'secondary' }],
+      ),
+    );
+    // Same plan: the default source IS a Constant of the config value.
+    expect(JSON.stringify(positionY(defaulted))).toEqual(JSON.stringify(positionY(routedDefault)));
+  });
+
+  it('an authored config value becomes the default source constant when unwired', () => {
+    const plan = compileOk(
+      wavePatch(
+        [],
+        [],
+      ),
+    );
+    // Default amplitude 0.15, frequency 6, speed 2 all appear as const leaves.
+    const leaves = constLeaves(positionY(plan));
+    expect(leaves).toContain(0.15);
+    expect(leaves).toContain(6);
+    expect(leaves).toContain(2);
+  });
+});
+
+describe('scalar routing — a live Time source carries a PlanExpr', () => {
+  it('routing Time into the speed knob makes the phase read the live time input twice', () => {
+    const defaulted = compileOk(wavePatch([], []));
+    const routed = compileOk(
+      wavePatch(
+        [{ id: 'clock', kind: 'generator', type: 'Time', config: {} }],
+        [{ id: 'k', source: 'clock', target: 'wave', inputSlot: 'speed', role: 'secondary' }],
+      ),
+    );
+    // The wave already reads `time` once for its travelling phase. Routing Time
+    // into `speed` means the phase reads `time` a second time — the routed value
+    // is a live PlanExpr, not a baked number. [LAW:effects-at-boundaries]
+    expect(countInput(positionY(routed), 'time')).toBe(
+      countInput(positionY(defaulted), 'time') + 1,
+    );
+  });
+});
+
+describe('scalar routing — a knob wired to a non-scalar source is loud', () => {
+  it('wiring a bundle source into a scalar knob is a surfaced error', () => {
+    const errors = compileErr(
+      wavePatch(
+        [{ id: 'other', kind: 'generator', type: 'InstanceCount', config: { count: 4 } }],
+        [{ id: 'k', source: 'other', target: 'wave', inputSlot: 'amplitude', role: 'secondary' }],
+      ),
+    );
+    expect(errors.join('\n')).toMatch(/not a scalar source/);
+  });
+});

--- a/src/pillars/scene/__tests__/scalar-routing.test.ts
+++ b/src/pillars/scene/__tests__/scalar-routing.test.ts
@@ -49,6 +49,8 @@ function constLeaves(expr: PlanExpr): number[] {
       return constLeaves(expr.arg);
     case 'binary':
       return [...constLeaves(expr.lhs), ...constLeaves(expr.rhs)];
+    default:
+      return assertNever(expr);
   }
 }
 
@@ -64,7 +66,18 @@ function countInput(expr: PlanExpr, channel: string): number {
       return countInput(expr.arg, channel);
     case 'binary':
       return countInput(expr.lhs, channel) + countInput(expr.rhs, channel);
+    default:
+      return assertNever(expr);
   }
+}
+
+/**
+ * Exhaustiveness guard mirroring the production consumers (inputs.ts, assemble.ts):
+ * a new PlanExpr kind is a compile error here, never a silently-empty walk that
+ * lets an assertion pass when it should fail. [LAW:no-silent-failure]
+ */
+function assertNever(value: never): never {
+  throw new Error(`unhandled PlanExpr kind: ${JSON.stringify(value)}`);
 }
 
 /** A grid → WaveOffset → draw patch, with optional scalar sources + knob edges. */

--- a/src/pillars/scene/__tests__/validate.test.ts
+++ b/src/pillars/scene/__tests__/validate.test.ts
@@ -32,7 +32,9 @@ function port(
   direction: 'input' | 'output',
   value: SceneValueKind,
 ): ScenePortDeclaration {
-  return { id, label: id, direction, value };
+  return direction === 'input'
+    ? { id, label: id, direction, value, default: { kind: 'required' } }
+    : { id, label: id, direction, value };
 }
 
 function catalogOf(

--- a/src/pillars/scene/assemble.ts
+++ b/src/pillars/scene/assemble.ts
@@ -181,6 +181,11 @@ function resolveBundle(
         `[scene] instance chain ends at draw block '${blockId}', which is not an instance source`,
       );
       return null;
+    case 'scalarSource':
+      errors.push(
+        `[scene] instance chain references scalar source '${blockId}', which produces no instance bundle`,
+      );
+      return null;
     default:
       return assertNever(contribution);
   }

--- a/src/pillars/scene/authoring.ts
+++ b/src/pillars/scene/authoring.ts
@@ -73,7 +73,10 @@ export function defaultSceneConfig(
 ): Record<string, unknown> {
   const config: Record<string, unknown> = {};
   for (const field of catalog.configFields) {
-    const value = defaultForControl(field.control);
+    // A field's authored default (a knob's `SceneScalarKnob.default`) is the
+    // single source of that value; only a field with no authored default falls to
+    // the control-generic default. [LAW:one-source-of-truth]
+    const value = field.defaultValue ?? defaultForControl(field.control);
     // An omitted key is the honest default for an optional field.
     if (value !== undefined) config[field.key] = value;
   }

--- a/src/pillars/scene/authoring.ts
+++ b/src/pillars/scene/authoring.ts
@@ -35,6 +35,8 @@ export function pillarKindForRole(role: SceneContributionRole): PillarKind {
   switch (role) {
     case 'instanceSource':
       return 'generator';
+    case 'scalarSource':
+      return 'generator';
     case 'modifier':
       return 'modifier';
     case 'draw':

--- a/src/pillars/scene/blocks/brightness.ts
+++ b/src/pillars/scene/blocks/brightness.ts
@@ -25,7 +25,7 @@ export const BrightnessBlock = defineSceneBlock({
     displayName: 'Brightness',
     category: 'modifier',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/color-by-index.ts
+++ b/src/pillars/scene/blocks/color-by-index.ts
@@ -33,7 +33,7 @@ export const ColorByIndexBlock = defineSceneBlock({
     displayName: 'Color By Index',
     category: 'color',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/color-cycle.ts
+++ b/src/pillars/scene/blocks/color-cycle.ts
@@ -40,7 +40,7 @@ export const ColorCycleBlock = defineSceneBlock({
     displayName: 'Color Cycle',
     category: 'color',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/color-from-gradient.ts
+++ b/src/pillars/scene/blocks/color-from-gradient.ts
@@ -32,7 +32,7 @@ export const ColorFromGradientBlock = defineSceneBlock({
     displayName: 'Color From Gradient',
     category: 'color',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/constant.ts
+++ b/src/pillars/scene/blocks/constant.ts
@@ -1,0 +1,33 @@
+/**
+ * src/pillars/scene/blocks/constant.ts
+ *
+ * The bare scalar source: a single constant value, routable into any modifier
+ * knob. It is also the block a knob's *canonical default source* is made of —
+ * an unwired knob compiles to a synthesized `Constant` carrying its config
+ * default, so "a value with no wire" and "a value from a placed Constant" are the
+ * same shape, never two code paths.
+ *
+ * [LAW:one-type-per-behavior] The user-placed constant and a knob's synthesized
+ *   default are one type — a `scalarSource` yielding `konst(value)`.
+ * [LAW:composability] Does one thing, asks for nothing: it fans out to as many
+ *   knobs as wire to it.
+ */
+
+import { konst } from '../../../render/scene-plan';
+import { defineSceneBlock, sceneConfig } from '../scene-block';
+
+const config = {
+  value: sceneConfig.finiteNumber({ label: 'Value', control: 'number' }),
+} as const;
+
+export const ConstantBlock = defineSceneBlock({
+  type: 'Constant',
+  role: 'scalarSource',
+  catalog: {
+    displayName: 'Constant',
+    category: 'signal',
+    ports: [{ id: 'value', label: 'Value', direction: 'output', value: 'scalar' }],
+  },
+  config,
+  contribute: (config) => ({ role: 'scalarSource', value: konst(config.value) }),
+});

--- a/src/pillars/scene/blocks/draw-instances.ts
+++ b/src/pillars/scene/blocks/draw-instances.ts
@@ -49,7 +49,7 @@ export const DrawInstancesBlock = defineSceneBlock({
     displayName: 'Draw Instances',
     category: 'draw',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'draw', label: 'Draw', direction: 'output', value: 'materialShell' },
     ],
   },

--- a/src/pillars/scene/blocks/gradient.ts
+++ b/src/pillars/scene/blocks/gradient.ts
@@ -33,7 +33,7 @@ export const GradientBlock = defineSceneBlock({
     displayName: 'Gradient',
     category: 'color',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/index.ts
+++ b/src/pillars/scene/blocks/index.ts
@@ -6,6 +6,8 @@
  */
 
 import type { SceneBlockDefinition } from '../scene-block';
+import { ConstantBlock } from './constant';
+import { TimeBlock } from './time';
 import { InstanceGridBlock } from './instance-grid';
 import { InstanceCountBlock } from './instance-count';
 import { RingLayoutBlock } from './ring-layout';
@@ -23,6 +25,8 @@ import { ThresholdVisibilityBlock } from './threshold-visibility';
 import { DrawInstancesBlock } from './draw-instances';
 
 export const ALL_SCENE_BLOCKS: readonly SceneBlockDefinition<unknown>[] = [
+  ConstantBlock as SceneBlockDefinition<unknown>,
+  TimeBlock as SceneBlockDefinition<unknown>,
   InstanceGridBlock as SceneBlockDefinition<unknown>,
   InstanceCountBlock as SceneBlockDefinition<unknown>,
   RingLayoutBlock as SceneBlockDefinition<unknown>,

--- a/src/pillars/scene/blocks/kaleidoscope.ts
+++ b/src/pillars/scene/blocks/kaleidoscope.ts
@@ -28,7 +28,7 @@ export const KaleidoscopeBlock = defineSceneBlock({
     displayName: 'Kaleidoscope',
     category: 'modifier',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/ring-layout.ts
+++ b/src/pillars/scene/blocks/ring-layout.ts
@@ -32,7 +32,7 @@ export const RingLayoutBlock = defineSceneBlock({
     displayName: 'Ring Layout',
     category: 'modifier',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/scatter.ts
+++ b/src/pillars/scene/blocks/scatter.ts
@@ -39,7 +39,7 @@ export const ScatterBlock = defineSceneBlock({
     displayName: 'Scatter',
     category: 'modifier',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/solid-color.ts
+++ b/src/pillars/scene/blocks/solid-color.ts
@@ -33,7 +33,7 @@ export const SolidColorBlock = defineSceneBlock({
     displayName: 'Solid Color',
     category: 'color',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/spirograph.ts
+++ b/src/pillars/scene/blocks/spirograph.ts
@@ -35,7 +35,7 @@ export const SpirographBlock = defineSceneBlock({
     displayName: 'Spirograph',
     category: 'modifier',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/threshold-visibility.ts
+++ b/src/pillars/scene/blocks/threshold-visibility.ts
@@ -31,7 +31,7 @@ export const ThresholdVisibilityBlock = defineSceneBlock({
     displayName: 'Threshold Visibility',
     category: 'color',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },

--- a/src/pillars/scene/blocks/time.ts
+++ b/src/pillars/scene/blocks/time.ts
@@ -1,0 +1,26 @@
+/**
+ * src/pillars/scene/blocks/time.ts
+ *
+ * A live scalar source: the runtime `time` channel in seconds, routable into any
+ * modifier knob. Where a `Constant` bakes a number, `Time` proves a routed knob
+ * carries a live `PlanExpr` — a knob wired to it animates every frame, because the
+ * value it resolves to is `input('time')`, not a compile-time constant.
+ *
+ * [LAW:effects-at-boundaries] The block contributes a *description* (`input('time')`);
+ *   the per-frame value is bound behind the renderer seam, not read here.
+ */
+
+import { input } from '../../../render/scene-plan';
+import { defineSceneBlock } from '../scene-block';
+
+export const TimeBlock = defineSceneBlock({
+  type: 'Time',
+  role: 'scalarSource',
+  catalog: {
+    displayName: 'Time',
+    category: 'signal',
+    ports: [{ id: 'value', label: 'Seconds', direction: 'output', value: 'scalar' }],
+  },
+  config: {},
+  contribute: () => ({ role: 'scalarSource', value: input('time') }),
+});

--- a/src/pillars/scene/blocks/wave-offset.ts
+++ b/src/pillars/scene/blocks/wave-offset.ts
@@ -10,13 +10,20 @@
  *   a pure bundle transform. Adding it edits no draw block and no assembly code.
  */
 
-import { add, input, intrinsic, konst, mul, sin } from '../../../render/scene-plan';
-import { defineSceneBlock, sceneConfig } from '../scene-block';
+import { add, input, intrinsic, mul, sin } from '../../../render/scene-plan';
+import { defineSceneBlock } from '../scene-block';
 
-const config = {
-  amplitude: sceneConfig.finiteNumber({ label: 'Amplitude', control: 'number' }),
-  frequency: sceneConfig.finiteNumber({ label: 'Frequency', control: 'number' }),
-  speed: sceneConfig.finiteNumber({ label: 'Speed', control: 'number' }),
+/**
+ * `amplitude`, `frequency`, and `speed` are routable scalar *knobs*: each is a
+ * config default AND a scalar input port. Unwired, a knob resolves to its config
+ * constant (the prior behavior); wired to a Constant/Time source it resolves to
+ * that routed scalar — this is the block that proves a scalar drives a modifier's
+ * math. [LAW:one-source-of-truth] One declaration is field + port + default.
+ */
+const knobs = {
+  amplitude: { label: 'Amplitude', default: 0.15 },
+  frequency: { label: 'Frequency', default: 6 },
+  speed: { label: 'Speed', default: 2 },
 } as const;
 
 export const WaveOffsetBlock = defineSceneBlock({
@@ -26,15 +33,18 @@ export const WaveOffsetBlock = defineSceneBlock({
     displayName: 'Wave Offset',
     category: 'modifier',
     ports: [
-      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle' },
+      { id: 'primary', label: 'Instances', direction: 'input', value: 'instanceBundle', default: { kind: 'required' } },
       { id: 'instances', label: 'Instances', direction: 'output', value: 'instanceBundle' },
     ],
   },
-  config,
-  contribute: (config) => ({
+  config: {},
+  knobs,
+  contribute: (_config, inputs) => ({
     role: 'modifier',
     // [LAW:dataflow-not-control-flow] The displacement is added onto the upstream
-    //   positionY expression; an amplitude of 0 is the identity, not a branch.
+    //   positionY expression; an amplitude of 0 is the identity, not a branch. The
+    //   knob PlanExprs (`inputs.x`) are the resolved routed scalars — a wired
+    //   Constant/Time or the synthesized config default, uniformly.
     apply: (bundle) => ({
       ...bundle,
       transform: {
@@ -42,11 +52,11 @@ export const WaveOffsetBlock = defineSceneBlock({
         positionY: add(
           bundle.transform.positionY,
           mul(
-            konst(config.amplitude),
+            inputs.amplitude,
             sin(
               add(
-                mul(intrinsic('rank'), konst(config.frequency)),
-                mul(input('time'), konst(config.speed)),
+                mul(intrinsic('rank'), inputs.frequency),
+                mul(input('time'), inputs.speed),
               ),
             ),
           ),

--- a/src/pillars/scene/compile.ts
+++ b/src/pillars/scene/compile.ts
@@ -15,19 +15,40 @@
  *   swallowed.
  */
 
+import type { PlanExpr } from '../../render/scene-plan';
 import type { PillarPatch } from '../types';
 import { ALL_SCENE_BLOCKS } from './blocks';
 import {
   buildSceneRegistry,
+  type SceneBlockDefinition,
   type SceneContribution,
   type SceneDiagnostic,
 } from './scene-block';
+import { resolveKnobInputs } from './scalar-inputs';
 import { assembleScenePlan, type SceneCompileResult } from './assemble';
 
+interface ParsedBlock {
+  readonly blockId: string;
+  readonly def: SceneBlockDefinition<unknown>;
+  readonly config: unknown;
+}
+
+/**
+ * Compile an authored patch to a ScenePlan. Contribution happens in two ordered
+ * passes so a routable knob can read a live upstream scalar:
+ *
+ *  1. Scalar sources (Constant, Time) contribute first — they are leaves, so
+ *     their `PlanExpr` values are known before anything reads them.
+ *  2. Every other block resolves its knob inputs (a wired source's scalar, or the
+ *     synthesized config default) and contributes with them.
+ *
+ * [LAW:dataflow-not-control-flow] The two passes are the data dependency (sources
+ *   before consumers), not a branch on block type at each step.
+ */
 export function compileScenePlan(patch: PillarPatch): SceneCompileResult {
   const registry = buildSceneRegistry(ALL_SCENE_BLOCKS);
   const diagnostics: SceneDiagnostic[] = [];
-  const contributions = new Map<string, SceneContribution>();
+  const parsed: ParsedBlock[] = [];
 
   for (const block of patch.blocks) {
     const def = registry.get(block.type);
@@ -40,11 +61,42 @@ export function compileScenePlan(patch: PillarPatch): SceneCompileResult {
     }
     const config = def.readConfig(block.config, block.id, diagnostics);
     if (config === null) continue;
-    contributions.set(block.id, def.contribute(config));
+    parsed.push({ blockId: block.id, def, config });
   }
 
   if (diagnostics.length > 0) {
     return { kind: 'error', errors: diagnostics.map((d) => d.message) };
+  }
+
+  const contributions = new Map<string, SceneContribution>();
+  const scalarValues = new Map<string, PlanExpr>();
+
+  // Pass 1: scalar sources. They have no knob inputs, so an empty resolved-inputs
+  // record is complete; their value becomes available to every consumer below.
+  for (const { blockId, def, config } of parsed) {
+    if (def.role !== 'scalarSource') continue;
+    const contribution = def.contribute(config, {});
+    contributions.set(blockId, contribution);
+    if (contribution.role === 'scalarSource') scalarValues.set(blockId, contribution.value);
+  }
+
+  // Pass 2: everything else, with knob inputs resolved against the scalar sources.
+  const errors: string[] = [];
+  for (const { blockId, def, config } of parsed) {
+    if (def.role === 'scalarSource') continue;
+    const inputs = resolveKnobInputs(
+      blockId,
+      def.catalog.ports,
+      config,
+      patch.edges,
+      scalarValues,
+      errors,
+    );
+    contributions.set(blockId, def.contribute(config, inputs));
+  }
+
+  if (errors.length > 0) {
+    return { kind: 'error', errors };
   }
 
   return assembleScenePlan(patch.edges, contributions);

--- a/src/pillars/scene/index.ts
+++ b/src/pillars/scene/index.ts
@@ -23,6 +23,8 @@ export {
   type SceneCatalogMetadata,
   type ScenePortDeclaration,
   type ScenePortDirection,
+  type ScenePortInputDefault,
+  type SceneScalarKnob,
   type SceneValueKind,
   type InstanceBundle,
   type DrawShell,

--- a/src/pillars/scene/scalar-inputs.ts
+++ b/src/pillars/scene/scalar-inputs.ts
@@ -1,0 +1,88 @@
+/**
+ * src/pillars/scene/scalar-inputs.ts
+ *
+ * Resolve the scalar `PlanExpr` feeding every routable knob input port, so a
+ * modifier's `contribute` reads `inputs.x` with no wired/unwired branch of its
+ * own. This module is the single owner of the "canonical default source" rule:
+ * an unwired knob resolves to a `Constant` carrying its config value (a synthesized
+ * default source), a wired knob resolves to the scalar value its source produced.
+ *
+ * [LAW:single-enforcer] The default-source rule lives here, once — every block's
+ *   `contribute` consumes the resolved value and never re-derives the default.
+ * [LAW:one-source-of-truth] The default's constant is read from config; it is not
+ *   a second copy stored on the port or the patch.
+ * [LAW:no-silent-failure] A knob wired to a source that produces no scalar is a
+ *   surfaced diagnostic, not a silently-dropped route.
+ */
+
+import { konst, type PlanExpr } from '../../render/scene-plan';
+import type { PillarEdge } from '../types';
+import type { ScenePortDeclaration } from './scene-block';
+
+/**
+ * Resolve every routable knob input port of one block to a scalar `PlanExpr`.
+ * Non-knob ports (a required instance bundle) are not knobs and are skipped; they
+ * are resolved as bundle edges by assembly, not here.
+ */
+export function resolveKnobInputs(
+  blockId: string,
+  ports: readonly ScenePortDeclaration[],
+  config: unknown,
+  edges: readonly PillarEdge[],
+  scalarValues: ReadonlyMap<string, PlanExpr>,
+  errors: string[],
+): Record<string, PlanExpr> {
+  const inputs: Record<string, PlanExpr> = {};
+  for (const port of ports) {
+    if (port.direction !== 'input') continue;
+    if (port.default.kind !== 'configScalar') continue;
+    inputs[port.id] = resolveKnob(blockId, port, port.default.configKey, config, edges, scalarValues, errors);
+  }
+  return inputs;
+}
+
+/**
+ * The scalar value one knob resolves to. The wired/unwired distinction is genuine
+ * graph state, decided here once: an unwired knob is its synthesized default
+ * source `konst(config[configKey])`; a wired knob is the value its source
+ * produced. Downstream (`contribute`) sees a single `PlanExpr` either way.
+ */
+function resolveKnob(
+  blockId: string,
+  port: ScenePortDeclaration,
+  configKey: string,
+  config: unknown,
+  edges: readonly PillarEdge[],
+  scalarValues: ReadonlyMap<string, PlanExpr>,
+  errors: string[],
+): PlanExpr {
+  const edge = edges.find((e) => e.target === blockId && e.inputSlot === port.id);
+  if (edge === undefined) {
+    return konst(numberConfig(config, configKey, blockId, port.id));
+  }
+  const value = scalarValues.get(edge.source);
+  if (value === undefined) {
+    errors.push(
+      `[scene] knob '${blockId}.${port.id}' is fed by '${edge.source}', which is not a scalar source`,
+    );
+    // Still resolve to the default so one bad wire yields one diagnostic, not a
+    // cascade of "missing input" errors from the rest of assembly.
+    return konst(numberConfig(config, configKey, blockId, port.id));
+  }
+  return value;
+}
+
+/**
+ * Read a knob's default constant from parsed config. The knob's config field is a
+ * finite number with a default, so a non-number here is an impossible state (a
+ * broken schema), surfaced loudly rather than coerced. [LAW:no-silent-failure]
+ */
+function numberConfig(config: unknown, key: string, blockId: string, portId: string): number {
+  const raw = (config as Record<string, unknown>)[key];
+  if (typeof raw !== 'number') {
+    throw new Error(
+      `[scene] knob '${blockId}.${portId}': default config field '${key}' is not a number`,
+    );
+  }
+  return raw;
+}

--- a/src/pillars/scene/scene-block.ts
+++ b/src/pillars/scene/scene-block.ts
@@ -3,6 +3,7 @@ import type { AssetId } from '../../core/ids';
 import type {
   CameraPlan,
   GeometryDef,
+  PlanExpr,
   RenderTarget,
   TransformBinding,
 } from '../../render/scene-plan';
@@ -49,6 +50,9 @@ export type BundleTransform = (input: InstanceBundle) => InstanceBundle;
  * - `modifier` carries a bundle *transform* (a modifier: bundle → bundle); the
  *   concrete bundle is produced only once assembly folds it over its upstream.
  * - `draw` carries the shell assembly joins to the resolved upstream bundle.
+ * - `scalarSource` carries a single scalar `PlanExpr` a routable knob reads in
+ *   place of its config default (a Constant is `konst(value)`, a clock is
+ *   `input('time')`). It never feeds an instance chain — only a knob input port.
  *
  * [LAW:dataflow-not-control-flow] A modifier's behavior is the `apply` *value*,
  *   not a branch in assembly: folding the modifier chain is one generic walk, so
@@ -57,7 +61,8 @@ export type BundleTransform = (input: InstanceBundle) => InstanceBundle;
 export type SceneContribution =
   | { readonly role: 'instanceSource'; readonly bundle: InstanceBundle }
   | { readonly role: 'modifier'; readonly apply: BundleTransform }
-  | { readonly role: 'draw'; readonly shell: DrawShell };
+  | { readonly role: 'draw'; readonly shell: DrawShell }
+  | { readonly role: 'scalarSource'; readonly value: PlanExpr };
 
 export type SceneContributionRole = SceneContribution['role'];
 
@@ -73,12 +78,45 @@ export type SceneValueKind =
 
 export type ScenePortDirection = 'input' | 'output';
 
-export interface ScenePortDeclaration {
+/**
+ * How an input port is fed when the author draws no wire to it — a *typed* port
+ * property, so "defaultable vs required" is representable, not folded into a
+ * codepath.
+ *
+ * - `required`: the port MUST be wired; unwired is a loud error (a draw's primary
+ *   instance bundle has no meaningful default).
+ * - `configScalar`: the port has a canonical default *source* — a Constant
+ *   carrying the value of config field `configKey`. When the port is unwired the
+ *   compiler synthesizes that source, so every knob input has exactly one source
+ *   and resolution never branches on wired/unwired.
+ *
+ * [LAW:no-silent-failure] A required input left unwired is surfaced, never
+ *   silently defaulted. [LAW:one-source-of-truth] The default's constant lives in
+ *   config; the synthesized source is derived from it, never a second copy.
+ */
+export type ScenePortInputDefault =
+  | { readonly kind: 'required' }
+  | { readonly kind: 'configScalar'; readonly configKey: string };
+
+interface ScenePortBase {
   readonly id: string;
   readonly label: string;
-  readonly direction: ScenePortDirection;
   readonly value: SceneValueKind;
 }
+
+/**
+ * A declared port. Discriminated on `direction`: only an input port carries a
+ * `default` policy (an output produces a value, it is never fed).
+ *
+ * [LAW:types-are-the-program] The default policy is unrepresentable on an output
+ *   and mandatory on an input — the shape forbids the illegal combinations.
+ */
+export type ScenePortDeclaration =
+  | (ScenePortBase & { readonly direction: 'output' })
+  | (ScenePortBase & {
+      readonly direction: 'input';
+      readonly default: ScenePortInputDefault;
+    });
 
 export type SceneBlockCategory =
   | 'instance'
@@ -86,7 +124,9 @@ export type SceneBlockCategory =
   | 'draw'
   | 'material'
   | 'asset'
-  | 'color';
+  | 'color'
+  // A scalar signal source (Constant, Time) — produces one routable scalar value.
+  | 'signal';
 
 export type SceneConfigControl =
   | 'number'
@@ -126,6 +166,32 @@ export interface SceneCatalogConfigField extends SceneConfigFieldCatalog {
   readonly key: string;
 }
 
+/**
+ * A routable scalar knob: a numeric parameter that is *both* a persisted config
+ * default AND a scalar input port a wire can override. One declaration projects
+ * to a config field (the default's constant), a scalar input port, and a resolved
+ * `PlanExpr` handed to `contribute`.
+ *
+ * [LAW:one-source-of-truth] A knob is one declaration, not a config field and a
+ *   port and a default kept in sync by hand.
+ */
+export interface SceneScalarKnob {
+  readonly label: string;
+  readonly default: number;
+}
+
+export type SceneKnobFields = Readonly<Record<string, SceneScalarKnob>>;
+
+/** A knob's persisted config value: a finite number (its default source's constant). */
+type KnobConfigFor<TKnobs extends SceneKnobFields> = {
+  readonly [K in keyof TKnobs]: number;
+};
+
+/** The resolved scalar `PlanExpr` feeding each knob input port at compile time. */
+export type KnobInputsFor<TKnobs extends SceneKnobFields> = {
+  readonly [K in keyof TKnobs]: PlanExpr;
+};
+
 export interface SceneBlockDefinition<
   TConfig,
   TRole extends SceneContributionRole = SceneContributionRole,
@@ -139,11 +205,21 @@ export interface SceneBlockDefinition<
     blockId: string,
     diagnostics: SceneDiagnostic[],
   ) => TConfig | null;
-  readonly contribute: (config: TConfig) => Extract<SceneContribution, { readonly role: TRole }>;
+  /**
+   * Produce the block's contribution from its parsed config and its resolved
+   * scalar knob inputs. `inputs` is keyed by knob (= scalar input port) id; the
+   * compiler guarantees every knob is present (a wired source or the synthesized
+   * config default), so a block reads `inputs.x` with no wired/unwired branch.
+   */
+  readonly contribute: (
+    config: TConfig,
+    inputs: Readonly<Record<string, PlanExpr>>,
+  ) => Extract<SceneContribution, { readonly role: TRole }>;
 }
 
 export interface SceneBlockDeclaration<
   TFields extends SceneConfigFields,
+  TKnobs extends SceneKnobFields,
   TRole extends SceneContributionRole,
 > {
   readonly type: string;
@@ -151,8 +227,11 @@ export interface SceneBlockDeclaration<
   // `type` and `configFields` are derived from the declaration, not repeated here.
   readonly catalog: Omit<SceneCatalogMetadata, 'configFields' | 'type'>;
   readonly config: TFields;
+  /** Routable scalar knobs; omit for a block with no routable parameters. */
+  readonly knobs?: TKnobs;
   readonly contribute: (
-    config: SceneConfigFor<TFields>,
+    config: SceneConfigFor<TFields> & KnobConfigFor<TKnobs>,
+    inputs: KnobInputsFor<TKnobs>,
   ) => Extract<SceneContribution, { readonly role: TRole }>;
 }
 
@@ -162,21 +241,46 @@ type SceneConfigShape<TFields extends SceneConfigFields> = {
 
 export function defineSceneBlock<
   const TFields extends SceneConfigFields,
+  const TKnobs extends SceneKnobFields,
   const TRole extends SceneContributionRole,
 >(
-  declaration: SceneBlockDeclaration<TFields, TRole>,
-): SceneBlockDefinition<SceneConfigFor<TFields>, TRole> {
-  // [LAW:one-source-of-truth] One field map derives both parsing and catalog metadata.
-  const configSchema = z.object(configShape(declaration.config)) as z.ZodType<
-    SceneConfigFor<TFields>
-  >;
+  declaration: SceneBlockDeclaration<TFields, TKnobs, TRole>,
+): SceneBlockDefinition<SceneConfigFor<TFields> & KnobConfigFor<TKnobs>, TRole> {
+  const knobs: SceneKnobFields = declaration.knobs ?? {};
+
+  // [LAW:one-source-of-truth] Each knob derives its config field (default
+  //   source's constant), its scalar input port, and its catalog control from one
+  //   declaration — never three hand-synced copies.
+  const knobSchema = Object.fromEntries(
+    Object.entries(knobs).map(([key, knob]) => [key, z.number().finite().default(knob.default)]),
+  );
+  const configSchema = z.object({
+    ...configShape(declaration.config),
+    ...knobSchema,
+  }) as z.ZodType<SceneConfigFor<TFields> & KnobConfigFor<TKnobs>>;
+
+  const knobPorts: ScenePortDeclaration[] = Object.entries(knobs).map(([key, knob]) => ({
+    id: key,
+    label: knob.label,
+    direction: 'input',
+    value: 'scalar',
+    default: { kind: 'configScalar', configKey: key },
+  }));
+
+  const configFields: SceneCatalogConfigField[] = [
+    ...Object.entries(declaration.config).map(([key, field]) => ({ key, ...field.catalog })),
+    ...Object.entries(knobs).map(([key, knob]) => ({
+      key,
+      label: knob.label,
+      control: 'number' as const,
+    })),
+  ];
+
   const catalog: SceneCatalogMetadata = {
     type: declaration.type,
     ...declaration.catalog,
-    configFields: Object.entries(declaration.config).map(([key, field]) => ({
-      key,
-      ...field.catalog,
-    })),
+    ports: [...declaration.catalog.ports, ...knobPorts],
+    configFields,
   };
 
   return {
@@ -195,7 +299,12 @@ export function defineSceneBlock<
       }
       return null;
     },
-    contribute: declaration.contribute,
+    // The declaration's `contribute` reads a knob-typed inputs record; the erased
+    // definition hands it a loose `Record<string, PlanExpr>` the compiler fills.
+    contribute: declaration.contribute as SceneBlockDefinition<
+      SceneConfigFor<TFields> & KnobConfigFor<TKnobs>,
+      TRole
+    >['contribute'],
   };
 }
 

--- a/src/pillars/scene/scene-block.ts
+++ b/src/pillars/scene/scene-block.ts
@@ -164,6 +164,14 @@ export interface SceneCatalogMetadata {
 
 export interface SceneCatalogConfigField extends SceneConfigFieldCatalog {
   readonly key: string;
+  /**
+   * The field's authored default value, when it has one (a knob carries its
+   * `SceneScalarKnob.default`). A field with no authored default omits this and
+   * falls to the editor's control-generic default. [LAW:one-source-of-truth] For
+   *   a knob this is derived from `SceneScalarKnob.default` alongside the zod
+   *   `.default`, in `defineSceneBlock` — one authored source, two projections.
+   */
+  readonly defaultValue?: number;
 }
 
 /**
@@ -273,6 +281,9 @@ export function defineSceneBlock<
       key,
       label: knob.label,
       control: 'number' as const,
+      // [LAW:one-source-of-truth] The knob's authored default flows to the catalog
+      //   field here, so a freshly-added block seeds this value — not a generic 1.
+      defaultValue: knob.default,
     })),
   ];
 

--- a/src/pillars/scene/validate.ts
+++ b/src/pillars/scene/validate.ts
@@ -150,14 +150,17 @@ export function validateScenePatch(
     }
   }
 
-  // Required inputs: every declared input port must be fed by an edge. (No scene
-  // input is optional today; an optional flag would be added to the contract
-  // before any input could go unwired.)
+  // Required inputs: an input port whose default policy is `required` must be fed
+  // by an edge. A `configScalar` knob is defaultable — unwired it compiles to its
+  // synthesized config default, so an unwired knob is not a missing input.
+  // [LAW:dataflow-not-control-flow] The port's typed default policy decides this,
+  //   not a per-block special case.
   for (const block of patch.blocks) {
     const def = registry.get(block.type);
     if (def === undefined) continue;
     for (const port of def.catalog.ports) {
       if (port.direction !== 'input') continue;
+      if (port.default.kind !== 'required') continue;
       const fed = patch.edges.some((e) => e.target === block.id && e.inputSlot === port.id);
       if (!fed) diagnostics.push({ kind: 'missingRequiredInput', address: addressOf(block, port) });
     }

--- a/src/ui/nativeEditor/SceneBlockNode.tsx
+++ b/src/ui/nativeEditor/SceneBlockNode.tsx
@@ -58,6 +58,7 @@ const CATEGORY_ACCENT: Record<SceneBlockCategory, string> = {
   material: '#2bb3a3',
   asset: '#d9a441',
   color: '#d65db1',
+  signal: '#7dcf5b',
 };
 
 const VALUE_KIND_COLOR: Record<SceneValueKind, string> = {

--- a/src/ui/nativeEditor/__tests__/modulationTable.test.ts
+++ b/src/ui/nativeEditor/__tests__/modulationTable.test.ts
@@ -75,6 +75,37 @@ describe('buildModulationTable', () => {
   });
 });
 
+describe('scalar routing — a scalar source column feeds a knob row', () => {
+  it('shows a connectable scalar row/column pair and connects it', () => {
+    // A bare patch with a Constant scalar source and a WaveOffset (whose amplitude
+    // is a routable scalar knob). The table must offer Constant.value → the knob.
+    const store = new PillarPatchStore({ blocks: [], edges: [] });
+    const constId = store.addBlock('Constant');
+    const waveId = store.addBlock('WaveOffset');
+
+    const { cell, row, column } = locate(store, waveId, 'amplitude', constId);
+    // The scalar row (a knob input) crosses the scalar column (Constant output) as
+    // a connectable, empty cell.
+    expect(row.value).toBe('scalar');
+    expect(column.value).toBe('scalar');
+    expect(cell.edge).toBeNull();
+    expect(cell.connectable).toBe(true);
+
+    // Clicking it connects the Constant into the knob.
+    const action = cellAction(cell, row, column);
+    expect(action).toEqual({
+      kind: 'connect',
+      source: constId,
+      target: waveId,
+      inputSlot: 'amplitude',
+    });
+    if (action?.kind === 'connect') store.addEdge(action.source, action.target, action.inputSlot);
+
+    // The rebuilt table now shows the connection at that scalar crossing.
+    expect(locate(store, waveId, 'amplitude', constId).cell.edge).not.toBeNull();
+  });
+});
+
 describe('cellAction', () => {
   it('resolves an occupied cell to a disconnect of its edge', () => {
     const store = new PillarPatchStore(makeGridOfSquaresPatch());


### PR DESCRIPTION
## What

Introduces **routable scalar values** into the live ScenePlan compiler (`src/pillars/scene/`) — the substrate `nt56.14.1` (per-cell transform chains) folds onto. Before this, the compiler routed only `instanceBundle`; a modifier's knobs (amplitude, threshold, …) were config, not routable ports, so a transform chain had no scalar to apply to.

Closes the substrate half of `oscilla-pillars-scene-nt56.25`; unblocks `nt56.14.1`.

## Design

Per the ticket's resolved design comment — *"everything is a block"*, every input has a canonical default source:

- **`scalarSource` contribution role** + `Constant` (`konst(value)`) and `Time` (`input('time')`) blocks — each produces one routable scalar `PlanExpr`.
- **Routable scalar *knobs*** — one `knobs` declaration on `defineSceneBlock` projects to a config field (the default's constant), a scalar input port, and a resolved `PlanExpr` handed to `contribute`. One source of truth, not three hand-synced copies. `[LAW:one-source-of-truth]`
- **Typed input default policy** (`required | configScalar`) — "defaultable vs required" is a port property, not a codepath. A required input (primary bundle) unwired stays a loud error; a knob unwired resolves to its synthesized config default. `[LAW:no-silent-failure]`
- **One-enforcer resolution** — `compile` resolves every knob to exactly one scalar (a wired source's value or the synthesized default), so `contribute` reads `inputs.x` with no wired/unwired branch. `[LAW:dataflow-not-control-flow]` `[LAW:single-enforcer]`
- **WaveOffset** amplitude/frequency/speed become routable knobs (the proving modifier). New `scalar-route` demo routes a `Constant(0.45)` into amplitude.

The modulation table, validator, and insertability are pure projections of catalog ports — so scalar rows/columns and connection offers fall out with **no UI change**.

## Verification

- **Screenshot gate** (`?scenePlan=scalar-route`): the routed value visibly drives a taller traveling wave, animating across frames.
- **Unit tests**: routed value replaces the config default in the plan; an unwired knob compiles identically to routing a `Constant` of its config value; `Time` carries a live `PlanExpr`; a knob wired to a non-scalar source is a loud error; the modulation table shows a connectable scalar row/column pair.
- Full suite green (2411 pass; one pre-existing load-sensitive perf test aside).

https://claude.ai/code/session_01Q29RRdNV6SsCaKqh61ECP7