### PR TITLE
feat(pillars-scene nt56.14.1): per-cell transform chains in the Modulation Table (scale/offset/clamp)

### DIFF
--- a/src/pillars/scene/__tests__/compile.test.ts
+++ b/src/pillars/scene/__tests__/compile.test.ts
@@ -220,6 +220,9 @@ describe('scene block contract — catalog and registration', () => {
     expect(catalog.map((block) => block.displayName)).toEqual([
       'Constant',
       'Time',
+      'Scale',
+      'Offset',
+      'Clamp',
       'Instance Grid',
       'Instance Count',
       'Ring Layout',
@@ -239,6 +242,12 @@ describe('scene block contract — catalog and registration', () => {
     expect(catalog.flatMap((block) => block.ports.map((port) => port.value))).toEqual([
       'scalar', // Constant output
       'scalar', // Time output
+      'scalar', // Scale in
+      'scalar', // Scale out
+      'scalar', // Offset in
+      'scalar', // Offset out
+      'scalar', // Clamp in
+      'scalar', // Clamp out
       'instanceBundle', // InstanceGrid output
       'instanceBundle', // InstanceCount output
       'instanceBundle', // RingLayout input
@@ -273,6 +282,10 @@ describe('scene block contract — catalog and registration', () => {
     ]);
     expect(catalog.flatMap((block) => block.configFields.map((field) => field.key))).toEqual([
       'value', // Constant (Time has no config fields)
+      'factor', // Scale
+      'amount', // Offset
+      'lo', // Clamp
+      'hi',
       'rows',
       'cols',
       'spacing',

--- a/src/pillars/scene/__tests__/scalar-routing.test.ts
+++ b/src/pillars/scene/__tests__/scalar-routing.test.ts
@@ -300,6 +300,20 @@ describe('scalar routing — a scalar modifier folds onto the route', () => {
     );
   });
 
+  it('Clamp rejects an inverted range (lo > hi) with a loud diagnostic, not a dead constant', () => {
+    const errors = compileErr(
+      routedKnobPatch(
+        [{ id: 'cl', kind: 'modifier', type: 'Clamp', config: { lo: 0.9, hi: 0.1 } }],
+        [
+          { id: 'a', source: 'amp', target: 'cl', inputSlot: 'in', role: 'secondary' },
+          { id: 'b', source: 'cl', target: 'wave', inputSlot: 'amplitude', role: 'secondary' },
+        ],
+      ),
+    );
+    // Surfaced at config-parse time — never silently compiled to `max(0.9, …) = 0.9`.
+    expect(errors.join('\n')).toMatch(/Min .* must be .* Max/);
+  });
+
   it('a scalar modifier with no input edge is a surfaced error, not a silent drop', () => {
     const errors = compileErr(
       routedKnobPatch(

--- a/src/pillars/scene/__tests__/scalar-routing.test.ts
+++ b/src/pillars/scene/__tests__/scalar-routing.test.ts
@@ -71,6 +71,22 @@ function countInput(expr: PlanExpr, channel: string): number {
   }
 }
 
+/** Every binary operator used anywhere in an expression tree. */
+function binaryOps(expr: PlanExpr): string[] {
+  switch (expr.kind) {
+    case 'const':
+    case 'input':
+    case 'intrinsic':
+      return [];
+    case 'unary':
+      return binaryOps(expr.arg);
+    case 'binary':
+      return [expr.op, ...binaryOps(expr.lhs), ...binaryOps(expr.rhs)];
+    default:
+      return assertNever(expr);
+  }
+}
+
 /**
  * Exhaustiveness guard mirroring the production consumers (inputs.ts, assemble.ts):
  * a new PlanExpr kind is a compile error here, never a silently-empty walk that
@@ -176,5 +192,122 @@ describe('scalar routing — a knob wired to a non-scalar source is loud', () =>
       ),
     );
     expect(errors.join('\n')).toMatch(/not a scalar source/);
+  });
+});
+
+/**
+ * A scalar modifier (Scale/Offset/Clamp) on the route between a source and a knob.
+ * The route `Constant → <transform> → knob` must FOLD: resolution walks the chain
+ * back to the source and applies each transform, exactly as `resolveBundle` folds
+ * an instance-modifier chain. These pin the transform math into the compiled plan.
+ *
+ * The transform block's ports are `in` (scalar) / `out` (scalar); the edge from
+ * the source feeds `in`, and the edge into the knob comes from the block (its sole
+ * output). Both are scalar edges → role 'secondary'.
+ */
+function routedKnobPatch(chain: PillarPatch['blocks'], chainEdges: PillarPatch['edges']): PillarPatch {
+  return wavePatch(
+    [{ id: 'amp', kind: 'generator', type: 'Constant', config: { value: 0.5 } }, ...chain],
+    chainEdges,
+  );
+}
+
+describe('scalar routing — a scalar modifier folds onto the route', () => {
+  it('Constant → Scale → knob multiplies the routed value by the factor', () => {
+    // 0.5 (Constant) scaled by 3 → the plan reads 0.5 and 3 as leaves of a `mul`.
+    const plan = compileOk(
+      routedKnobPatch(
+        [{ id: 'sc', kind: 'modifier', type: 'Scale', config: { factor: 3 } }],
+        [
+          { id: 'a', source: 'amp', target: 'sc', inputSlot: 'in', role: 'secondary' },
+          { id: 'b', source: 'sc', target: 'wave', inputSlot: 'amplitude', role: 'secondary' },
+        ],
+      ),
+    );
+    const leaves = constLeaves(positionY(plan));
+    expect(leaves).toContain(0.5); // the source value
+    expect(leaves).toContain(3); // the scale factor
+    expect(leaves).not.toContain(0.15); // the knob default is overridden by the route
+  });
+
+  it('Constant → Offset → knob adds the amount to the routed value', () => {
+    const plan = compileOk(
+      routedKnobPatch(
+        [{ id: 'of', kind: 'modifier', type: 'Offset', config: { amount: 0.25 } }],
+        [
+          { id: 'a', source: 'amp', target: 'of', inputSlot: 'in', role: 'secondary' },
+          { id: 'b', source: 'of', target: 'wave', inputSlot: 'amplitude', role: 'secondary' },
+        ],
+      ),
+    );
+    const leaves = constLeaves(positionY(plan));
+    expect(leaves).toContain(0.5);
+    expect(leaves).toContain(0.25);
+  });
+
+  it('Constant → Clamp → knob composes into min/max bounds on the routed value', () => {
+    const plan = compileOk(
+      routedKnobPatch(
+        [{ id: 'cl', kind: 'modifier', type: 'Clamp', config: { lo: 0.1, hi: 0.9 } }],
+        [
+          { id: 'a', source: 'amp', target: 'cl', inputSlot: 'in', role: 'secondary' },
+          { id: 'b', source: 'cl', target: 'wave', inputSlot: 'amplitude', role: 'secondary' },
+        ],
+      ),
+    );
+    const leaves = constLeaves(positionY(plan));
+    // clamp(x, lo, hi) === max(lo, min(hi, x)) — both bounds appear as leaves.
+    expect(leaves).toContain(0.1);
+    expect(leaves).toContain(0.9);
+    expect(binaryOps(positionY(plan))).toEqual(expect.arrayContaining(['min', 'max']));
+  });
+
+  it('chains fold in order: Constant → Scale → Offset → knob is offset(scale(value))', () => {
+    const plan = compileOk(
+      routedKnobPatch(
+        [
+          { id: 'sc', kind: 'modifier', type: 'Scale', config: { factor: 2 } },
+          { id: 'of', kind: 'modifier', type: 'Offset', config: { amount: 0.1 } },
+        ],
+        [
+          { id: 'a', source: 'amp', target: 'sc', inputSlot: 'in', role: 'secondary' },
+          { id: 'b', source: 'sc', target: 'of', inputSlot: 'in', role: 'secondary' },
+          { id: 'c', source: 'of', target: 'wave', inputSlot: 'amplitude', role: 'secondary' },
+        ],
+      ),
+    );
+    const leaves = constLeaves(positionY(plan));
+    expect(leaves).toEqual(expect.arrayContaining([0.5, 2, 0.1]));
+  });
+
+  it('a live Time source folds through a Scale: the scaled clock still reads time', () => {
+    const defaulted = compileOk(wavePatch([], []));
+    const routed = compileOk(
+      wavePatch(
+        [
+          { id: 'clock', kind: 'generator', type: 'Time', config: {} },
+          { id: 'sc', kind: 'modifier', type: 'Scale', config: { factor: 4 } },
+        ],
+        [
+          { id: 'a', source: 'clock', target: 'sc', inputSlot: 'in', role: 'secondary' },
+          { id: 'b', source: 'sc', target: 'wave', inputSlot: 'speed', role: 'secondary' },
+        ],
+      ),
+    );
+    // The transform preserves the live input: the folded expr still reads `time`.
+    expect(countInput(positionY(routed), 'time')).toBe(
+      countInput(positionY(defaulted), 'time') + 1,
+    );
+  });
+
+  it('a scalar modifier with no input edge is a surfaced error, not a silent drop', () => {
+    const errors = compileErr(
+      routedKnobPatch(
+        [{ id: 'sc', kind: 'modifier', type: 'Scale', config: { factor: 3 } }],
+        // `sc.in` is left unwired; only the output edge into the knob exists.
+        [{ id: 'b', source: 'sc', target: 'wave', inputSlot: 'amplitude', role: 'secondary' }],
+      ),
+    );
+    expect(errors.join('\n')).toMatch(/no input edge/);
   });
 });

--- a/src/pillars/scene/assemble.ts
+++ b/src/pillars/scene/assemble.ts
@@ -186,6 +186,11 @@ function resolveBundle(
         `[scene] instance chain references scalar source '${blockId}', which produces no instance bundle`,
       );
       return null;
+    case 'scalarModifier':
+      errors.push(
+        `[scene] instance chain references scalar modifier '${blockId}', which produces no instance bundle`,
+      );
+      return null;
     default:
       return assertNever(contribution);
   }

--- a/src/pillars/scene/authoring.ts
+++ b/src/pillars/scene/authoring.ts
@@ -39,6 +39,9 @@ export function pillarKindForRole(role: SceneContributionRole): PillarKind {
       return 'generator';
     case 'modifier':
       return 'modifier';
+    case 'scalarModifier':
+      // A scalar transform on a route is a modifier, like a bundle modifier.
+      return 'modifier';
     case 'draw':
       return 'intent';
     default:

--- a/src/pillars/scene/blocks/clamp.ts
+++ b/src/pillars/scene/blocks/clamp.ts
@@ -1,0 +1,21 @@
+/**
+ * src/pillars/scene/blocks/clamp.ts
+ *
+ * A scalar transform on a route: confine the incoming scalar to `[lo, hi]`. Folded
+ * from `… → Clamp → knob` into `max(lo, min(hi, upstream))` — the composed clamp,
+ * which is why the vocabulary gained `min`/`max` (not a bespoke `clamp` op).
+ * [LAW:one-type-per-behavior] one of three transform blocks (Scale/Offset/Clamp).
+ */
+
+import { clamp, konst } from '../../../render/scene-plan';
+import { defineScalarModifier, sceneConfig } from '../scene-block';
+
+export const ClampBlock = defineScalarModifier({
+  type: 'Clamp',
+  displayName: 'Clamp',
+  config: {
+    lo: sceneConfig.finiteNumber({ label: 'Min', control: 'number' }),
+    hi: sceneConfig.finiteNumber({ label: 'Max', control: 'number' }),
+  },
+  transform: (config, value) => clamp(value, konst(config.lo), konst(config.hi)),
+});

--- a/src/pillars/scene/blocks/clamp.ts
+++ b/src/pillars/scene/blocks/clamp.ts
@@ -17,5 +17,12 @@ export const ClampBlock = defineScalarModifier({
     lo: sceneConfig.finiteNumber({ label: 'Min', control: 'number' }),
     hi: sceneConfig.finiteNumber({ label: 'Max', control: 'number' }),
   },
+  // [LAW:no-silent-failure] With `lo > hi`, `max(lo, min(hi, x))` collapses to `lo`
+  //   for every input — the clamp silently destroys the signal. Reject the inverted
+  //   range at parse time so it surfaces as a diagnostic, never a dead constant.
+  validateConfig: (config) =>
+    config.lo <= config.hi
+      ? null
+      : `Min (${config.lo}) must be ≤ Max (${config.hi})`,
   transform: (config, value) => clamp(value, konst(config.lo), konst(config.hi)),
 });

--- a/src/pillars/scene/blocks/index.ts
+++ b/src/pillars/scene/blocks/index.ts
@@ -8,6 +8,9 @@
 import type { SceneBlockDefinition } from '../scene-block';
 import { ConstantBlock } from './constant';
 import { TimeBlock } from './time';
+import { ScaleBlock } from './scale';
+import { OffsetBlock } from './offset';
+import { ClampBlock } from './clamp';
 import { InstanceGridBlock } from './instance-grid';
 import { InstanceCountBlock } from './instance-count';
 import { RingLayoutBlock } from './ring-layout';
@@ -27,6 +30,9 @@ import { DrawInstancesBlock } from './draw-instances';
 export const ALL_SCENE_BLOCKS: readonly SceneBlockDefinition<unknown>[] = [
   ConstantBlock as SceneBlockDefinition<unknown>,
   TimeBlock as SceneBlockDefinition<unknown>,
+  ScaleBlock as SceneBlockDefinition<unknown>,
+  OffsetBlock as SceneBlockDefinition<unknown>,
+  ClampBlock as SceneBlockDefinition<unknown>,
   InstanceGridBlock as SceneBlockDefinition<unknown>,
   InstanceCountBlock as SceneBlockDefinition<unknown>,
   RingLayoutBlock as SceneBlockDefinition<unknown>,

--- a/src/pillars/scene/blocks/offset.ts
+++ b/src/pillars/scene/blocks/offset.ts
@@ -1,0 +1,20 @@
+/**
+ * src/pillars/scene/blocks/offset.ts
+ *
+ * A scalar transform on a route: add a constant amount to the incoming scalar —
+ * the `add` op of a per-cell transform chain in the Modulation Table. Folded from
+ * `… → Offset → knob` into `add(upstream, konst(amount))`.
+ * [LAW:one-type-per-behavior] one of three transform blocks (Scale/Offset/Clamp).
+ */
+
+import { add, konst } from '../../../render/scene-plan';
+import { defineScalarModifier, sceneConfig } from '../scene-block';
+
+export const OffsetBlock = defineScalarModifier({
+  type: 'Offset',
+  displayName: 'Offset',
+  config: {
+    amount: sceneConfig.finiteNumber({ label: 'Amount', control: 'number' }),
+  },
+  transform: (config, value) => add(value, konst(config.amount)),
+});

--- a/src/pillars/scene/blocks/scale.ts
+++ b/src/pillars/scene/blocks/scale.ts
@@ -1,0 +1,22 @@
+/**
+ * src/pillars/scene/blocks/scale.ts
+ *
+ * A scalar transform on a route: multiply the incoming scalar by a factor. It is
+ * the simplest scalar modifier — the `mul` half of a per-cell transform chain in
+ * the Modulation Table. Wired `Constant → Scale → knob`, the compiler folds it to
+ * `mul(konst(value), konst(factor))`; wired `Time → Scale → knob`, it scales the
+ * live clock. [LAW:one-type-per-behavior] one of three transform blocks (with
+ * Offset/Clamp) that differ only by their math.
+ */
+
+import { konst, mul } from '../../../render/scene-plan';
+import { defineScalarModifier, sceneConfig } from '../scene-block';
+
+export const ScaleBlock = defineScalarModifier({
+  type: 'Scale',
+  displayName: 'Scale',
+  config: {
+    factor: sceneConfig.finiteNumber({ label: 'Factor', control: 'number' }),
+  },
+  transform: (config, value) => mul(value, konst(config.factor)),
+});

--- a/src/pillars/scene/compile.ts
+++ b/src/pillars/scene/compile.ts
@@ -15,11 +15,11 @@
  *   swallowed.
  */
 
-import type { PlanExpr } from '../../render/scene-plan';
 import type { PillarPatch } from '../types';
 import { ALL_SCENE_BLOCKS } from './blocks';
 import {
   buildSceneRegistry,
+  type ScalarContribution,
   type SceneBlockDefinition,
   type SceneContribution,
   type SceneDiagnostic,
@@ -34,16 +34,27 @@ interface ParsedBlock {
 }
 
 /**
+ * A block that produces a scalar (a source or a scalar modifier). Both contribute
+ * without reading any resolved knob input, so both belong in pass 1 — before any
+ * consumer folds a scalar route. [LAW:one-type-per-behavior] the two roles get the
+ * same pass-1 treatment: contribute from config alone.
+ */
+function producesScalar(role: SceneBlockDefinition<unknown>['role']): boolean {
+  return role === 'scalarSource' || role === 'scalarModifier';
+}
+
+/**
  * Compile an authored patch to a ScenePlan. Contribution happens in two ordered
- * passes so a routable knob can read a live upstream scalar:
+ * passes so a routable knob can read a live upstream scalar route:
  *
- *  1. Scalar sources (Constant, Time) contribute first — they are leaves, so
- *     their `PlanExpr` values are known before anything reads them.
- *  2. Every other block resolves its knob inputs (a wired source's scalar, or the
- *     synthesized config default) and contributes with them.
+ *  1. Scalar blocks (Constant, Time, and scalar modifiers like Scale/Offset/
+ *     Clamp) contribute first — none reads a knob input, so each is complete
+ *     before anything folds a route through it.
+ *  2. Every other block resolves its knob inputs (a wired route's folded scalar,
+ *     or the synthesized config default) and contributes with them.
  *
- * [LAW:dataflow-not-control-flow] The two passes are the data dependency (sources
- *   before consumers), not a branch on block type at each step.
+ * [LAW:dataflow-not-control-flow] The two passes are the data dependency (scalar
+ *   producers before consumers), not a branch on block type at each step.
  */
 export function compileScenePlan(patch: PillarPatch): SceneCompileResult {
   const registry = buildSceneRegistry(ALL_SCENE_BLOCKS);
@@ -69,27 +80,37 @@ export function compileScenePlan(patch: PillarPatch): SceneCompileResult {
   }
 
   const contributions = new Map<string, SceneContribution>();
-  const scalarValues = new Map<string, PlanExpr>();
+  // The scalar route fold reads this map, fully populated by pass 1 and never
+  // mutated in pass 2 — a stable view so a knob's diagnostic never depends on
+  // block iteration order. [LAW:no-ambient-temporal-coupling]
+  const scalarProducers = new Map<string, ScalarContribution>();
+  const knownBlockIds = new Set(parsed.map((p) => p.blockId));
 
-  // Pass 1: scalar sources. They have no knob inputs, so an empty resolved-inputs
-  // record is complete; their value becomes available to every consumer below.
+  // Pass 1: scalar producers (sources + modifiers). None reads a knob input, so
+  // each contributes from config alone; the fold in pass 2 walks these to resolve
+  // any scalar route back to its source.
   for (const { blockId, def, config } of parsed) {
-    if (def.role !== 'scalarSource') continue;
+    if (!producesScalar(def.role)) continue;
     const contribution = def.contribute(config, {});
     contributions.set(blockId, contribution);
-    if (contribution.role === 'scalarSource') scalarValues.set(blockId, contribution.value);
+    // `producesScalar` guarantees the role, but only the runtime discriminant
+    // narrows the union to `ScalarContribution` for the typed producer map.
+    if (contribution.role === 'scalarSource' || contribution.role === 'scalarModifier') {
+      scalarProducers.set(blockId, contribution);
+    }
   }
 
-  // Pass 2: everything else, with knob inputs resolved against the scalar sources.
+  // Pass 2: everything else, with knob inputs resolved against the scalar routes.
   const errors: string[] = [];
   for (const { blockId, def, config } of parsed) {
-    if (def.role === 'scalarSource') continue;
+    if (producesScalar(def.role)) continue;
     const inputs = resolveKnobInputs(
       blockId,
       def.catalog.ports,
       config,
       patch.edges,
-      scalarValues,
+      scalarProducers,
+      knownBlockIds,
       errors,
     );
     contributions.set(blockId, def.contribute(config, inputs));

--- a/src/pillars/scene/scalar-inputs.ts
+++ b/src/pillars/scene/scalar-inputs.ts
@@ -5,38 +5,62 @@
  * modifier's `contribute` reads `inputs.x` with no wired/unwired branch of its
  * own. This module is the single owner of the "canonical default source" rule:
  * an unwired knob resolves to a `Constant` carrying its config value (a synthesized
- * default source), a wired knob resolves to the scalar value its source produced.
+ * default source), a wired knob resolves to the scalar its source route produced.
+ *
+ * A wired knob's route may pass through scalar *modifier* blocks (scale/offset/
+ * clamp) before reaching a source. `resolveScalar` folds that chain back to the
+ * source, exactly as `assemble.ts`'s `resolveBundle` folds an instance-modifier
+ * chain back to its instance source — one recursive walk, no per-block branch.
  *
  * [LAW:single-enforcer] The default-source rule lives here, once — every block's
  *   `contribute` consumes the resolved value and never re-derives the default.
  * [LAW:one-source-of-truth] The default's constant is read from config; it is not
  *   a second copy stored on the port or the patch.
+ * [LAW:dataflow-not-control-flow] The scalar route folds through a generic walk
+ *   over contributions; a scalar modifier is a value carrying `apply`, not a case.
  * [LAW:no-silent-failure] A knob wired to a source that produces no scalar is a
  *   surfaced diagnostic, not a silently-dropped route.
  */
 
 import { konst, type PlanExpr } from '../../render/scene-plan';
 import type { PillarEdge } from '../types';
-import type { ScenePortDeclaration } from './scene-block';
+import type { ScenePortDeclaration, ScalarContribution } from './scene-block';
 
 /**
  * Resolve every routable knob input port of one block to a scalar `PlanExpr`.
  * Non-knob ports (a required instance bundle) are not knobs and are skipped; they
  * are resolved as bundle edges by assembly, not here.
+ *
+ * `scalarProducers` holds exactly the blocks a scalar route can fold through
+ * (sources + scalar modifiers), fully populated before any knob resolves — so the
+ * fold reads a stable map, never one growing under it. `knownBlockIds` is every
+ * block in the patch, used to tell a real-but-non-scalar block ("not a scalar
+ * source") from a dangling reference ("unknown block") deterministically, without
+ * depending on which blocks have contributed yet. [LAW:no-ambient-temporal-coupling]
  */
 export function resolveKnobInputs(
   blockId: string,
   ports: readonly ScenePortDeclaration[],
   config: unknown,
   edges: readonly PillarEdge[],
-  scalarValues: ReadonlyMap<string, PlanExpr>,
+  scalarProducers: ReadonlyMap<string, ScalarContribution>,
+  knownBlockIds: ReadonlySet<string>,
   errors: string[],
 ): Record<string, PlanExpr> {
   const inputs: Record<string, PlanExpr> = {};
   for (const port of ports) {
     if (port.direction !== 'input') continue;
     if (port.default.kind !== 'configScalar') continue;
-    inputs[port.id] = resolveKnob(blockId, port, port.default.configKey, config, edges, scalarValues, errors);
+    inputs[port.id] = resolveKnob(
+      blockId,
+      port,
+      port.default.configKey,
+      config,
+      edges,
+      scalarProducers,
+      knownBlockIds,
+      errors,
+    );
   }
   return inputs;
 }
@@ -44,8 +68,9 @@ export function resolveKnobInputs(
 /**
  * The scalar value one knob resolves to. The wired/unwired distinction is genuine
  * graph state, decided here once: an unwired knob is its synthesized default
- * source `konst(config[configKey])`; a wired knob is the value its source
- * produced. Downstream (`contribute`) sees a single `PlanExpr` either way.
+ * source `konst(config[configKey])`; a wired knob is the scalar its route
+ * produced (folded through any scalar modifiers). Downstream (`contribute`) sees a
+ * single `PlanExpr` either way.
  */
 function resolveKnob(
   blockId: string,
@@ -53,23 +78,92 @@ function resolveKnob(
   configKey: string,
   config: unknown,
   edges: readonly PillarEdge[],
-  scalarValues: ReadonlyMap<string, PlanExpr>,
+  scalarProducers: ReadonlyMap<string, ScalarContribution>,
+  knownBlockIds: ReadonlySet<string>,
   errors: string[],
 ): PlanExpr {
   const edge = edges.find((e) => e.target === blockId && e.inputSlot === port.id);
   if (edge === undefined) {
     return konst(numberConfig(config, configKey, blockId, port.id));
   }
-  const value = scalarValues.get(edge.source);
-  if (value === undefined) {
-    errors.push(
-      `[scene] knob '${blockId}.${port.id}' is fed by '${edge.source}', which is not a scalar source`,
-    );
-    // Still resolve to the default so one bad wire yields one diagnostic, not a
-    // cascade of "missing input" errors from the rest of assembly.
+  const value = resolveScalar(edge.source, edges, scalarProducers, knownBlockIds, errors, new Set());
+  if (value === null) {
+    // `resolveScalar` already surfaced why the route produces no scalar. Fall to
+    // the default so one bad route yields one diagnostic, not a cascade of
+    // "missing input" errors from the rest of assembly.
     return konst(numberConfig(config, configKey, blockId, port.id));
   }
   return value;
+}
+
+/**
+ * Fold the scalar route feeding a knob (or another scalar modifier) back to its
+ * source. A `scalarSource` is the base case (its value); a `scalarModifier`
+ * resolves its own scalar input and applies its transform.
+ *
+ * A block absent from `scalarProducers` produces no scalar: if it is a real block
+ * in the patch it is an instance/draw block ending a scalar route illegally ("not
+ * a scalar source"); otherwise the route dangles ("unknown block"). Classifying
+ * via `knownBlockIds` — not via which blocks happen to have contributed yet —
+ * keeps the diagnostic deterministic. [LAW:no-ambient-temporal-coupling]
+ *
+ * [LAW:dataflow-not-control-flow] One generic fold: a scalar modifier is a value
+ *   carrying `apply`, not a per-type branch — adding a transform block adds no
+ *   code path here, exactly as with `resolveBundle`.
+ * [LAW:no-silent-failure] A chain that dangles, cycles, or bottoms out at a
+ *   non-scalar block is a surfaced error, never a silently-dropped route.
+ */
+function resolveScalar(
+  blockId: string,
+  edges: readonly PillarEdge[],
+  scalarProducers: ReadonlyMap<string, ScalarContribution>,
+  knownBlockIds: ReadonlySet<string>,
+  errors: string[],
+  visiting: ReadonlySet<string>,
+): PlanExpr | null {
+  if (visiting.has(blockId)) {
+    errors.push(`[scene] scalar route has a cycle through block '${blockId}'`);
+    return null;
+  }
+  const contribution = scalarProducers.get(blockId);
+  if (contribution === undefined) {
+    errors.push(
+      knownBlockIds.has(blockId)
+        ? `[scene] block '${blockId}' is not a scalar source`
+        : `[scene] scalar route references unknown block '${blockId}'`,
+    );
+    return null;
+  }
+
+  switch (contribution.role) {
+    case 'scalarSource':
+      return contribution.value;
+    case 'scalarModifier': {
+      const inputEdge = edges.find(
+        (e) => e.target === blockId && e.inputSlot === contribution.input,
+      );
+      if (!inputEdge) {
+        errors.push(`[scene] scalar modifier '${blockId}' has no input edge`);
+        return null;
+      }
+      const upstream = resolveScalar(
+        inputEdge.source,
+        edges,
+        scalarProducers,
+        knownBlockIds,
+        errors,
+        new Set(visiting).add(blockId),
+      );
+      if (upstream === null) return null;
+      return contribution.apply(upstream);
+    }
+    default:
+      return assertNever(contribution);
+  }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`[scene] unhandled scalar contribution: ${JSON.stringify(value)}`);
 }
 
 /**

--- a/src/pillars/scene/scene-block.ts
+++ b/src/pillars/scene/scene-block.ts
@@ -53,18 +53,45 @@ export type BundleTransform = (input: InstanceBundle) => InstanceBundle;
  * - `scalarSource` carries a single scalar `PlanExpr` a routable knob reads in
  *   place of its config default (a Constant is `konst(value)`, a clock is
  *   `input('time')`). It never feeds an instance chain — only a knob input port.
+ * - `scalarModifier` carries a scalar *transform* (`PlanExpr → PlanExpr`) and the
+ *   id of the scalar input port it reads. It is to a scalar route what `modifier`
+ *   is to an instance bundle: `scale`/`offset`/`clamp` fold onto the routed scalar
+ *   the same way `WaveOffset` folds onto a bundle — resolution walks the chain
+ *   back to its `scalarSource`, applying each transform (see `resolveScalar`).
  *
  * [LAW:dataflow-not-control-flow] A modifier's behavior is the `apply` *value*,
  *   not a branch in assembly: folding the modifier chain is one generic walk, so
  *   adding a modifier adds no assembly code path.
+ * [LAW:one-type-per-behavior] A scalar transform (scale/offset/clamp) is a
+ *   scalar→scalar function, i.e. a block — not a bag of ops on the edge. It is the
+ *   scalar sibling of `modifier`, resolved by the same kind of fold.
  */
 export type SceneContribution =
   | { readonly role: 'instanceSource'; readonly bundle: InstanceBundle }
   | { readonly role: 'modifier'; readonly apply: BundleTransform }
   | { readonly role: 'draw'; readonly shell: DrawShell }
-  | { readonly role: 'scalarSource'; readonly value: PlanExpr };
+  | { readonly role: 'scalarSource'; readonly value: PlanExpr }
+  | {
+      readonly role: 'scalarModifier';
+      /** The scalar input port whose upstream route this modifier transforms. */
+      readonly input: string;
+      /** Fold this modifier's transform onto the resolved upstream scalar. */
+      readonly apply: (value: PlanExpr) => PlanExpr;
+    };
 
 export type SceneContributionRole = SceneContribution['role'];
+
+/**
+ * A contribution that yields a scalar `PlanExpr` — the only kinds a scalar route
+ * can be folded through. Naming this subset lets the fold's producer map hold
+ * exactly these two roles, so `resolveScalar` never has to defend against an
+ * instance/draw contribution appearing where a scalar is expected.
+ * [LAW:types-are-the-program]
+ */
+export type ScalarContribution = Extract<
+  SceneContribution,
+  { readonly role: 'scalarSource' | 'scalarModifier' }
+>;
 
 export type SceneValueKind =
   | 'instanceBundle'
@@ -126,7 +153,11 @@ export type SceneBlockCategory =
   | 'asset'
   | 'color'
   // A scalar signal source (Constant, Time) — produces one routable scalar value.
-  | 'signal';
+  | 'signal'
+  // A scalar→scalar transform (Scale, Offset, Clamp) that lives *on a route*
+  // between a signal source and a knob. The Modulation Table reads this category
+  // to keep transforms out of its grid (route-internal), never a name heuristic.
+  | 'transform';
 
 export type SceneConfigControl =
   | 'number'
@@ -317,6 +348,70 @@ export function defineSceneBlock<
       TRole
     >['contribute'],
   };
+}
+
+/**
+ * The scalar input / output port ids every scalar modifier shares. Owned here so
+ * `defineScalarModifier` and the route fold (`resolveScalar` reads the port id off
+ * the contribution) agree on one name, never a string repeated per block.
+ * [LAW:one-source-of-truth]
+ */
+export const SCALAR_MODIFIER_INPUT = 'in';
+export const SCALAR_MODIFIER_OUTPUT = 'out';
+
+/**
+ * A scalar→scalar transform block: one scalar `in`, one scalar `out`, and config
+ * for its parameters (`scale`'s factor, `clamp`'s bounds). It declares the whole
+ * block from just its math — the standard in/out ports and the `transform`
+ * category are supplied here, so a new transform is a `transform:` function and a
+ * config shape, nothing else.
+ *
+ * The parameters are plain config, NOT knobs: a scalar modifier has exactly one
+ * scalar input (the value it transforms), mirroring a bundle modifier's single
+ * `primary`. That keeps the route fold unambiguous — one upstream edge to follow.
+ *
+ * [LAW:one-type-per-behavior] scale/offset/clamp differ only by their `transform`;
+ *   they are instances of one block shape, not three bespoke definitions.
+ * [LAW:effects-at-boundaries] `transform` composes `PlanExpr` trees (a
+ *   description), it never evaluates them.
+ */
+export interface ScalarModifierDeclaration<TFields extends SceneConfigFields> {
+  readonly type: string;
+  readonly displayName: string;
+  readonly config: TFields;
+  readonly transform: (config: SceneConfigFor<TFields>, value: PlanExpr) => PlanExpr;
+}
+
+export function defineScalarModifier<const TFields extends SceneConfigFields>(
+  declaration: ScalarModifierDeclaration<TFields>,
+): SceneBlockDefinition<SceneConfigFor<TFields>, 'scalarModifier'> {
+  return defineSceneBlock({
+    type: declaration.type,
+    role: 'scalarModifier',
+    catalog: {
+      displayName: declaration.displayName,
+      category: 'transform',
+      ports: [
+        {
+          id: SCALAR_MODIFIER_INPUT,
+          label: 'In',
+          direction: 'input',
+          value: 'scalar',
+          default: { kind: 'required' },
+        },
+        { id: SCALAR_MODIFIER_OUTPUT, label: 'Out', direction: 'output', value: 'scalar' },
+      ],
+    },
+    config: declaration.config,
+    // No knobs: the transform's parameters are plain config, so the block has one
+    // scalar input (the value chain) and the route fold has one edge to follow.
+    knobs: {},
+    contribute: (config) => ({
+      role: 'scalarModifier',
+      input: SCALAR_MODIFIER_INPUT,
+      apply: (value) => declaration.transform(config, value),
+    }),
+  });
 }
 
 function configShape<TFields extends SceneConfigFields>(

--- a/src/pillars/scene/scene-block.ts
+++ b/src/pillars/scene/scene-block.ts
@@ -268,6 +268,15 @@ export interface SceneBlockDeclaration<
   readonly config: TFields;
   /** Routable scalar knobs; omit for a block with no routable parameters. */
   readonly knobs?: TKnobs;
+  /**
+   * A cross-field invariant on the parsed config, returning a diagnostic message
+   * when violated or `null` when valid. Per-field constraints belong on the field
+   * schemas; this is for relationships between fields (e.g. Clamp's `lo <= hi`) that
+   * no single field can express. It runs as part of config parsing, so a violation
+   * surfaces as a loud config diagnostic — never a value silently compiled into a
+   * degenerate result. [LAW:no-silent-failure] [LAW:types-are-the-program]
+   */
+  readonly validateConfig?: (config: SceneConfigFor<TFields> & KnobConfigFor<TKnobs>) => string | null;
   readonly contribute: (
     config: SceneConfigFor<TFields> & KnobConfigFor<TKnobs>,
     inputs: KnobInputsFor<TKnobs>,
@@ -293,10 +302,23 @@ export function defineSceneBlock<
   const knobSchema = Object.fromEntries(
     Object.entries(knobs).map(([key, knob]) => [key, z.number().finite().default(knob.default)]),
   );
-  const configSchema = z.object({
+  const baseSchema = z.object({
     ...configShape(declaration.config),
     ...knobSchema,
-  }) as z.ZodType<SceneConfigFor<TFields> & KnobConfigFor<TKnobs>>;
+  });
+  const { validateConfig } = declaration;
+  // A cross-field invariant runs as a refinement, so its violation is one more
+  // config issue on the same parse path — surfaced, not silently compiled through.
+  // [LAW:single-enforcer] config validity has one gate (readConfig's parse).
+  const refinedSchema = validateConfig
+    ? baseSchema.superRefine((val, ctx) => {
+        const message = validateConfig(val as SceneConfigFor<TFields> & KnobConfigFor<TKnobs>);
+        if (message !== null) ctx.addIssue({ code: 'custom', message });
+      })
+    : baseSchema;
+  const configSchema = refinedSchema as unknown as z.ZodType<
+    SceneConfigFor<TFields> & KnobConfigFor<TKnobs>
+  >;
 
   const knobPorts: ScenePortDeclaration[] = Object.entries(knobs).map(([key, knob]) => ({
     id: key,
@@ -379,13 +401,23 @@ export interface ScalarModifierDeclaration<TFields extends SceneConfigFields> {
   readonly type: string;
   readonly displayName: string;
   readonly config: TFields;
+  /**
+   * A cross-field invariant on the parsed config (e.g. Clamp's `lo <= hi`),
+   * returning a diagnostic message when violated. Surfaces through the same config
+   * parse gate as any other config error. [LAW:no-silent-failure]
+   */
+  readonly validateConfig?: (config: SceneConfigFor<TFields>) => string | null;
   readonly transform: (config: SceneConfigFor<TFields>, value: PlanExpr) => PlanExpr;
 }
 
 export function defineScalarModifier<const TFields extends SceneConfigFields>(
   declaration: ScalarModifierDeclaration<TFields>,
 ): SceneBlockDefinition<SceneConfigFor<TFields>, 'scalarModifier'> {
-  return defineSceneBlock({
+  // Pin the knobs generic to the empty shape: a scalar modifier never has knobs, and
+  // the `validateConfig` parameter would otherwise widen `TKnobs` by contravariant
+  // inference. With no knobs, `SceneConfigFor<TFields> & KnobConfigFor<{}>` reduces
+  // to `SceneConfigFor<TFields>`, matching the declared return type.
+  return defineSceneBlock<TFields, Record<never, never>, 'scalarModifier'>({
     type: declaration.type,
     role: 'scalarModifier',
     catalog: {
@@ -406,6 +438,7 @@ export function defineScalarModifier<const TFields extends SceneConfigFields>(
     // No knobs: the transform's parameters are plain config, so the block has one
     // scalar input (the value chain) and the route fold has one edge to follow.
     knobs: {},
+    validateConfig: declaration.validateConfig,
     contribute: (config) => ({
       role: 'scalarModifier',
       input: SCALAR_MODIFIER_INPUT,

--- a/src/render/scene-plan/__tests__/capability-matrix.test.ts
+++ b/src/render/scene-plan/__tests__/capability-matrix.test.ts
@@ -47,6 +47,7 @@ import {
   div,
   mod,
   step,
+  clamp,
   type PlanExpr,
   type PlanUnaryOp,
   type PlanBinaryOp,
@@ -105,8 +106,9 @@ function buildCapabilityCoveragePlan(): ScenePlan {
     // unary: sin, cos
     positionX: sin(rank),
     positionY: cos(rank),
-    // unary: fract (fractional part of a ramp), hash (pseudo-random from the index)
-    rotation: add(fract(mul(rank, konst(3))), hash(index)),
+    // unary: fract (fractional part of a ramp), hash (pseudo-random from the index);
+    // binary: min, max via clamp (the ramp confined to [0.2, 0.8]).
+    rotation: clamp(add(fract(mul(rank, konst(3))), hash(index)), konst(0.2), konst(0.8)),
   };
 
   return defineScenePlan({
@@ -277,7 +279,7 @@ describe('ScenePlan capability matrix — representative coverage', () => {
     const { kinds, unary, binary } = collectExprVocabulary(plan);
     expect(kinds).toEqual(new Set(['const', 'input', 'intrinsic', 'unary', 'binary']));
     expect(unary).toEqual(new Set<PlanUnaryOp>(['floor', 'sin', 'cos', 'negate', 'fract', 'hash']));
-    expect(binary).toEqual(new Set<PlanBinaryOp>(['add', 'sub', 'mul', 'div', 'mod', 'step']));
+    expect(binary).toEqual(new Set<PlanBinaryOp>(['add', 'sub', 'mul', 'div', 'mod', 'step', 'min', 'max']));
   });
 
   it('frames with an orthographic camera and draws to the preview canvas', () => {

--- a/src/render/scene-plan/expr.ts
+++ b/src/render/scene-plan/expr.ts
@@ -75,8 +75,13 @@ export type PlanUnaryOp = 'floor' | 'sin' | 'cos' | 'negate' | 'fract' | 'hash';
  * binding" claim is unrepresentable without it, and a smooth fade would be a
  * dishonest stand-in. [LAW:no-mode-explosion] One operator, every consumer kept
  * exhaustive; no flag selects "threshold mode".
+ *
+ * `min`/`max` are the range primitives: they are what a `clamp` scalar modifier
+ * lowers to — `clamp(x, lo, hi)` is `max(lo, min(hi, x))`. A clamp is not a new
+ * operator; it composes from these two, so the vocabulary gains the primitives,
+ * not the convenience. [LAW:no-mode-explosion]
  */
-export type PlanBinaryOp = 'add' | 'sub' | 'mul' | 'div' | 'mod' | 'step';
+export type PlanBinaryOp = 'add' | 'sub' | 'mul' | 'div' | 'mod' | 'step' | 'min' | 'max';
 
 /**
  * A backend-neutral scalar expression.
@@ -127,3 +132,15 @@ export const div = binary('div');
 export const mod = binary('mod');
 /** `step(edge, x)` → `1` when `x >= edge`, else `0`. */
 export const step = binary('step');
+/** `min(a, b)` → the lesser of the two operands. */
+export const min = binary('min');
+/** `max(a, b)` → the greater of the two operands. */
+export const max = binary('max');
+
+/**
+ * `clamp(x, lo, hi)` → `x` confined to `[lo, hi]`, composed from `min`/`max` so
+ * it adds no operator to {@link PlanBinaryOp}. This is the exact expression a
+ * `Clamp` scalar modifier lowers to; keeping it a builder means both the block
+ * and any hand-written plan denote the clamp one way. [LAW:one-source-of-truth]
+ */
+export const clamp = (x: PlanExpr, lo: PlanExpr, hi: PlanExpr): PlanExpr => max(lo, min(hi, x));

--- a/src/render/scene-plan/index.ts
+++ b/src/render/scene-plan/index.ts
@@ -53,6 +53,9 @@ export {
   div,
   mod,
   step,
+  min,
+  max,
+  clamp,
 } from './expr';
 
 // Plan structure.

--- a/src/render/webgpu/three/plan-expr-tsl.ts
+++ b/src/render/webgpu/three/plan-expr-tsl.ts
@@ -25,7 +25,7 @@
  */
 
 import type { Node } from 'three/webgpu';
-import { add, cos, div, floor, fract, hash, instanceIndex, mod, mul, negate, sin, step, sub, float } from 'three/tsl';
+import { add, cos, div, floor, fract, hash, instanceIndex, max, min, mod, mul, negate, sin, step, sub, float } from 'three/tsl';
 
 import type {
   PlanBinaryOp,
@@ -82,6 +82,8 @@ const BINARY_OPS: Record<PlanBinaryOp, (lhs: TSLNode, rhs: TSLNode) => TSLNode> 
   mod: (lhs, rhs) => mod(lhs, rhs),
   // TSL `step(edge, x)` → 1 when x >= edge, else 0; lhs is the edge.
   step: (lhs, rhs) => step(lhs, rhs),
+  min: (lhs, rhs) => min(lhs, rhs),
+  max: (lhs, rhs) => max(lhs, rhs),
 };
 
 function intrinsicToTSL(name: PlanIntrinsic, ctx: PlanExprContext): TSLNode {

--- a/src/ui/nativeEditor/ModulationTablePanel.tsx
+++ b/src/ui/nativeEditor/ModulationTablePanel.tsx
@@ -408,9 +408,7 @@ const ChainEditor: React.FC<{
             style={styles.removeBtn as React.CSSProperties}
             title="Remove this transform"
             data-testid={`mod-remove-${transform.blockId}`}
-            onClick={() =>
-              applyAction(store, removeTransformAction(route, row, store.registry, index))
-            }
+            onClick={() => applyAction(store, removeTransformAction(route, row, index))}
           >
             ×
           </button>

--- a/src/ui/nativeEditor/ModulationTablePanel.tsx
+++ b/src/ui/nativeEditor/ModulationTablePanel.tsx
@@ -207,11 +207,15 @@ function applyAction(store: PillarPatchStore, action: ModulationAction): void {
       store.removeEdge(action.inputEdgeId);
       return;
     case 'appendTransform': {
-      const newId = store.addBlock(action.transformType);
+      // Resolve the precondition before any mutation: a null sole-input slot (an
+      // impossible state defineScalarModifier prevents) must throw before addBlock,
+      // never after — a failed precondition leaves the store untouched.
+      // [LAW:effects-at-boundaries]
       const inSlot = soleInputPortId(store.registry, action.transformType);
       if (inSlot === null) {
         throw new Error(`[modulation-table] transform '${action.transformType}' has no sole input port`);
       }
+      const newId = store.addBlock(action.transformType);
       store.addEdge(action.upstreamBlockId, newId, inSlot); // upstream → newTransform.in
       store.addEdge(newId, action.target, action.inputSlot); // newTransform.out → input (replaces feeder)
       return;

--- a/src/ui/nativeEditor/ModulationTablePanel.tsx
+++ b/src/ui/nativeEditor/ModulationTablePanel.tsx
@@ -2,16 +2,24 @@
  * src/ui/nativeEditor/ModulationTablePanel.tsx
  *
  * The Modulation Table: a spreadsheet-style projection of all patch routing. Rows
- * are input ports, columns are output ports, and each cell is the connection at
- * that crossing. Clicking a cell connects, disconnects, or retargets — mutating
- * the SAME `PillarPatchStore` the graph canvas edits, so the two views stay in
- * lockstep by construction (one patch, two views).
+ * are input ports, columns are output ports, and each cell is the ROUTE at that
+ * crossing. Clicking a cell connects, disconnects, or retargets — mutating the SAME
+ * `PillarPatchStore` the graph canvas edits, so the two views stay in lockstep by
+ * construction (one patch, two views).
+ *
+ * A route may pass through transform blocks (Scale/Offset/Clamp). Those are
+ * route-internal: they never appear as their own row or column. Instead an occupied
+ * cell carries a compact chain editor (the `ƒ` affordance) that inserts, removes,
+ * and retunes the transforms along the route — each edit is an ordinary graph
+ * mutation on the store. The chain editor is a SEPARATE affordance from the primary
+ * cell click, which stays connect/disconnect for the route itself.
  *
  * [LAW:one-way-deps] Reads/writes `PillarPatchStore` through the pure model in
  *   `modulationTable.ts`; it touches no renderer and no Three object.
- * [LAW:effects-at-boundaries] The grid and per-cell action are computed purely;
- *   this component only performs the resolved action against the store.
- * [LAW:dataflow-not-control-flow] Each cell renders from its (edge, connectable)
+ * [LAW:effects-at-boundaries] The grid, per-cell action, and per-edit action are
+ *   computed purely; this component only performs the resolved action against the
+ *   store.
+ * [LAW:dataflow-not-control-flow] Each cell renders from its (route, connectable)
  *   value through one presentation map — no per-block-type branching.
  */
 
@@ -21,11 +29,17 @@ import { observer } from 'mobx-react-lite';
 import { useStores } from '../../stores';
 import type { PillarPatchStore } from '../../stores/PillarPatchStore';
 import {
+  appendTransformAction,
   buildModulationTable,
   cellAction,
+  removeTransformAction,
+  setTransformConfigAction,
+  soleInputPortId,
+  transformPalette,
   type ModulationAction,
   type ModulationCell,
   type ModulationPortRef,
+  type ModulationRoute,
 } from './modulationTable';
 
 const styles = {
@@ -73,7 +87,8 @@ const styles = {
   },
   rowPort: { color: '#7a7a95', fontSize: 10 },
   cell: {
-    width: 36,
+    position: 'relative',
+    width: 40,
     height: 30,
     textAlign: 'center',
     verticalAlign: 'middle',
@@ -95,23 +110,131 @@ const styles = {
     background: '#0c0c14',
     cursor: 'default',
   },
+  // The `ƒ` chain-editor affordance in the corner of an occupied cell.
+  fxBadge: {
+    position: 'absolute',
+    top: 1,
+    right: 2,
+    fontSize: 9,
+    lineHeight: '10px',
+    padding: '0 3px',
+    borderRadius: 4,
+    background: '#2a3a48',
+    color: '#5bc0be',
+    cursor: 'pointer',
+    border: '1px solid #38505e',
+  },
+  fxBadgeActive: { background: '#5bc0be', color: '#0f0f17' },
+  popover: {
+    position: 'absolute',
+    top: 30,
+    right: 0,
+    zIndex: 10,
+    minWidth: 200,
+    padding: 10,
+    background: '#151521',
+    border: '1px solid #38505e',
+    borderRadius: 6,
+    boxShadow: '0 6px 18px rgba(0,0,0,0.5)',
+    textAlign: 'left',
+    cursor: 'default',
+  },
+  popTitle: { color: '#8a8aa0', fontSize: 10, marginBottom: 8 },
+  chainItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+    padding: '4px 0',
+    borderTop: '1px solid #23233400',
+  },
+  chainName: { color: '#5bc0be', fontSize: 11, minWidth: 46 },
+  fieldLabel: { color: '#7a7a95', fontSize: 10 },
+  numberInput: {
+    width: 46,
+    background: '#0c0c14',
+    color: '#e6e6ef',
+    border: '1px solid #2a2a38',
+    borderRadius: 3,
+    fontSize: 11,
+    padding: '2px 4px',
+  },
+  removeBtn: {
+    marginLeft: 'auto',
+    color: '#c46',
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: 13,
+  },
+  addRow: { display: 'flex', gap: 4, marginTop: 8, flexWrap: 'wrap' },
+  addBtn: {
+    fontSize: 10,
+    padding: '2px 6px',
+    borderRadius: 4,
+    background: '#1c2a24',
+    color: '#6fcf97',
+    border: '1px solid #2a3a30',
+    cursor: 'pointer',
+  },
+  disconnectBtn: {
+    marginTop: 8,
+    width: '100%',
+    fontSize: 10,
+    padding: '3px 6px',
+    borderRadius: 4,
+    background: '#2a1414',
+    color: '#e08a8a',
+    border: '1px solid #3a2020',
+    cursor: 'pointer',
+  },
 } as const;
 
-/** Apply a resolved cell action to the store. The one effectful step. */
+/**
+ * Apply a resolved action to the store — the one effectful step. Each kind composes
+ * the store's block/edge CRUD; the model decided *what*, this performs it.
+ */
 function applyAction(store: PillarPatchStore, action: ModulationAction): void {
   switch (action.kind) {
     case 'connect':
       store.addEdge(action.source, action.target, action.inputSlot);
       return;
     case 'disconnect':
-      store.removeEdge(action.edgeId);
+      // Remove the transform blocks (each cascades its edges) and the input edge.
+      for (const id of action.transformBlockIds) store.removeBlock(id);
+      store.removeEdge(action.inputEdgeId);
+      return;
+    case 'appendTransform': {
+      const newId = store.addBlock(action.transformType);
+      const inSlot = soleInputPortId(store.registry, action.transformType);
+      if (inSlot === null) {
+        throw new Error(`[modulation-table] transform '${action.transformType}' has no sole input port`);
+      }
+      store.addEdge(action.upstreamBlockId, newId, inSlot); // upstream → newTransform.in
+      store.addEdge(newId, action.target, action.inputSlot); // newTransform.out → input (replaces feeder)
+      return;
+    }
+    case 'removeTransform':
+      // Bridge upstream → downstream (replaces the transform's downstream feeder),
+      // then drop the transform block (cascades its now-dangling upstream edge).
+      store.addEdge(action.upstreamBlockId, action.downstreamTarget, action.downstreamInputSlot);
+      store.removeBlock(action.blockId);
+      return;
+    case 'setTransformConfig':
+      store.updateConfig(action.blockId, action.key, action.value);
       return;
   }
+}
+
+/** Which cell's chain editor is open, by grid position. */
+interface OpenEditor {
+  readonly rowIndex: number;
+  readonly colIndex: number;
 }
 
 export const ModulationTablePanel: React.FC = observer(() => {
   const { pillarPatch } = useStores();
   const model = buildModulationTable(pillarPatch.patch, pillarPatch.registry);
+  const [openEditor, setOpenEditor] = React.useState<OpenEditor | null>(null);
 
   if (model.rows.length === 0 || model.columns.length === 0) {
     return (
@@ -126,7 +249,8 @@ export const ModulationTablePanel: React.FC = observer(() => {
   return (
     <div style={styles.panel as React.CSSProperties} data-testid="modulation-table">
       <div style={styles.intro as React.CSSProperties}>
-        Rows are inputs, columns are outputs. Click a cell to connect, disconnect, or retarget.
+        Rows are inputs, columns are outputs. Click a cell to connect or disconnect; use ƒ on a
+        connected cell to insert scale / offset / clamp transforms along the route.
       </div>
       <table style={styles.table as React.CSSProperties}>
         <thead>
@@ -154,6 +278,14 @@ export const ModulationTablePanel: React.FC = observer(() => {
                   row={row}
                   column={column}
                   store={pillarPatch}
+                  editorOpen={openEditor?.rowIndex === rowIndex && openEditor?.colIndex === colIndex}
+                  onToggleEditor={() =>
+                    setOpenEditor((cur) =>
+                      cur?.rowIndex === rowIndex && cur?.colIndex === colIndex
+                        ? null
+                        : { rowIndex, colIndex },
+                    )
+                  }
                 />
               ))}
             </tr>
@@ -169,9 +301,12 @@ const CellView: React.FC<{
   row: ModulationPortRef;
   column: ModulationPortRef;
   store: PillarPatchStore;
-}> = ({ cell, row, column, store }) => {
+  editorOpen: boolean;
+  onToggleEditor: () => void;
+}> = ({ cell, row, column, store, editorOpen, onToggleEditor }) => {
   const action = cellAction(cell, row, column);
-  const connected = cell.edge !== null;
+  const connected = cell.route !== null;
+  const chainLength = cell.route?.transforms.length ?? 0;
   const stateStyle = connected
     ? styles.cellConnected
     : action !== null
@@ -184,9 +319,12 @@ const CellView: React.FC<{
       style={{ ...styles.cell, ...stateStyle } as React.CSSProperties}
       data-testid={`mod-cell-${row.blockId}:${row.portId}--${column.blockId}`}
       data-connected={connected}
+      data-chain-length={chainLength}
       title={
         connected
-          ? `${column.blockLabel} → ${row.blockLabel}.${row.portLabel} (click to disconnect)`
+          ? `${column.blockLabel} → ${row.blockLabel}.${row.portLabel}` +
+            (chainLength > 0 ? ` (via ${chainLength} transform${chainLength > 1 ? 's' : ''})` : '') +
+            ' — click to disconnect'
           : action !== null
             ? `Connect ${column.blockLabel} → ${row.blockLabel}.${row.portLabel}`
             : 'Incompatible'
@@ -194,6 +332,118 @@ const CellView: React.FC<{
       onClick={action === null ? undefined : () => applyAction(store, action)}
     >
       {glyph}
+      {connected && cell.route !== null && (
+        <span
+          style={
+            {
+              ...styles.fxBadge,
+              ...(editorOpen ? styles.fxBadgeActive : {}),
+            } as React.CSSProperties
+          }
+          data-testid={`mod-fx-${row.blockId}:${row.portId}--${column.blockId}`}
+          title="Edit transform chain"
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleEditor();
+          }}
+        >
+          {chainLength > 0 ? `ƒ${chainLength}` : 'ƒ'}
+        </span>
+      )}
+      {editorOpen && cell.route !== null && (
+        <ChainEditor route={cell.route} row={row} store={store} onClose={onToggleEditor} />
+      )}
     </td>
+  );
+};
+
+/**
+ * The compact in-cell chain editor: the transforms along a route, each with its
+ * editable parameters and a remove control, plus a palette to append more and a
+ * button to disconnect the whole route. Every control resolves to a pure
+ * `ModulationAction` applied against the store.
+ */
+const ChainEditor: React.FC<{
+  route: ModulationRoute;
+  row: ModulationPortRef;
+  store: PillarPatchStore;
+  onClose: () => void;
+}> = ({ route, row, store, onClose }) => {
+  const palette = transformPalette(store.registry);
+  return (
+    <div
+      style={styles.popover as React.CSSProperties}
+      data-testid={`mod-chain-${row.blockId}:${row.portId}`}
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div style={styles.popTitle as React.CSSProperties}>Transform chain (source → input)</div>
+
+      {route.transforms.length === 0 && (
+        <div style={{ color: '#6f6f88', fontSize: 10 } as React.CSSProperties}>
+          Direct route — add a transform below.
+        </div>
+      )}
+
+      {route.transforms.map((transform, index) => (
+        <div key={transform.blockId} style={styles.chainItem as React.CSSProperties}>
+          <span style={styles.chainName as React.CSSProperties}>{transform.displayName}</span>
+          {transform.fields.map((field) => (
+            <label key={field.key} style={styles.fieldLabel as React.CSSProperties}>
+              {field.label}{' '}
+              <input
+                style={styles.numberInput as React.CSSProperties}
+                type="number"
+                value={typeof field.value === 'number' ? field.value : ''}
+                data-testid={`mod-field-${transform.blockId}-${field.key}`}
+                onChange={(e) =>
+                  applyAction(
+                    store,
+                    setTransformConfigAction(transform.blockId, field.key, e.target.valueAsNumber),
+                  )
+                }
+              />
+            </label>
+          ))}
+          <button
+            style={styles.removeBtn as React.CSSProperties}
+            title="Remove this transform"
+            data-testid={`mod-remove-${transform.blockId}`}
+            onClick={() =>
+              applyAction(store, removeTransformAction(route, row, store.registry, index))
+            }
+          >
+            ×
+          </button>
+        </div>
+      ))}
+
+      <div style={styles.addRow as React.CSSProperties}>
+        {palette.map((entry) => (
+          <button
+            key={entry.type}
+            style={styles.addBtn as React.CSSProperties}
+            data-testid={`mod-add-${entry.type}`}
+            onClick={() => applyAction(store, appendTransformAction(route, row, entry.type))}
+          >
+            + {entry.displayName}
+          </button>
+        ))}
+      </div>
+
+      <button
+        style={styles.disconnectBtn as React.CSSProperties}
+        data-testid={`mod-disconnect-${row.blockId}:${row.portId}`}
+        onClick={() => {
+          applyAction(store, {
+            kind: 'disconnect',
+            inputEdgeId: route.inputEdgeId,
+            transformBlockIds: route.transforms.map((t) => t.blockId),
+          });
+          onClose();
+        }}
+      >
+        Disconnect route
+      </button>
+    </div>
   );
 };

--- a/src/ui/nativeEditor/ModulationTablePanel.tsx
+++ b/src/ui/nativeEditor/ModulationTablePanel.tsx
@@ -196,6 +196,9 @@ const styles = {
 function applyAction(store: PillarPatchStore, action: ModulationAction): void {
   switch (action.kind) {
     case 'connect':
+      // Tear down the route this connect replaces (its transforms + their edges)
+      // before wiring the new source, so a retarget leaves no orphaned chain.
+      for (const id of action.replacedTransformBlockIds) store.removeBlock(id);
       store.addEdge(action.source, action.target, action.inputSlot);
       return;
     case 'disconnect':

--- a/src/ui/nativeEditor/ModulationTablePanel.tsx
+++ b/src/ui/nativeEditor/ModulationTablePanel.tsx
@@ -393,7 +393,11 @@ const ChainEditor: React.FC<{
               <input
                 style={styles.numberInput as React.CSSProperties}
                 type="number"
-                value={typeof field.value === 'number' ? field.value : ''}
+                // A cleared/partial number input yields NaN (which is `typeof
+                // 'number'`); Number.isFinite keeps the field blank rather than
+                // rendering NaN, matching the field's `.finite()` schema. The
+                // transient invalid value is still caught loudly by zod at compile.
+                value={typeof field.value === 'number' && Number.isFinite(field.value) ? field.value : ''}
                 data-testid={`mod-field-${transform.blockId}-${field.key}`}
                 onChange={(e) =>
                   applyAction(

--- a/src/ui/nativeEditor/SceneBlockNode.tsx
+++ b/src/ui/nativeEditor/SceneBlockNode.tsx
@@ -59,6 +59,9 @@ const CATEGORY_ACCENT: Record<SceneBlockCategory, string> = {
   asset: '#d9a441',
   color: '#d65db1',
   signal: '#7dcf5b',
+  // A scalar→scalar transform on a route (Scale/Offset/Clamp) — a scalar sibling
+  // of `modifier`, so it takes a related-but-distinct teal from modifier's blue.
+  transform: '#5bc0be',
 };
 
 const VALUE_KIND_COLOR: Record<SceneValueKind, string> = {

--- a/src/ui/nativeEditor/__tests__/ModulationTablePanel.test.tsx
+++ b/src/ui/nativeEditor/__tests__/ModulationTablePanel.test.tsx
@@ -98,3 +98,95 @@ describe('ModulationTablePanel', () => {
     expect(readComputed(() => store.pillarPatch.patch.edges.length)).toBe(before);
   });
 });
+
+describe('ModulationTablePanel — in-cell transform chain editor', () => {
+  /**
+   * Seed a COMPLETE renderable patch (grid → WaveOffset → draw) plus a direct
+   * Constant → WaveOffset.amplitude scalar route — so compilation is `ok` and
+   * inserting a transform on the route is a real round-trip, not a plan with a
+   * missing draw.
+   */
+  function seedScalarRoute() {
+    localStorageMock.clear();
+    store = new RootStore();
+    const patch = store.pillarPatch;
+    for (const edge of [...patch.patch.edges]) patch.removeEdge(edge.id);
+    for (const block of [...patch.patch.blocks]) patch.removeBlock(block.id);
+    const gridId = patch.addBlock('InstanceGrid');
+    const waveId = patch.addBlock('WaveOffset');
+    const drawId = patch.addBlock('DrawInstances');
+    const constId = patch.addBlock('Constant');
+    patch.addEdge(gridId, waveId, 'primary');
+    patch.addEdge(waveId, drawId, 'primary');
+    patch.addEdge(constId, waveId, 'amplitude');
+    return { constId, waveId };
+  }
+
+  it('inserts a Scale transform along the route via the ƒ editor, and it round-trips', () => {
+    const { constId, waveId } = seedScalarRoute();
+    renderTable();
+
+    // Open the chain editor on the connected (amplitude × Constant) cell.
+    fireEvent.click(screen.getByTestId(`mod-fx-${waveId}:amplitude--${constId}`));
+    // Append a Scale transform.
+    fireEvent.click(screen.getByTestId('mod-add-Scale'));
+
+    // The store now routes Constant → Scale → amplitude, with exactly one transform.
+    const edges = readComputed(() => store.pillarPatch.patch.edges);
+    const scaleBlock = readComputed(() =>
+      store.pillarPatch.patch.blocks.find((b) => b.type === 'Scale'),
+    );
+    expect(scaleBlock).toBeDefined();
+    const scaleId = scaleBlock!.id;
+    expect(edges.some((e) => e.source === constId && e.target === scaleId)).toBe(true);
+    expect(edges.some((e) => e.source === scaleId && e.target === waveId && e.inputSlot === 'amplitude')).toBe(true);
+    // No direct Constant → amplitude edge remains (the feeder was replaced).
+    expect(edges.some((e) => e.source === constId && e.target === waveId)).toBe(false);
+
+    // The route compiles (the scalar transform folds cleanly into the plan).
+    expect(readComputed(() => store.pillarPatch.compiled.kind)).toBe('ok');
+    // The cell now advertises a one-transform chain.
+    expect(screen.getByTestId(`mod-cell-${waveId}:amplitude--${constId}`)).toHaveAttribute(
+      'data-chain-length',
+      '1',
+    );
+  });
+
+  it('removing the transform restores the direct route', () => {
+    const { constId, waveId } = seedScalarRoute();
+    renderTable();
+    fireEvent.click(screen.getByTestId(`mod-fx-${waveId}:amplitude--${constId}`));
+    fireEvent.click(screen.getByTestId('mod-add-Scale'));
+
+    const scaleId = readComputed(
+      () => store.pillarPatch.patch.blocks.find((b) => b.type === 'Scale')!.id,
+    );
+    // Remove it via the × control (editor is still open on the same cell).
+    fireEvent.click(screen.getByTestId(`mod-remove-${scaleId}`));
+
+    const blocks = readComputed(() => store.pillarPatch.patch.blocks);
+    const edges = readComputed(() => store.pillarPatch.patch.edges);
+    expect(blocks.some((b) => b.type === 'Scale')).toBe(false);
+    // The direct Constant → amplitude route is back.
+    expect(edges.some((e) => e.source === constId && e.target === waveId && e.inputSlot === 'amplitude')).toBe(true);
+  });
+
+  it('editing a transform field writes the block config (persisted with the patch)', () => {
+    const { constId, waveId } = seedScalarRoute();
+    renderTable();
+    fireEvent.click(screen.getByTestId(`mod-fx-${waveId}:amplitude--${constId}`));
+    fireEvent.click(screen.getByTestId('mod-add-Scale'));
+
+    const scaleId = readComputed(
+      () => store.pillarPatch.patch.blocks.find((b) => b.type === 'Scale')!.id,
+    );
+    fireEvent.change(screen.getByTestId(`mod-field-${scaleId}-factor`), {
+      target: { value: '4' },
+    });
+
+    const config = readComputed(
+      () => store.pillarPatch.patch.blocks.find((b) => b.id === scaleId)!.config,
+    );
+    expect(config.factor).toBe(4);
+  });
+});

--- a/src/ui/nativeEditor/__tests__/ModulationTablePanel.test.tsx
+++ b/src/ui/nativeEditor/__tests__/ModulationTablePanel.test.tsx
@@ -171,6 +171,38 @@ describe('ModulationTablePanel — in-cell transform chain editor', () => {
     expect(edges.some((e) => e.source === constId && e.target === waveId && e.inputSlot === 'amplitude')).toBe(true);
   });
 
+  it('retargeting a transform-laden route to a new source removes the orphaned chain', () => {
+    // grid → wave → draw, Constant → Scale → wave.amplitude, plus a Time source.
+    localStorageMock.clear();
+    store = new RootStore();
+    const p = store.pillarPatch;
+    for (const e of [...p.patch.edges]) p.removeEdge(e.id);
+    for (const b of [...p.patch.blocks]) p.removeBlock(b.id);
+    const gridId = p.addBlock('InstanceGrid');
+    const waveId = p.addBlock('WaveOffset');
+    const drawId = p.addBlock('DrawInstances');
+    const constId = p.addBlock('Constant');
+    const scaleId = p.addBlock('Scale');
+    const timeId = p.addBlock('Time');
+    p.addEdge(gridId, waveId, 'primary');
+    p.addEdge(waveId, drawId, 'primary');
+    p.addEdge(constId, scaleId, 'in');
+    p.addEdge(scaleId, waveId, 'amplitude');
+    renderTable();
+
+    // Retarget the amplitude knob to Time by clicking that empty cell.
+    fireEvent.click(screen.getByTestId(`mod-cell-${waveId}:amplitude--${timeId}`));
+
+    const blocks = readComputed(() => store.pillarPatch.patch.blocks);
+    const edges = readComputed(() => store.pillarPatch.patch.edges);
+    // The old Scale chain is gone — no orphaned block, no dangling Constant→Scale edge.
+    expect(blocks.some((b) => b.id === scaleId)).toBe(false);
+    expect(edges.some((e) => e.source === scaleId || e.target === scaleId)).toBe(false);
+    // Amplitude is now fed directly by Time, and the patch compiles clean.
+    expect(edges.some((e) => e.source === timeId && e.target === waveId && e.inputSlot === 'amplitude')).toBe(true);
+    expect(readComputed(() => store.pillarPatch.compiled.kind)).toBe('ok');
+  });
+
   it('editing a transform field writes the block config (persisted with the patch)', () => {
     const { constId, waveId } = seedScalarRoute();
     renderTable();

--- a/src/ui/nativeEditor/__tests__/modulationTable.test.ts
+++ b/src/ui/nativeEditor/__tests__/modulationTable.test.ts
@@ -200,13 +200,37 @@ describe('in-cell chain edit actions', () => {
     store.addEdge(scaleId, waveId, 'amplitude');
 
     const { cell, row } = locate(store, waveId, 'amplitude', constId);
-    const action = removeTransformAction(cell.route!, row, store.registry, 0);
+    const action = removeTransformAction(cell.route!, row, 0);
     expect(action).toEqual({
       kind: 'removeTransform',
       blockId: scaleId,
       upstreamBlockId: constId,
       downstreamTarget: waveId,
       downstreamInputSlot: 'amplitude',
+    });
+  });
+
+  it('removeTransformAction bridges to the next transform\'s own input slot mid-chain', () => {
+    const store = new PillarPatchStore({ blocks: [], edges: [] });
+    const constId = store.addBlock('Constant');
+    const waveId = store.addBlock('WaveOffset');
+    const scaleId = store.addBlock('Scale');
+    const offsetId = store.addBlock('Offset');
+    // Constant → Scale → Offset → amplitude
+    store.addEdge(constId, scaleId, 'in');
+    store.addEdge(scaleId, offsetId, 'in');
+    store.addEdge(offsetId, waveId, 'amplitude');
+
+    const { cell, row } = locate(store, waveId, 'amplitude', constId);
+    // Remove the first transform (Scale): its downstream is Offset's own input slot,
+    // read from the route (carried at trace time), never re-derived to an empty string.
+    const action = removeTransformAction(cell.route!, row, 0);
+    expect(action).toEqual({
+      kind: 'removeTransform',
+      blockId: scaleId,
+      upstreamBlockId: constId,
+      downstreamTarget: offsetId,
+      downstreamInputSlot: 'in',
     });
   });
 

--- a/src/ui/nativeEditor/__tests__/modulationTable.test.ts
+++ b/src/ui/nativeEditor/__tests__/modulationTable.test.ts
@@ -13,7 +13,13 @@ import { describe, it, expect } from 'vitest';
 import { PillarPatchStore } from '../../../stores/PillarPatchStore';
 import { makeGridOfSquaresPatch } from '../../../pillars/fixtures/grid-of-squares';
 import type { PillarEdge } from '../../../pillars/types';
-import { buildModulationTable, cellAction } from '../modulationTable';
+import {
+  appendTransformAction,
+  buildModulationTable,
+  cellAction,
+  removeTransformAction,
+  setTransformConfigAction,
+} from '../modulationTable';
 
 /** Locate a cell by its row (target input) and column (source output) block ids. */
 function locate(
@@ -58,9 +64,11 @@ describe('buildModulationTable', () => {
     const store = new PillarPatchStore(makeGridOfSquaresPatch());
     const model = buildModulationTable(store.patch, store.registry);
 
-    const connectedCells = model.cells.flat().filter((cell) => cell.edge !== null);
+    const connectedCells = model.cells.flat().filter((cell) => cell.route !== null);
     expect(connectedCells).toHaveLength(store.patch.edges.length);
-    expect(connectedCells.map((c) => c.edge?.id).sort()).toEqual(['e0', 'e1']);
+    // Both seed routes are direct (no transforms); their input edges are e0, e1.
+    expect(connectedCells.map((c) => c.route?.inputEdgeId).sort()).toEqual(['e0', 'e1']);
+    expect(connectedCells.every((c) => c.route?.transforms.length === 0)).toBe(true);
   });
 
   it('marks a block feeding itself and type-incompatible crossings as not connectable', () => {
@@ -88,7 +96,7 @@ describe('scalar routing — a scalar source column feeds a knob row', () => {
     // a connectable, empty cell.
     expect(row.value).toBe('scalar');
     expect(column.value).toBe('scalar');
-    expect(cell.edge).toBeNull();
+    expect(cell.route).toBeNull();
     expect(cell.connectable).toBe(true);
 
     // Clicking it connects the Constant into the knob.
@@ -102,15 +110,125 @@ describe('scalar routing — a scalar source column feeds a knob row', () => {
     if (action?.kind === 'connect') store.addEdge(action.source, action.target, action.inputSlot);
 
     // The rebuilt table now shows the connection at that scalar crossing.
-    expect(locate(store, waveId, 'amplitude', constId).cell.edge).not.toBeNull();
+    expect(locate(store, waveId, 'amplitude', constId).cell.route).not.toBeNull();
+  });
+});
+
+describe('transform blocks are route-internal, not grid rows/columns', () => {
+  /** Constant → Scale → WaveOffset.amplitude — a scalar route through one transform. */
+  function transformRoutePatch() {
+    const store = new PillarPatchStore({ blocks: [], edges: [] });
+    const constId = store.addBlock('Constant');
+    const waveId = store.addBlock('WaveOffset');
+    const scaleId = store.addBlock('Scale');
+    store.addEdge(constId, scaleId, 'in'); // Constant → Scale.in
+    store.addEdge(scaleId, waveId, 'amplitude'); // Scale.out → amplitude
+    return { store, constId, waveId, scaleId };
+  }
+
+  it('a transform block is absent from both rows and columns', () => {
+    const { store, scaleId } = transformRoutePatch();
+    const model = buildModulationTable(store.patch, store.registry);
+    expect(model.rows.some((r) => r.blockId === scaleId)).toBe(false);
+    expect(model.columns.some((c) => c.blockId === scaleId)).toBe(false);
+  });
+
+  it('a route through a transform shows as an occupied cell carrying the chain', () => {
+    const { store, constId, waveId, scaleId } = transformRoutePatch();
+    const { cell } = locate(store, waveId, 'amplitude', constId);
+    expect(cell.route).not.toBeNull();
+    expect(cell.route?.sourceBlockId).toBe(constId);
+    expect(cell.route?.transforms.map((t) => t.blockId)).toEqual([scaleId]);
+    expect(cell.route?.transforms.map((t) => t.displayName)).toEqual(['Scale']);
+    // The transform's factor is read from its block config, not copied onto the route.
+    const factor = cell.route?.transforms[0].fields.find((f) => f.key === 'factor');
+    expect(factor?.value).toBe(store.patch.blocks.find((b) => b.id === scaleId)?.config.factor);
+  });
+
+  it('the route still compiles: the transform-bearing patch is a valid ScenePlan input', () => {
+    const { store } = transformRoutePatch();
+    // A DrawInstances is needed for a full plan; the point here is the scalar route
+    // through Scale does not itself break compilation (loud errors would surface).
+    expect(store.compiled.kind === 'ok' || store.compiled.kind === 'error').toBe(true);
+    if (store.compiled.kind === 'error') {
+      // Any errors must be about the missing draw, never the scalar transform route.
+      expect(store.compiled.errors.join('\n')).not.toMatch(/scalar|transform|Scale/i);
+    }
+  });
+
+  it('disconnecting a transform route tears down the transform block too', () => {
+    const { store, constId, waveId, scaleId } = transformRoutePatch();
+    const { cell, row, column } = locate(store, waveId, 'amplitude', constId);
+    const action = cellAction(cell, row, column);
+    expect(action).toEqual({
+      kind: 'disconnect',
+      inputEdgeId: store.patch.edges.find((e) => e.target === waveId && e.inputSlot === 'amplitude')?.id,
+      transformBlockIds: [scaleId],
+    });
+  });
+});
+
+describe('in-cell chain edit actions', () => {
+  function directRoutePatch() {
+    const store = new PillarPatchStore({ blocks: [], edges: [] });
+    const constId = store.addBlock('Constant');
+    const waveId = store.addBlock('WaveOffset');
+    store.addEdge(constId, waveId, 'amplitude'); // direct Constant → amplitude
+    return { store, constId, waveId };
+  }
+
+  it('appendTransformAction inserts a transform at the input end of a route', () => {
+    const { store, constId, waveId } = directRoutePatch();
+    const { cell, row } = locate(store, waveId, 'amplitude', constId);
+    expect(cell.route).not.toBeNull();
+    const action = appendTransformAction(cell.route!, row, 'Scale');
+    expect(action).toEqual({
+      kind: 'appendTransform',
+      transformType: 'Scale',
+      upstreamBlockId: constId, // a direct route's upstream is the source
+      target: waveId,
+      inputSlot: 'amplitude',
+    });
+  });
+
+  it('removeTransformAction bridges upstream to the input for the last transform', () => {
+    const store = new PillarPatchStore({ blocks: [], edges: [] });
+    const constId = store.addBlock('Constant');
+    const waveId = store.addBlock('WaveOffset');
+    const scaleId = store.addBlock('Scale');
+    store.addEdge(constId, scaleId, 'in');
+    store.addEdge(scaleId, waveId, 'amplitude');
+
+    const { cell, row } = locate(store, waveId, 'amplitude', constId);
+    const action = removeTransformAction(cell.route!, row, store.registry, 0);
+    expect(action).toEqual({
+      kind: 'removeTransform',
+      blockId: scaleId,
+      upstreamBlockId: constId,
+      downstreamTarget: waveId,
+      downstreamInputSlot: 'amplitude',
+    });
+  });
+
+  it('setTransformConfigAction targets one field of one transform block', () => {
+    expect(setTransformConfigAction('sc-1', 'factor', 2.5)).toEqual({
+      kind: 'setTransformConfig',
+      blockId: 'sc-1',
+      key: 'factor',
+      value: 2.5,
+    });
   });
 });
 
 describe('cellAction', () => {
-  it('resolves an occupied cell to a disconnect of its edge', () => {
+  it('resolves an occupied direct route to a disconnect of its input edge', () => {
     const store = new PillarPatchStore(makeGridOfSquaresPatch());
     const { cell, row, column } = locate(store, 'color', 'primary', 'grid');
-    expect(cellAction(cell, row, column)).toEqual({ kind: 'disconnect', edgeId: 'e0' });
+    expect(cellAction(cell, row, column)).toEqual({
+      kind: 'disconnect',
+      inputEdgeId: 'e0',
+      transformBlockIds: [],
+    });
   });
 
   it('resolves an empty compatible cell to a connect', () => {
@@ -140,8 +258,8 @@ describe('table edits mutate the same patch the graph edits', () => {
     // Table path: click the connected (color.primary × grid) cell.
     const { cell, row, column } = locate(viaTable, 'color', 'primary', 'grid');
     const action = cellAction(cell, row, column);
-    expect(action).toEqual({ kind: 'disconnect', edgeId: 'e0' });
-    if (action?.kind === 'disconnect') viaTable.removeEdge(action.edgeId);
+    expect(action).toEqual({ kind: 'disconnect', inputEdgeId: 'e0', transformBlockIds: [] });
+    if (action?.kind === 'disconnect') viaTable.removeEdge(action.inputEdgeId);
 
     // Graph path: the same intent expressed as the store call the graph makes.
     viaGraph.removeEdge('e0');
@@ -192,7 +310,7 @@ describe('table edits mutate the same patch the graph edits', () => {
 
     // The table, rebuilt from the same patch, reflects it: grid→draw is now
     // connected and color→draw is empty.
-    expect(locate(store, 'draw', 'primary', 'grid').cell.edge).not.toBeNull();
-    expect(locate(store, 'draw', 'primary', 'color').cell.edge).toBeNull();
+    expect(locate(store, 'draw', 'primary', 'grid').cell.route).not.toBeNull();
+    expect(locate(store, 'draw', 'primary', 'color').cell.route).toBeNull();
   });
 });

--- a/src/ui/nativeEditor/__tests__/modulationTable.test.ts
+++ b/src/ui/nativeEditor/__tests__/modulationTable.test.ts
@@ -106,6 +106,7 @@ describe('scalar routing — a scalar source column feeds a knob row', () => {
       source: constId,
       target: waveId,
       inputSlot: 'amplitude',
+      replacedTransformBlockIds: [], // the knob was unwired — nothing to replace
     });
     if (action?.kind === 'connect') store.addEdge(action.source, action.target, action.inputSlot);
 
@@ -164,6 +165,24 @@ describe('transform blocks are route-internal, not grid rows/columns', () => {
       kind: 'disconnect',
       inputEdgeId: store.patch.edges.find((e) => e.target === waveId && e.inputSlot === 'amplitude')?.id,
       transformBlockIds: [scaleId],
+    });
+  });
+
+  it('retargeting a transform route to a new source carries the old chain for teardown', () => {
+    const { store, waveId, scaleId } = transformRoutePatch();
+    const timeId = store.addBlock('Time'); // a second scalar source column
+
+    // The (amplitude × Time) cell is empty+connectable; the row's route (through
+    // Scale) is surfaced as rowRoute so the connect can replace the whole chain.
+    const { cell, row, column } = locate(store, waveId, 'amplitude', timeId);
+    expect(cell.route).toBeNull();
+    const action = cellAction(cell, row, column);
+    expect(action).toEqual({
+      kind: 'connect',
+      source: timeId,
+      target: waveId,
+      inputSlot: 'amplitude',
+      replacedTransformBlockIds: [scaleId], // the orphaned-otherwise Scale block
     });
   });
 });
@@ -264,6 +283,7 @@ describe('cellAction', () => {
       source: 'grid',
       target: 'draw',
       inputSlot: 'primary',
+      replacedTransformBlockIds: [],
     });
   });
 

--- a/src/ui/nativeEditor/modulationTable.ts
+++ b/src/ui/nativeEditor/modulationTable.ts
@@ -281,6 +281,12 @@ function traceRoute(
   const seen = new Set<string>();
 
   for (;;) {
+    // `find` (not `filter`) relies on the one-feeder-per-input-slot invariant that
+    // the store's `addEdge` singly enforces — the same invariant every edge-reader
+    // trusts (resolveScalar, resolveBundle, the compiler's own lookups). Re-checking
+    // it here would duplicate enforcement across readers and drift; if a corrupt
+    // persisted patch is a concern, it belongs to one validator at the deserialize
+    // boundary, not per reader. [LAW:single-enforcer] [LAW:no-defensive-null-guards]
     const edge = patch.edges.find((e) => e.target === target && e.inputSlot === slot);
     if (edge === undefined) {
       // Unwired: no route into the row, or a dangling transform chain (which the

--- a/src/ui/nativeEditor/modulationTable.ts
+++ b/src/ui/nativeEditor/modulationTable.ts
@@ -80,6 +80,14 @@ export interface RouteTransform {
   readonly blockId: string;
   readonly type: string;
   readonly displayName: string;
+  /**
+   * The transform's sole scalar input port id — the slot its upstream feeds. It is
+   * resolved once during tracing (a transform with no sole input aborts the trace),
+   * so a `RouteTransform` always carries a real slot. Splicing a transform out reads
+   * this rather than re-deriving it, keeping a malformed empty slot unrepresentable.
+   * [LAW:types-are-the-program]
+   */
+  readonly inputPortId: string;
   readonly fields: readonly RouteTransformField[];
 }
 
@@ -277,17 +285,21 @@ function traceRoute(
     // A transform on the route. Guard against a cycle before recursing upstream.
     if (seen.has(source.id)) return null;
     seen.add(source.id);
-    transforms.unshift(routeTransform(registry, source));
 
     const upstreamSlot = soleInputPortId(registry, source.type);
     if (upstreamSlot === null) return null; // not a linear transform — cannot trace
+    transforms.unshift(routeTransform(registry, source, upstreamSlot));
     target = source.id;
     slot = upstreamSlot;
   }
 }
 
 /** Build the editor-facing view of a transform block from its config + catalog. */
-function routeTransform(registry: SceneRegistry, block: PillarBlock): RouteTransform {
+function routeTransform(
+  registry: SceneRegistry,
+  block: PillarBlock,
+  inputPortId: string,
+): RouteTransform {
   const catalog = registry.get(block.type)?.catalog;
   const displayName = catalog?.displayName ?? block.type;
   const fields: RouteTransformField[] = (catalog?.configFields ?? []).map(
@@ -298,7 +310,7 @@ function routeTransform(registry: SceneRegistry, block: PillarBlock): RouteTrans
       value: block.config[field.key],
     }),
   );
-  return { blockId: block.id, type: block.type, displayName, fields };
+  return { blockId: block.id, type: block.type, displayName, inputPortId, fields };
 }
 
 /** The id of a block type's sole input port, or null if it does not have exactly one. */
@@ -371,16 +383,16 @@ export function appendTransformAction(
 export function removeTransformAction(
   route: ModulationRoute,
   row: ModulationPortRef,
-  registry: SceneRegistry,
   index: number,
 ): ModulationAction {
   const transform = route.transforms[index];
   const upstreamBlockId =
     index === 0 ? route.sourceBlockId : route.transforms[index - 1].blockId;
   const next = route.transforms[index + 1];
+  // The downstream is the next transform's own input slot (carried on the route) or
+  // the row's input for the last transform — never a re-derived, possibly-empty slot.
   const downstreamTarget = next === undefined ? row.blockId : next.blockId;
-  const downstreamInputSlot =
-    next === undefined ? row.portId : (soleInputPortId(registry, next.type) ?? '');
+  const downstreamInputSlot = next === undefined ? row.portId : next.inputPortId;
   return {
     kind: 'removeTransform',
     blockId: transform.blockId,

--- a/src/ui/nativeEditor/modulationTable.ts
+++ b/src/ui/nativeEditor/modulationTable.ts
@@ -1,29 +1,41 @@
 /**
  * src/ui/nativeEditor/modulationTable.ts
  *
- * The Modulation Table's pure model: the authored patch viewed as a routing
- * grid. Rows are input ports (things that receive a value), columns are output
- * ports (things that produce one, one per source block under the editor's
- * sole-output model), and each cell is the connection at that crossing — or an
- * empty, possibly-connectable slot.
+ * The Modulation Table's pure model: the authored patch viewed as a routing grid.
+ * Rows are input ports (things that receive a value), columns are output ports
+ * (things that produce one, one per source block under the editor's sole-output
+ * model), and each cell is the ROUTE at that crossing — or an empty, possibly-
+ * connectable slot.
  *
- * This is the SAME data the graph view reads (`PillarPatchStore.patch`); the
- * table is a second projection of it, never a second copy. A cell click resolves
+ * A route is not always a single edge. A scalar route may pass through transform
+ * blocks (Scale/Offset/Clamp) between its source and the input it feeds. Those
+ * transform blocks are ROUTE-INTERNAL: they never appear as their own grid row or
+ * column (that would multiply the grid and defeat the compact-spreadsheet purpose).
+ * Instead the table traces each input back through any transforms to the ultimate
+ * non-transform source, and the cell at (input, source) carries the transform
+ * chain, edited in place. A transform is identified by its typed catalog category
+ * (`'transform'`), never a name heuristic. [LAW:types-are-the-program]
+ *
+ * This is the SAME data the graph view reads (`PillarPatchStore.patch`); the table
+ * is a second projection of it, never a second copy. A cell interaction resolves
  * to a description of a store operation (`ModulationAction`); the React view
- * performs it against the store. So a table edit and a graph edit are literally
- * the same mutation on the same source of truth.
+ * performs it against the store. So a table edit and a graph edit are literally the
+ * same mutation on the same source of truth.
  *
  * [LAW:one-source-of-truth] The grid is derived from the authored patch on every
- *   read; it stores no connection truth of its own.
+ *   read; it stores no connection truth of its own. A transform's parameters live
+ *   in its block config, not duplicated on the route.
  * [LAW:effects-at-boundaries] This module is pure — it computes the grid and the
  *   action to take, but never touches the store; the view applies the action.
- * [LAW:dataflow-not-control-flow] A cell carries its edge (or null) and whether it
- *   is connectable as VALUES; `cellAction` maps those values to one of a fixed set
- *   of operations rather than the view branching on block type or wiring state.
+ * [LAW:dataflow-not-control-flow] A cell carries its route (or null) and whether it
+ *   is connectable as VALUES; the action builders map those values to one of a
+ *   fixed set of operations rather than the view branching on block type or wiring.
  */
 
 import {
   compareScenePorts,
+  type SceneCatalogConfigField,
+  type SceneConfigControl,
   type SceneRegistry,
   type SceneValueKind,
 } from '../../pillars/scene';
@@ -51,15 +63,48 @@ export interface ModulationPortRef {
   readonly value: SceneValueKind;
 }
 
+/** One editable parameter of a transform block on a route. */
+export interface RouteTransformField {
+  readonly key: string;
+  readonly label: string;
+  readonly control: SceneConfigControl;
+  readonly value: unknown;
+}
+
 /**
- * One crossing of a row (input) and a column (output). `edge` is the connection
- * there, or null when the slot is empty. `connectable` says whether an empty slot
- * would accept a wire (compatible kinds, not the block feeding itself). An
- * existing `edge` is shown regardless of `connectable`: a persisted patch can hold
- * a type-invalid route, and the table must let the user see and delete it.
+ * A transform block sitting on a route, with exactly what the in-cell editor needs
+ * to show and edit it. Its parameters are read from the block's config — the one
+ * source of truth — never copied onto the route.
+ */
+export interface RouteTransform {
+  readonly blockId: string;
+  readonly type: string;
+  readonly displayName: string;
+  readonly fields: readonly RouteTransformField[];
+}
+
+/**
+ * The route feeding one input, traced back through any transform blocks to its
+ * ultimate non-transform source. `transforms` is in source→input order (empty for
+ * a direct wire). `inputEdgeId` is the edge into the row's own input — the last hop
+ * — which disconnecting the route must remove alongside the transform blocks.
+ */
+export interface ModulationRoute {
+  readonly sourceBlockId: string;
+  readonly transforms: readonly RouteTransform[];
+  readonly inputEdgeId: string;
+}
+
+/**
+ * One crossing of a row (input) and a column (output). `route` is the traced route
+ * whose source is this column, or null when no route from this column reaches this
+ * input. `connectable` says whether an empty slot would accept a wire (compatible
+ * kinds, not the block feeding itself). An existing `route` is shown regardless of
+ * `connectable`: a persisted patch can hold a type-invalid route, and the table
+ * must let the user see and delete it.
  */
 export interface ModulationCell {
-  readonly edge: PillarEdge | null;
+  readonly route: ModulationRoute | null;
   readonly connectable: boolean;
 }
 
@@ -71,19 +116,65 @@ export interface ModulationTableModel {
   readonly cells: readonly (readonly ModulationCell[])[];
 }
 
-/** The store operation a cell click performs. */
+/**
+ * The store operation an interaction performs. `connect`/`disconnect` are the
+ * primary cell click; the rest are the in-cell transform-chain affordance on an
+ * occupied cell. Each carries exactly the block/edge ids the store needs, computed
+ * purely from the route so the view stays effect-free. [LAW:effects-at-boundaries]
+ */
 export type ModulationAction =
   | { readonly kind: 'connect'; readonly source: string; readonly target: string; readonly inputSlot: string }
-  | { readonly kind: 'disconnect'; readonly edgeId: string };
+  // Tear down a whole route: remove its transform blocks (each cascades its edges)
+  // and the edge into the input. A direct route is `transformBlockIds: []`.
+  | {
+      readonly kind: 'disconnect';
+      readonly inputEdgeId: string;
+      readonly transformBlockIds: readonly string[];
+    }
+  // Insert a new transform at the input end of an existing route: the block now
+  // feeding `target.inputSlot` (`upstreamBlockId`) is rewired through the new block.
+  | {
+      readonly kind: 'appendTransform';
+      readonly transformType: string;
+      readonly upstreamBlockId: string;
+      readonly target: string;
+      readonly inputSlot: string;
+    }
+  // Splice a transform out of a route, bridging its upstream to its downstream.
+  | {
+      readonly kind: 'removeTransform';
+      readonly blockId: string;
+      readonly upstreamBlockId: string;
+      readonly downstreamTarget: string;
+      readonly downstreamInputSlot: string;
+    }
+  // Retune one transform parameter.
+  | { readonly kind: 'setTransformConfig'; readonly blockId: string; readonly key: string; readonly value: unknown };
+
+/** A transform type the editor may append to a route. */
+export interface TransformPaletteEntry {
+  readonly type: string;
+  readonly displayName: string;
+}
+
+/** The transform blocks the in-cell editor offers, read from the catalog category. */
+export function transformPalette(registry: SceneRegistry): readonly TransformPaletteEntry[] {
+  return registry.catalog
+    .filter((block) => block.category === 'transform')
+    .map((block) => ({ type: block.type, displayName: block.displayName }));
+}
 
 /**
  * Derive the routing grid from the authored patch. Rows are every input port of
- * every block; columns are every block that has exactly one output port (the
- * sole-output model the whole editor assumes — a zero-output sink is no column, a
- * multi-output block is skipped rather than silently anchored to one output).
+ * every non-transform block; columns are every non-transform block that has exactly
+ * one output port (the sole-output model the whole editor assumes). Transform
+ * blocks are excluded from both — they are route-internal, shown inside the cells
+ * of the routes they sit on, never as their own row or column.
  *
  * [LAW:no-silent-failure] A multi-output block is omitted from the columns, not
  *   collapsed to its first output behind the user's back.
+ * [LAW:types-are-the-program] Transform exclusion reads the typed `'transform'`
+ *   category, so the grid can never accidentally surface a transform as a route.
  */
 export function buildModulationTable(
   patch: PillarPatch,
@@ -92,8 +183,12 @@ export function buildModulationTable(
   const labelOf = (block: PillarBlock): string =>
     registry.get(block.type)?.catalog.displayName ?? block.type;
   const portsOf = (block: PillarBlock) => registry.get(block.type)?.catalog.ports ?? [];
+  const isTransform = (block: PillarBlock): boolean =>
+    registry.get(block.type)?.catalog.category === 'transform';
 
-  const rows: ModulationPortRef[] = patch.blocks.flatMap((block) =>
+  const routableBlocks = patch.blocks.filter((block) => !isTransform(block));
+
+  const rows: ModulationPortRef[] = routableBlocks.flatMap((block) =>
     portsOf(block)
       .filter((port) => port.direction === 'input')
       .map((port) => ({
@@ -105,7 +200,7 @@ export function buildModulationTable(
       })),
   );
 
-  const columns: ModulationPortRef[] = patch.blocks.flatMap((block) => {
+  const columns: ModulationPortRef[] = routableBlocks.flatMap((block) => {
     const outputs = portsOf(block).filter((port) => port.direction === 'output');
     if (outputs.length !== 1) return [];
     const output = outputs[0];
@@ -120,28 +215,105 @@ export function buildModulationTable(
     ];
   });
 
-  const cells: ModulationCell[][] = rows.map((row) =>
-    columns.map((column) => ({
-      edge:
-        patch.edges.find(
-          (edge) =>
-            edge.source === column.blockId &&
-            edge.target === row.blockId &&
-            edge.inputSlot === row.portId,
-        ) ?? null,
+  // Each input has at most one feeder, so its route is a property of the row; it
+  // lands in whichever column matches the traced source. Trace once per row.
+  const routeByRow: (ModulationRoute | null)[] = rows.map((row) =>
+    traceRoute(patch, registry, row.blockId, row.portId),
+  );
+
+  const cells: ModulationCell[][] = rows.map((row, rowIndex) => {
+    const route = routeByRow[rowIndex];
+    return columns.map((column) => ({
+      route: route !== null && route.sourceBlockId === column.blockId ? route : null,
       connectable:
         column.blockId !== row.blockId && kindsConnectable(column.value, row.value),
-    })),
-  );
+    }));
+  });
 
   return { rows, columns, cells };
 }
 
 /**
+ * Trace the route feeding `(inputBlockId, inputPortId)` back through any transform
+ * blocks to its ultimate non-transform source. Returns null when the input is
+ * unwired, or when the chain dangles at a transform whose own input is unwired (a
+ * broken route the compiler surfaces as a diagnostic — the grid, which can only
+ * place a route under a source column, shows nothing rather than a phantom source).
+ */
+function traceRoute(
+  patch: PillarPatch,
+  registry: SceneRegistry,
+  inputBlockId: string,
+  inputPortId: string,
+): ModulationRoute | null {
+  const blockById = (id: string): PillarBlock | undefined =>
+    patch.blocks.find((b) => b.id === id);
+  const isTransform = (block: PillarBlock): boolean =>
+    registry.get(block.type)?.catalog.category === 'transform';
+
+  const transforms: RouteTransform[] = [];
+  let target = inputBlockId;
+  let slot = inputPortId;
+  let inputEdgeId: string | null = null;
+  const seen = new Set<string>();
+
+  for (;;) {
+    const edge = patch.edges.find((e) => e.target === target && e.inputSlot === slot);
+    if (edge === undefined) {
+      // Unwired: no route into the row, or a dangling transform chain (which the
+      // compiler surfaces). Either way there is no source column to place it under.
+      return null;
+    }
+    if (inputEdgeId === null) inputEdgeId = edge.id;
+
+    const source = blockById(edge.source);
+    if (source === undefined || !isTransform(source)) {
+      // Reached the ultimate source (or a dangling edge — no route to show).
+      return source === undefined
+        ? null
+        : { sourceBlockId: source.id, transforms, inputEdgeId };
+    }
+
+    // A transform on the route. Guard against a cycle before recursing upstream.
+    if (seen.has(source.id)) return null;
+    seen.add(source.id);
+    transforms.unshift(routeTransform(registry, source));
+
+    const upstreamSlot = soleInputPortId(registry, source.type);
+    if (upstreamSlot === null) return null; // not a linear transform — cannot trace
+    target = source.id;
+    slot = upstreamSlot;
+  }
+}
+
+/** Build the editor-facing view of a transform block from its config + catalog. */
+function routeTransform(registry: SceneRegistry, block: PillarBlock): RouteTransform {
+  const catalog = registry.get(block.type)?.catalog;
+  const displayName = catalog?.displayName ?? block.type;
+  const fields: RouteTransformField[] = (catalog?.configFields ?? []).map(
+    (field: SceneCatalogConfigField) => ({
+      key: field.key,
+      label: field.label,
+      control: field.control,
+      value: block.config[field.key],
+    }),
+  );
+  return { blockId: block.id, type: block.type, displayName, fields };
+}
+
+/** The id of a block type's sole input port, or null if it does not have exactly one. */
+export function soleInputPortId(registry: SceneRegistry, blockType: string): string | null {
+  const inputs = (registry.get(blockType)?.catalog.ports ?? []).filter(
+    (port) => port.direction === 'input',
+  );
+  return inputs.length === 1 ? inputs[0].id : null;
+}
+
+/**
  * The store operation a click on this cell performs, or null when the cell is
- * inert (an empty, type-incompatible crossing). An occupied cell always
- * disconnects — a route can always be deleted, even a type-invalid one. An empty
- * connectable cell connects.
+ * inert (an empty, type-incompatible crossing). An occupied cell disconnects the
+ * whole route — direct wire or transform chain, a route can always be deleted, even
+ * a type-invalid one. An empty connectable cell connects a direct route.
  *
  * Retarget is NOT a third case: connecting into a row that already has a feeder
  * relies on the store replacing the old wire (its one-feeder-per-input-slot
@@ -153,9 +325,76 @@ export function cellAction(
   row: ModulationPortRef,
   column: ModulationPortRef,
 ): ModulationAction | null {
-  if (cell.edge !== null) return { kind: 'disconnect', edgeId: cell.edge.id };
+  if (cell.route !== null) {
+    return {
+      kind: 'disconnect',
+      inputEdgeId: cell.route.inputEdgeId,
+      transformBlockIds: cell.route.transforms.map((t) => t.blockId),
+    };
+  }
   if (cell.connectable) {
     return { kind: 'connect', source: column.blockId, target: row.blockId, inputSlot: row.portId };
   }
   return null;
+}
+
+/**
+ * Insert a transform at the input end of an existing route: the block currently
+ * feeding the input (the last transform, or the source for a direct route) is
+ * rewired through the new transform. The application composes `addBlock` +
+ * two `addEdge`s; the second replaces the input's feeder (one-per-slot), so the
+ * route becomes `… → newTransform → input`.
+ */
+export function appendTransformAction(
+  route: ModulationRoute,
+  row: ModulationPortRef,
+  transformType: string,
+): ModulationAction {
+  const upstream =
+    route.transforms.length === 0
+      ? route.sourceBlockId
+      : route.transforms[route.transforms.length - 1].blockId;
+  return {
+    kind: 'appendTransform',
+    transformType,
+    upstreamBlockId: upstream,
+    target: row.blockId,
+    inputSlot: row.portId,
+  };
+}
+
+/**
+ * Splice the transform at `index` out of a route, bridging its upstream to its
+ * downstream so the route stays connected. The downstream is the next transform's
+ * input, or the row's input for the last transform.
+ */
+export function removeTransformAction(
+  route: ModulationRoute,
+  row: ModulationPortRef,
+  registry: SceneRegistry,
+  index: number,
+): ModulationAction {
+  const transform = route.transforms[index];
+  const upstreamBlockId =
+    index === 0 ? route.sourceBlockId : route.transforms[index - 1].blockId;
+  const next = route.transforms[index + 1];
+  const downstreamTarget = next === undefined ? row.blockId : next.blockId;
+  const downstreamInputSlot =
+    next === undefined ? row.portId : (soleInputPortId(registry, next.type) ?? '');
+  return {
+    kind: 'removeTransform',
+    blockId: transform.blockId,
+    upstreamBlockId,
+    downstreamTarget,
+    downstreamInputSlot,
+  };
+}
+
+/** Retune one parameter of a transform on a route. */
+export function setTransformConfigAction(
+  blockId: string,
+  key: string,
+  value: unknown,
+): ModulationAction {
+  return { kind: 'setTransformConfig', blockId, key, value };
 }

--- a/src/ui/nativeEditor/modulationTable.ts
+++ b/src/ui/nativeEditor/modulationTable.ts
@@ -106,13 +106,17 @@ export interface ModulationRoute {
 /**
  * One crossing of a row (input) and a column (output). `route` is the traced route
  * whose source is this column, or null when no route from this column reaches this
- * input. `connectable` says whether an empty slot would accept a wire (compatible
- * kinds, not the block feeding itself). An existing `route` is shown regardless of
+ * input. `rowRoute` is the route currently feeding this cell's ROW regardless of
+ * column (equal to `route` in the source column, present on every cell of an
+ * occupied row) — so a `connect` here knows the existing chain it replaces.
+ * `connectable` says whether an empty slot would accept a wire (compatible kinds,
+ * not the block feeding itself). An existing `route` is shown regardless of
  * `connectable`: a persisted patch can hold a type-invalid route, and the table
  * must let the user see and delete it.
  */
 export interface ModulationCell {
   readonly route: ModulationRoute | null;
+  readonly rowRoute: ModulationRoute | null;
   readonly connectable: boolean;
 }
 
@@ -131,7 +135,17 @@ export interface ModulationTableModel {
  * purely from the route so the view stays effect-free. [LAW:effects-at-boundaries]
  */
 export type ModulationAction =
-  | { readonly kind: 'connect'; readonly source: string; readonly target: string; readonly inputSlot: string }
+  // Wire a source into an input. `replacedTransformBlockIds` are the transform
+  // blocks of the route this connect replaces (a retarget into an occupied row) —
+  // removed before the new edge is added so the old chain never orphans. Empty when
+  // the row was unwired or its prior route was direct.
+  | {
+      readonly kind: 'connect';
+      readonly source: string;
+      readonly target: string;
+      readonly inputSlot: string;
+      readonly replacedTransformBlockIds: readonly string[];
+    }
   // Tear down a whole route: remove its transform blocks (each cascades its edges)
   // and the edge into the input. A direct route is `transformBlockIds: []`.
   | {
@@ -230,9 +244,10 @@ export function buildModulationTable(
   );
 
   const cells: ModulationCell[][] = rows.map((row, rowIndex) => {
-    const route = routeByRow[rowIndex];
+    const rowRoute = routeByRow[rowIndex];
     return columns.map((column) => ({
-      route: route !== null && route.sourceBlockId === column.blockId ? route : null,
+      route: rowRoute !== null && rowRoute.sourceBlockId === column.blockId ? rowRoute : null,
+      rowRoute,
       connectable:
         column.blockId !== row.blockId && kindsConnectable(column.value, row.value),
     }));
@@ -329,8 +344,11 @@ export function soleInputPortId(registry: SceneRegistry, blockType: string): str
  *
  * Retarget is NOT a third case: connecting into a row that already has a feeder
  * relies on the store replacing the old wire (its one-feeder-per-input-slot
- * invariant), so "move a connection to a different source" is just a connect into
- * an occupied row. [LAW:dataflow-not-control-flow]
+ * invariant). But a retargeted route's transform blocks are NOT edges the feeder
+ * swap removes — so the connect carries `replacedTransformBlockIds` (the old route's
+ * transforms) for the applier to tear down, or the old chain orphans in the patch.
+ * [LAW:dataflow-not-control-flow] the teardown is a value on the action, not a
+ *   branch; [LAW:no-silent-failure] a retarget leaves no dangling blocks behind.
  */
 export function cellAction(
   cell: ModulationCell,
@@ -345,7 +363,16 @@ export function cellAction(
     };
   }
   if (cell.connectable) {
-    return { kind: 'connect', source: column.blockId, target: row.blockId, inputSlot: row.portId };
+    // This column is not the row's current source (else `route` would be non-null),
+    // so any existing `rowRoute` is the route this connect replaces — its transforms
+    // must be removed. A direct or absent prior route contributes an empty set.
+    return {
+      kind: 'connect',
+      source: column.blockId,
+      target: row.blockId,
+      inputSlot: row.portId,
+      replacedTransformBlockIds: cell.rowRoute?.transforms.map((t) => t.blockId) ?? [],
+    };
   }
   return null;
 }


### PR DESCRIPTION
Closes **oscilla-pillars-scene-nt56.14.1** — per-cell transform chains (scale/offset/clamp) in the Modulation Table.

## Design (per the ticket's DESIGN RESOLVED comment: *everything is a block*)
A scale/offset/clamp is a scalar→scalar transform = a **scalar modifier block**, not a field on the edge. `PillarEdge` stays `{id, source, target, inputSlot, role}` — the data-layer change dissolves. `[LAW:one-type-per-behavior]`

## Commit 1 — scale/offset/clamp scalar-modifier blocks + route fold
- `defineScalarModifier` helper + `scalarModifier` contribution role (one scalar `in`, one `out`, `transform` category). A new transform is just a `transform:` fn + config.
- `min`/`max` `PlanBinaryOp` + `clamp` builder (`clamp = max(lo, min(hi, x))`), wired into the TSL realizer. clamp adds no operator — it composes the primitives.
- `resolveScalar` recursive fold: a route `Constant → Scale → knob` folds back to its source applying each transform, mirroring `resolveBundle`.
- Fixed an order-dependent diagnostic in the two-pass compile refactor: the fold now reads a stable `scalarProducers` map + a complete `knownBlockIds` set, so a non-scalar block wired into a knob reports "not a scalar source" deterministically. Narrowing the producer map to `ScalarContribution` collapsed `resolveScalar`'s switch to its two real cases. `[LAW:no-ambient-temporal-coupling][LAW:types-are-the-program]`

## Commit 2 — route-aware Modulation Table + in-cell chain editor
- Transform blocks are **route-internal**: never grid rows/columns (read via the typed `'transform'` category). Each input is traced back through transforms to its source; the cell carries the chain.
- Pure action builders (append/remove/setConfig transform + connect/disconnect); the primary cell click stays connect/disconnect, transform editing is a separate `ƒ` popover on an occupied cell.

## Verification
- `typecheck` + `lint` clean; **2432 tests pass**. New: 6 fold cases, route-tracing/exclusion/action-builder model tests, DOM tests (append round-trips to a compiling plan, remove restores the direct route, field edit writes config).
- **Visually verified in the native editor**: `Constant → Scale → Offset → WaveOffset.amplitude` renders ("No problems — patch renders"), Scale/Offset absent from grid rows/columns, `ƒ2` chain edited in-cell, scaled wave amplitude visible on canvas.

https://claude.ai/code/session_01PTbsG7XcnFj4x17688WUjA