### PR TITLE
SPIKE: PillarPatchAdapter + neutral GraphDataAdapter vocabulary (nt8lsn.14)

### DIFF
--- a/src/stores/__tests__/PatchStore.authored-control.test.ts
+++ b/src/stores/__tests__/PatchStore.authored-control.test.ts
@@ -63,7 +63,7 @@ describe('PatchStore authored input control ownership', () => {
     });
   });
 
-  it('exposes authored input control through PatchStoreAdapter without leaking it back into block.params', () => {
+  it('surfaces an authored input control as a default-source decoration without leaking it into block.params', () => {
     const patchStore = new PatchStore();
     const layoutStore = new LayoutStore();
     const frontendStore = new FrontendResultStore();
@@ -72,8 +72,12 @@ describe('PatchStore authored input control ownership', () => {
     const blockId = patchStore.addBlock('Rotate2D', { angleDeg: 15 });
     const block = adapter.blocks.get(blockId as BlockId)!;
 
+    // The authored control does not leak back into raw params...
     expect(block.params.angleDeg).toBeUndefined();
-    expect(block.inputPorts.get('angleDeg')?.authoredControl?.source?.params.value).toBe(15);
+    // ...and it manifests on the port as a default-source indicator decoration
+    // (the neutral seam exposes the *effect*, not the V1 authoredControl record).
+    const port = block.inputPorts.get('angleDeg');
+    expect(port?.decorations?.some((d) => d.kind === 'indicator')).toBe(true);
   });
 
   it('persists authored input control through JSON serialization', () => {

--- a/src/stores/__tests__/PatchStore.authored-control.test.ts
+++ b/src/stores/__tests__/PatchStore.authored-control.test.ts
@@ -72,10 +72,14 @@ describe('PatchStore authored input control ownership', () => {
     const blockId = patchStore.addBlock('Rotate2D', { angleDeg: 15 });
     const block = adapter.blocks.get(blockId as BlockId)!;
 
-    // The authored control does not leak back into raw params...
+    // The authored value round-trips and is captured on the store's port
+    // (the canonical home for authored controls)...
+    expect(patchStore.patch.blocks.get(blockId)?.inputPorts.get('angleDeg')?.authoredControl?.source?.params.value)
+      .toBe(15);
+    // ...it does not leak back into raw params...
     expect(block.params.angleDeg).toBeUndefined();
-    // ...and it manifests on the port as a default-source indicator decoration
-    // (the neutral seam exposes the *effect*, not the V1 authoredControl record).
+    // ...and the neutral adapter surfaces it as a default-source indicator
+    // decoration (the seam exposes the *effect*, not the V1 authoredControl record).
     const port = block.inputPorts.get('angleDeg');
     expect(port?.decorations?.some((d) => d.kind === 'indicator')).toBe(true);
   });

--- a/src/stores/__tests__/control-surface-integration.test.ts
+++ b/src/stores/__tests__/control-surface-integration.test.ts
@@ -39,7 +39,7 @@ function getControlsViaAdapter(
   portId: string,
 ) {
   const block = adapter.blocks.get(blockId);
-  return block?.inputPorts.get(portId)?.binding?.controls ?? [];
+  return block?.inputPorts.get(portId)?.controls ?? [];
 }
 
 // =============================================================================

--- a/src/ui/graphEditor/CompositeStoreAdapter.ts
+++ b/src/ui/graphEditor/CompositeStoreAdapter.ts
@@ -18,6 +18,7 @@ import type { InternalBlockId, InternalEdge } from '../../blocks/composite-types
 import type { CompositeEditorStore } from '../../stores/CompositeEditorStore';
 import { getAnyBlockDefinition } from '../../blocks/registry';
 import type { AnyBlockDef } from '../../blocks/registry';
+import { typeDisplayFor, defaultSourceIndicator, UNTYPED_TYPE } from './neutral-projection';
 import type {
   GraphDataAdapter,
   BlockLike,
@@ -55,14 +56,16 @@ export class CompositeStoreAdapter implements GraphDataAdapter<InternalBlockId> 
         continue;
       }
 
-      // Transform InternalBlockState to BlockLike
+      // Transform InternalBlockState to neutral BlockLike
       blockMap.set(id, {
         id,
         type: blockState.type,
+        typeLabel: blockDef.label,
         displayName: blockState.displayName || blockDef.label,
         params: blockState.params || {},
         inputPorts: this.getInputPortsForBlock(blockDef),
         outputPorts: this.getOutputPortsForBlock(blockDef),
+        controls: [],
       });
     }
 
@@ -215,11 +218,14 @@ export class CompositeStoreAdapter implements GraphDataAdapter<InternalBlockId> 
     const portMap = new Map<string, InputPortLike>();
 
     for (const [id, inputDef] of Object.entries(blockDef.inputs)) {
+      if (inputDef.exposedAsPort === false) continue;
+      const ds = inputDef.defaultSource;
+      const typeDisplay = typeDisplayFor(inputDef.type ?? UNTYPED_TYPE);
       portMap.set(id, {
         id,
-        // Default combineMode to 'last' (matches PatchStore behavior for new blocks)
-        combineMode: 'last' as const,
-        defaultSource: inputDef.defaultSource,
+        label: inputDef.label || id,
+        typeDisplay,
+        decorations: ds ? [defaultSourceIndicator(ds, typeDisplay.tooltip)] : [],
       });
     }
 
@@ -232,9 +238,11 @@ export class CompositeStoreAdapter implements GraphDataAdapter<InternalBlockId> 
   private getOutputPortsForBlock(blockDef: AnyBlockDef): ReadonlyMap<string, OutputPortLike> {
     const portMap = new Map<string, OutputPortLike>();
 
-    for (const portId of Object.keys(blockDef.outputs)) {
-      portMap.set(portId, {
-        id: portId,
+    for (const [id, outputDef] of Object.entries(blockDef.outputs)) {
+      portMap.set(id, {
+        id,
+        label: outputDef.label || id,
+        typeDisplay: typeDisplayFor(outputDef.type ?? UNTYPED_TYPE),
       });
     }
 

--- a/src/ui/graphEditor/CompositeStoreAdapter.ts
+++ b/src/ui/graphEditor/CompositeStoreAdapter.ts
@@ -52,7 +52,20 @@ export class CompositeStoreAdapter implements GraphDataAdapter<InternalBlockId> 
     for (const [id, blockState] of this.store.internalBlocks) {
       const blockDef = getAnyBlockDefinition(blockState.type);
       if (!blockDef) {
-        // Skip blocks with missing definitions (shouldn't happen in normal use)
+        // [LAW:no-silent-failure] An unregistered block type still renders — as
+        // a bare block carrying its type as label — instead of vanishing from
+        // the projection with only a reduced count as evidence. (Matches
+        // PatchStoreAdapter's degraded-render fallback.)
+        blockMap.set(id, {
+          id,
+          type: blockState.type,
+          typeLabel: blockState.type,
+          displayName: blockState.displayName || blockState.type,
+          params: blockState.params || {},
+          inputPorts: new Map(),
+          outputPorts: new Map(),
+          controls: [],
+        });
         continue;
       }
 

--- a/src/ui/graphEditor/GraphEditorCore.tsx
+++ b/src/ui/graphEditor/GraphEditorCore.tsx
@@ -143,7 +143,7 @@ function stableParamsSignature(params: Readonly<Record<string, unknown>>): strin
 
 function blockSignature(block: BlockLike): string {
   const inputSig = Array.from(block.inputPorts.values())
-    .map((port) => `${port.id}:${port.label}:${port.typeDisplay?.compatibilityToken ?? ''}:${port.decorations?.length ?? 0}:${port.controls?.length ?? 0}`)
+    .map((port) => `${port.id}:${port.typeDisplay?.compatibilityToken ?? ''}:${port.decorations?.length ?? 0}:${port.controls?.length ?? 0}`)
     .join(';');
   const outputSig = Array.from(block.outputPorts.values())
     .map((port) => `${port.id}:${port.typeDisplay?.compatibilityToken ?? ''}`)

--- a/src/ui/graphEditor/GraphEditorCore.tsx
+++ b/src/ui/graphEditor/GraphEditorCore.tsx
@@ -143,10 +143,10 @@ function stableParamsSignature(params: Readonly<Record<string, unknown>>): strin
 
 function blockSignature(block: BlockLike): string {
   const inputSig = Array.from(block.inputPorts.values())
-    .map((port) => `${port.id}:${port.combineMode}:${port.defaultSource?.blockType ?? ''}:${port.lenses?.length ?? 0}:${port.resolvedType ? 1 : 0}`)
+    .map((port) => `${port.id}:${port.label}:${port.typeDisplay?.compatibilityToken ?? ''}:${port.decorations?.length ?? 0}:${port.controls?.length ?? 0}`)
     .join(';');
   const outputSig = Array.from(block.outputPorts.values())
-    .map((port) => `${port.id}:${port.resolvedType ? 1 : 0}`)
+    .map((port) => `${port.id}:${port.typeDisplay?.compatibilityToken ?? ''}`)
     .join(';');
 
   return [
@@ -213,7 +213,6 @@ export const GraphEditorCoreInner = observer(
       const nodesRef = useRef(nodes);
       const edgesRef = useRef(edges);
       const warnedInvalidEdgeIdsRef = useRef<Set<string>>(new Set());
-      const warnedMissingBlockDefIdsRef = useRef<Set<string>>(new Set());
       const fitViewTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
       nodesRef.current = nodes;
       edgesRef.current = edges;
@@ -255,16 +254,6 @@ export const GraphEditorCoreInner = observer(
             current,
             (blockId) => adapter.getBlockPosition(blockId),
             diagnosticsGetter,
-            (issue) => {
-              if (issue.kind !== 'missingBlockDef') return;
-              const key = `${issue.blockId}:${issue.blockType}`;
-              if (warnedMissingBlockDefIdsRef.current.has(key)) return;
-              warnedMissingBlockDefIdsRef.current.add(key);
-              diagnostics?.log({
-                level: 'warn',
-                message: `Dropped block '${issue.blockId}' from graph projection because block type '${issue.blockType}' is not registered.`,
-              });
-            },
           );
 
           // [LAW:no-shared-mutable-globals] Prune warning cache to current edge IDs
@@ -273,15 +262,6 @@ export const GraphEditorCoreInner = observer(
           for (const warnedId of warnedInvalidEdgeIdsRef.current) {
             if (!liveEdgeIds.has(warnedId)) {
               warnedInvalidEdgeIdsRef.current.delete(warnedId);
-            }
-          }
-
-          const liveMissingBlockKeys = new Set(
-            Array.from(adapter.blocks.values()).map((block) => `${block.id}:${block.type}`),
-          );
-          for (const warnedKey of warnedMissingBlockDefIdsRef.current) {
-            if (!liveMissingBlockKeys.has(warnedKey)) {
-              warnedMissingBlockDefIdsRef.current.delete(warnedKey);
             }
           }
 

--- a/src/ui/graphEditor/PatchStoreAdapter.ts
+++ b/src/ui/graphEditor/PatchStoreAdapter.ts
@@ -1,34 +1,46 @@
 /**
  * PatchStoreAdapter - Adapter for main patch graph editing
  *
- * Wraps PatchStore + LayoutStore to implement GraphDataAdapter.
- * This is a thin wrapper that preserves all existing behavior:
- * - MobX reactivity from PatchStore
- * - Event emission (BlockAdded, EdgeRemoved, etc.)
- * - Position persistence to LayoutStore
+ * Wraps PatchStore + LayoutStore + FrontendResultStore to implement the neutral
+ * GraphDataAdapter. This adapter is the boundary where the V1 backend's
+ * vocabulary (CanonicalType, default sources, provenance, binding) is projected
+ * into the editor's neutral, presentation-ready facts: a type display, a
+ * decoration list, and inline controls. [LAW:effects-at-boundaries]
  *
- * ARCHITECTURAL: This adapter does NOT duplicate logic.
- * It delegates all operations to the underlying stores.
+ * ARCHITECTURAL: This adapter does not duplicate graph logic — mutations
+ * delegate to the underlying stores. It DOES own the V1→neutral projection
+ * (formatting, decoration synthesis), so the renderer can stay pure.
  */
 
 import { makeObservable, computed, runInAction } from 'mobx';
-import type { BlockId, CombineMode, DefaultSource } from '../../types';
-import { portId } from '../../types';
+import type { BlockId, UIControlHint, DefaultSource } from '../../types';
 import type { PatchStore } from '../../stores/PatchStore';
 import type { LayoutStore } from '../../stores/LayoutStore';
 import type { FrontendResultStore } from '../../stores/FrontendResultStore';
-import type { InputPort, OutputPort } from '../../graph/Patch';
-import { getAnyBlockDefinition, type InputDef } from '../../blocks/registry';
+import type { Block, InputPort } from '../../graph/Patch';
+import { getAnyBlockDefinition, type AnyBlockDef, type InputDef } from '../../blocks/registry';
+import { canonicalType, FLOAT } from '../../core/canonical-types';
+import type { InferenceCanonicalType } from '../../core/inference-types';
+import type { PortProvenance } from '../../stores/FrontendResultStore';
+import {
+  formatCanonicalTypeTooltip,
+  formatProvenanceTooltip,
+  getAdapterBadgeLabel,
+  getUnresolvedWarning,
+} from './portTooltipFormatters';
+import { typeDisplayFor, defaultSourceIndicator } from './neutral-projection';
 import type {
   GraphDataAdapter,
   BlockLike,
   EdgeLike,
   InputPortLike,
   OutputPortLike,
+  ParamData,
+  PortDecoration,
 } from './types';
 
 /**
- * Adapter that exposes PatchStore + LayoutStore through GraphDataAdapter interface.
+ * Adapter that exposes PatchStore + LayoutStore through GraphDataAdapter.
  */
 export class PatchStoreAdapter implements GraphDataAdapter<BlockId> {
   constructor(
@@ -47,38 +59,19 @@ export class PatchStoreAdapter implements GraphDataAdapter<BlockId> {
   // Read Operations
   // ---------------------------------------------------------------------------
 
-  /**
-   * Returns all blocks as BlockLike.
-   * PERFORMANCE: Uses MobX computed to cache the transformation.
-   * The underlying patchStore.blocks is already observable.
-   */
   get blocks(): ReadonlyMap<BlockId, BlockLike> {
-    // Transform PatchStore blocks to BlockLike
-    // We create a new Map here, but MobX computed will cache it
     const blockMap = new Map<BlockId, BlockLike>();
 
-    // Read snapshot so MobX tracks it as a dependency of this computed
-    const snapshot = this.frontendStore.snapshot;
-    const hasFrontend = snapshot.status !== 'none';
+    // Read snapshot so MobX tracks it as a dependency of this computed.
+    const hasFrontend = this.frontendStore.snapshot.status !== 'none';
 
     for (const [id, block] of this.patchStore.blocks) {
-      blockMap.set(id, {
-        id,
-        type: block.type,
-        displayName: block.displayName,
-        params: block.params as Record<string, unknown>,
-        inputPorts: this.transformInputPorts(block.inputPorts, hasFrontend ? id : undefined, block.type),
-        outputPorts: this.transformOutputPorts(block.outputPorts, hasFrontend ? id : undefined),
-      });
+      blockMap.set(id, this.toBlockLike(id, block, hasFrontend));
     }
 
     return blockMap;
   }
 
-  /**
-   * Returns all edges as EdgeLike.
-   * PERFORMANCE: Uses MobX computed to cache the transformation.
-   */
   get edges(): readonly EdgeLike[] {
     return this.patchStore.edges.map((edge) => ({
       id: edge.id,
@@ -89,11 +82,6 @@ export class PatchStoreAdapter implements GraphDataAdapter<BlockId> {
     }));
   }
 
-  /**
-   * Version number that changes when frontend snapshot data changes.
-   * Used by MobX reactions to detect data-only changes (port types, default sources)
-   * that don't alter block/edge structure.
-   */
   get dataVersion(): number {
     return this.frontendStore.snapshot.patchRevision;
   }
@@ -102,43 +90,25 @@ export class PatchStoreAdapter implements GraphDataAdapter<BlockId> {
   // Block Operations
   // ---------------------------------------------------------------------------
 
-  /**
-   * Add a new block at the specified position.
-   * Delegates to PatchStore for block creation, LayoutStore for position.
-   */
   addBlock(type: string, position: { x: number; y: number }): BlockId {
     let blockId!: BlockId;
     runInAction(() => {
-      // [LAW:one-source-of-truth] Add + position are committed atomically so graph projection
-      // sees one coherent source of truth for new node placement.
+      // [LAW:one-source-of-truth] Add + position committed atomically.
       blockId = this.patchStore.addBlock(type, {});
       this.layoutStore.setPosition(blockId, position);
     });
     return blockId;
   }
 
-  /**
-   * Remove a block and its connected edges.
-   * Delegates to PatchStore (handles edge removal) and LayoutStore.
-   */
   removeBlock(id: BlockId): void {
-    // PatchStore removes the block and all connected edges
     this.patchStore.removeBlock(id);
-
-    // LayoutStore removes the position
     this.layoutStore.removePosition(id);
   }
 
-  /**
-   * Get block position from LayoutStore.
-   */
   getBlockPosition(id: BlockId): { x: number; y: number } | undefined {
     return this.layoutStore.getPosition(id);
   }
 
-  /**
-   * Set block position in LayoutStore.
-   */
   setBlockPosition(id: BlockId, position: { x: number; y: number }): void {
     this.layoutStore.setPosition(id, position);
   }
@@ -147,26 +117,13 @@ export class PatchStoreAdapter implements GraphDataAdapter<BlockId> {
   // Edge Operations
   // ---------------------------------------------------------------------------
 
-  /**
-   * Add an edge connecting two ports.
-   * Delegates to PatchStore.
-   */
-  addEdge(
-    source: BlockId,
-    sourcePort: string,
-    target: BlockId,
-    targetPort: string
-  ): string {
+  addEdge(source: BlockId, sourcePort: string, target: BlockId, targetPort: string): string {
     return this.patchStore.addEdge(
       { kind: 'port', blockId: source, slotId: sourcePort },
       { kind: 'port', blockId: target, slotId: targetPort }
     );
   }
 
-  /**
-   * Remove an edge.
-   * Delegates to PatchStore.
-   */
   removeEdge(id: string): void {
     this.patchStore.removeEdge(id);
   }
@@ -175,137 +132,174 @@ export class PatchStoreAdapter implements GraphDataAdapter<BlockId> {
   // Optional Operations (PatchStore-specific)
   // ---------------------------------------------------------------------------
 
-  /**
-   * Update block parameters.
-   * Delegates to PatchStore (emits ParamChanged events).
-   */
   updateBlockParams(id: BlockId, params: Record<string, unknown>): void {
     this.patchStore.updateBlockParams(id, params);
   }
 
-  /**
-   * Update block display name.
-   * Delegates to PatchStore (validates uniqueness).
-   */
   updateBlockDisplayName(id: BlockId, displayName: string): { error?: string } {
     return this.patchStore.updateBlockDisplayName(id, displayName);
   }
 
-  /**
-   * Update input port properties.
-   * Delegates to PatchStore.
-   */
-  updateInputPort(
+  // ---------------------------------------------------------------------------
+  // Private: V1 -> neutral projection
+  // ---------------------------------------------------------------------------
+
+  private toBlockLike(id: BlockId, block: Block, hasFrontend: boolean): BlockLike {
+    const blockDef = getAnyBlockDefinition(block.type);
+    const inputPorts = new Map<string, InputPortLike>();
+    const outputPorts = new Map<string, OutputPortLike>();
+    const controls: ParamData[] = [];
+    const handledParamIds = new Set<string>();
+
+    if (blockDef) {
+      for (const [portIdStr, inputDef] of Object.entries(blockDef.inputs)) {
+        if (inputDef.exposedAsPort === false) {
+          // Config-only input -> block-level inline control.
+          const value = block.params[portIdStr] ?? inputDef.defaultValue;
+          if (value !== undefined) {
+            handledParamIds.add(portIdStr);
+            controls.push({
+              id: portIdStr,
+              label: inputDef.label || portIdStr,
+              value,
+              hint: (inputDef as InputDef & { uiHint?: UIControlHint }).uiHint,
+              target: { kind: 'blockParam', blockId: id, paramId: portIdStr },
+            });
+          }
+          continue;
+        }
+        inputPorts.set(
+          portIdStr,
+          this.toInputPortLike(id, portIdStr, inputDef, block.inputPorts.get(portIdStr), blockDef, hasFrontend),
+        );
+      }
+
+      for (const [portIdStr, outputDef] of Object.entries(blockDef.outputs)) {
+        const resolved = hasFrontend
+          ? (this.frontendStore.getResolvedPortTypeByIds(id, portIdStr, 'out') as InferenceCanonicalType | undefined)
+          : undefined;
+        const t = resolved ?? outputDef.type ?? canonicalType(FLOAT);
+        outputPorts.set(portIdStr, {
+          id: portIdStr,
+          label: outputDef.label || portIdStr,
+          typeDisplay: typeDisplayFor(t),
+        });
+      }
+    } else {
+      // No block definition (should be rare for V1): render instance ports raw.
+      for (const [portIdStr, port] of block.inputPorts) {
+        inputPorts.set(portIdStr, { id: port.id, label: portIdStr });
+      }
+      for (const [portIdStr, port] of block.outputPorts) {
+        outputPorts.set(portIdStr, { id: port.id, label: portIdStr });
+      }
+    }
+
+    // Extra persisted params not represented by declared inputs.
+    for (const [paramId, value] of Object.entries(block.params)) {
+      if (handledParamIds.has(paramId)) continue;
+      if (paramId === 'payloadType') continue;
+      if (blockDef && paramId in blockDef.inputs) continue;
+      controls.push({
+        id: paramId,
+        label: paramId,
+        value,
+        target: { kind: 'blockParam', blockId: id, paramId },
+      });
+    }
+
+    return {
+      id,
+      type: block.type,
+      typeLabel: blockDef?.label ?? block.type,
+      displayName: block.displayName,
+      params: block.params as Record<string, unknown>,
+      inputPorts,
+      outputPorts,
+      controls,
+    };
+  }
+
+  private toInputPortLike(
     blockId: BlockId,
     portIdStr: string,
-    updates: { defaultSource?: DefaultSource; combineMode?: CombineMode }
-  ): void {
-    this.patchStore.updateInputPort(blockId, portId(portIdStr), updates);
-  }
-
-  /**
-   * Update input port combine mode.
-   * Delegates to PatchStore.
-   */
-  updateInputPortCombineMode(blockId: BlockId, portIdStr: string, mode: CombineMode): void {
-    this.patchStore.updateInputPortCombineMode(blockId, portId(portIdStr), mode);
-  }
-
-  // ---------------------------------------------------------------------------
-  // Private Helpers
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Transform InputPort map to InputPortLike map.
-   *
-   * When the frontend snapshot is available, default sources come from the
-   * compiler's normalization pass (the single enforcer for "which ports have
-   * materialized defaults"). When no snapshot exists, falls back to instance
-   * overrides and registry defaults.
-   */
-  private transformInputPorts(
-    ports: ReadonlyMap<string, InputPort>,
-    blockId?: BlockId,
-    blockType?: string,
-  ): ReadonlyMap<string, InputPortLike> {
-    const portMap = new Map<string, InputPortLike>();
-    const blockDef = blockType ? getAnyBlockDefinition(blockType) : undefined;
-
-    for (const [id, port] of ports) {
-      // Use frontend snapshot data if available (even from failed compilations - helps debugging)
-      // The snapshot is always the LATEST attempt, so it reflects current patch state
-      const hasSnapshot = this.frontendStore.snapshot.status !== 'none';
-
-      // Determine effective default source
-      let ds: DefaultSource | undefined;
-      if (blockId && hasSnapshot) {
-        // Frontend snapshot is the authority (even if compilation failed)
-        ds = this.frontendStore.getDefaultSourceByIds(blockId, id);
-      }
-
-      // If no snapshot data, fall back to authored control, instance override,
-      // or registry seed.
-      if (!ds) {
-        ds = port.authoredControl?.source
-          ? {
-              blockType: port.authoredControl.source.blockType,
-              output: port.authoredControl.source.outputPortId,
-              params: { ...port.authoredControl.source.params },
-            }
-          : port.defaultSource
-          ?? (blockDef?.inputs[id] as InputDef & { defaultSource?: DefaultSource } | undefined)?.defaultSource;
-      }
-
-      // Resolve type from frontend snapshot when available
-      const resolvedType = blockId && hasSnapshot
-        ? this.frontendStore.getResolvedPortTypeByIds(blockId, id, 'in')
-        : undefined;
-
-      // Get provenance from frontend snapshot
-      // If the snapshot has no data for this port, provenance will be undefined
-      const provenance = blockId && hasSnapshot
-        ? this.frontendStore.getPortProvenanceByIds(blockId, id, 'in')
-        : undefined;
-      const binding = blockId && hasSnapshot
-        ? this.frontendStore.getInputBindingByIds(blockId, id)
-        : undefined;
-
-      portMap.set(id, {
-        id: port.id,
-        combineMode: port.combineMode,
-        authoredControl: port.authoredControl,
-        defaultSource: ds,
-        lenses: port.lenses,
-        resolvedType,
-        provenance,
-        binding,
-      });
+    inputDef: InputDef,
+    port: InputPort | undefined,
+    blockDef: AnyBlockDef,
+    hasFrontend: boolean,
+  ): InputPortLike {
+    // Effective default source: frontend snapshot is the authority; fall back
+    // to authored control, instance override, then registry seed.
+    let ds: DefaultSource | undefined = hasFrontend
+      ? this.frontendStore.getDefaultSourceByIds(blockId, portIdStr)
+      : undefined;
+    if (!ds) {
+      ds = port?.authoredControl?.source
+        ? {
+            blockType: port.authoredControl.source.blockType,
+            output: port.authoredControl.source.outputPortId,
+            params: { ...port.authoredControl.source.params },
+          }
+        : port?.defaultSource
+        ?? (inputDef as InputDef & { defaultSource?: DefaultSource }).defaultSource;
     }
 
-    return portMap;
+    const resolved = hasFrontend
+      ? (this.frontendStore.getResolvedPortTypeByIds(blockId, portIdStr, 'in') as InferenceCanonicalType | undefined)
+      : undefined;
+    const effectiveType = resolved ?? inputDef.type ?? canonicalType(FLOAT);
+    const typeDisplay = typeDisplayFor(effectiveType);
+
+    const provenance = hasFrontend
+      ? this.frontendStore.getPortProvenanceByIds(blockId, portIdStr, 'in')
+      : undefined;
+    const binding = hasFrontend ? this.frontendStore.getInputBindingByIds(blockId, portIdStr) : undefined;
+
+    return {
+      id: port?.id ?? portIdStr,
+      label: inputDef.label || portIdStr,
+      typeDisplay,
+      decorations: this.inputDecorations(ds, provenance, resolved, typeDisplay.tooltip),
+      controls: binding?.controls?.map((control) => ({
+        id: `${portIdStr}:${control.id}`,
+        label: control.label,
+        value: control.value,
+        hint: control.hint,
+        target: control.target,
+      })),
+    };
   }
 
   /**
-   * Transform OutputPort map to OutputPortLike map.
-   * Extracts only the properties needed for rendering.
+   * Project V1 default-source + provenance into neutral port decorations.
+   * The indicator dot is always emitted when a default exists; the renderer
+   * hides it while the port is connected.
    */
-  private transformOutputPorts(
-    ports: ReadonlyMap<string, OutputPort>,
-    blockId?: BlockId,
-  ): ReadonlyMap<string, OutputPortLike> {
-    const portMap = new Map<string, OutputPortLike>();
+  private inputDecorations(
+    ds: DefaultSource | undefined,
+    provenance: PortProvenance | undefined,
+    resolved: InferenceCanonicalType | undefined,
+    typeTooltip: string,
+  ): readonly PortDecoration[] {
+    const decorations: PortDecoration[] = [];
 
-    for (const [id, port] of ports) {
-      const resolvedType = blockId
-        ? this.frontendStore.getResolvedPortTypeByIds(blockId, id, 'out')
-        : undefined;
-
-      portMap.set(id, {
-        id: port.id,
-        resolvedType,
-      });
+    if (ds) {
+      const detail = resolved ? formatCanonicalTypeTooltip(resolved) : typeTooltip;
+      const tooltip = [formatProvenanceTooltip(provenance), detail].join('\n\n');
+      decorations.push(defaultSourceIndicator(ds, tooltip));
     }
 
-    return portMap;
+    if (provenance) {
+      const badge = getAdapterBadgeLabel(provenance);
+      if (badge) {
+        decorations.push({ kind: 'badge', label: badge, tooltip: formatProvenanceTooltip(provenance) });
+      }
+      const warning = getUnresolvedWarning(provenance);
+      if (warning) {
+        decorations.push({ kind: 'warning', label: warning, tooltip: formatProvenanceTooltip(provenance) });
+      }
+    }
+
+    return decorations;
   }
 }

--- a/src/ui/graphEditor/PillarPatchAdapter.ts
+++ b/src/ui/graphEditor/PillarPatchAdapter.ts
@@ -84,7 +84,10 @@ export class PillarPatchAdapter implements GraphDataAdapter<string> {
     return this.store.patch.edges.map((edge) => ({
       id: edge.id,
       sourceBlockId: edge.source,
-      sourcePortId: outputHandleByBlock.get(edge.source) ?? 'out',
+      // On a registry miss use an impossible handle id (never a real port), so
+      // createEdgeFromEdgeLike's handle-validity check drops the edge rather than
+      // risking a coincidental match on a block that happens to expose 'out'.
+      sourcePortId: outputHandleByBlock.get(edge.source) ?? '__unresolved_output__',
       targetBlockId: edge.target,
       targetPortId: edge.inputSlot,
     }));

--- a/src/ui/graphEditor/PillarPatchAdapter.ts
+++ b/src/ui/graphEditor/PillarPatchAdapter.ts
@@ -111,11 +111,21 @@ export class PillarPatchAdapter implements GraphDataAdapter<string> {
   }
 
   getBlockPosition(id: string): { x: number; y: number } | undefined {
-    return this.positions.get(id);
+    const stored = this.positions.get(id);
+    if (stored) return stored;
+    // PillarPatchStore holds no layout, so seed a deterministic left→right
+    // position from the block's index. This keeps nodes readable on first paint
+    // with no dependency on a post-mount auto-layout pass firing at the right
+    // moment. [LAW:no-ambient-temporal-coupling]
+    const idx = this.store.patch.blocks.findIndex((b) => b.id === id);
+    if (idx < 0) return undefined;
+    return { x: idx * 260, y: (idx % 3) * 140 };
   }
 
   setBlockPosition(id: string, position: { x: number; y: number }): void {
-    this.positions.set(id, position);
+    runInAction(() => {
+      this.positions.set(id, position);
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/ui/graphEditor/PillarPatchAdapter.ts
+++ b/src/ui/graphEditor/PillarPatchAdapter.ts
@@ -1,0 +1,185 @@
+/**
+ * PillarPatchAdapter - Adapter for the pillar / ScenePlan authored graph.
+ *
+ * Projects PillarPatchStore (blocks + edges + scene registry) into the editor's
+ * neutral GraphDataAdapter, so the mature ReactFlow editor (GraphEditorCore +
+ * UnifiedNode) can render and edit a pillar patch. Editing flows straight back
+ * to PillarPatchStore, whose `compiled` computed drives the live ScenePlan
+ * preview via RuntimeService — no extra wiring here. [LAW:effects-at-boundaries]
+ *
+ * Positions: PillarPatchStore holds no layout, so this adapter owns an
+ * observable position map (the same role LayoutStore plays for the V1 patch).
+ * The mature editor's autoArrange (ELK) seeds a left→right layout on mount.
+ */
+
+import { makeObservable, computed, observable, runInAction } from 'mobx';
+import type { PillarPatchStore } from '../../stores/PillarPatchStore';
+import type { PillarBlock } from '../../pillars/types/graph';
+import type { SceneCatalogMetadata, SceneValueKind } from '../../pillars/scene/scene-block';
+import type {
+  GraphDataAdapter,
+  BlockLike,
+  EdgeLike,
+  InputPortLike,
+  OutputPortLike,
+  PortTypeDisplay,
+} from './types';
+
+/** Neutral swatch color per scene value kind (parallels the V1 payload palette). */
+const SCENE_VALUE_COLORS: Record<SceneValueKind, string> = {
+  instanceBundle: '#f59e0b',
+  geometry: '#a78bfa',
+  materialShell: '#38bdf8',
+  texture: '#f472b6',
+  camera: '#8b5cf6',
+  color: '#ec4899',
+  scalar: '#5a9fd4',
+  mask: '#10b981',
+};
+
+function sceneTypeDisplay(value: SceneValueKind): PortTypeDisplay {
+  return {
+    label: value,
+    tooltip: value,
+    color: SCENE_VALUE_COLORS[value] ?? '#888888',
+    compatibilityToken: value,
+  };
+}
+
+/**
+ * Adapter exposing PillarPatchStore through the neutral GraphDataAdapter.
+ */
+export class PillarPatchAdapter implements GraphDataAdapter<string> {
+  /** Editor layout positions (PillarPatchStore stores none). */
+  private readonly positions = observable.map<string, { x: number; y: number }>();
+
+  constructor(private readonly store: PillarPatchStore) {
+    makeObservable(this, {
+      blocks: computed,
+      edges: computed,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Read Operations
+  // ---------------------------------------------------------------------------
+
+  get blocks(): ReadonlyMap<string, BlockLike> {
+    const blockMap = new Map<string, BlockLike>();
+    for (const block of this.store.patch.blocks) {
+      blockMap.set(block.id, this.toBlockLike(block));
+    }
+    return blockMap;
+  }
+
+  get edges(): readonly EdgeLike[] {
+    // Pillar edges name only the source *block*; anchor to its sole output port.
+    const outputHandleByBlock = new Map<string, string | undefined>(
+      this.store.patch.blocks.map((b) => [
+        b.id,
+        this.store.registry.get(b.type)?.catalog.ports.find((p) => p.direction === 'output')?.id,
+      ]),
+    );
+
+    return this.store.patch.edges.map((edge) => ({
+      id: edge.id,
+      sourceBlockId: edge.source,
+      sourcePortId: outputHandleByBlock.get(edge.source) ?? 'out',
+      targetBlockId: edge.target,
+      targetPortId: edge.inputSlot,
+    }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // Block Operations
+  // ---------------------------------------------------------------------------
+
+  addBlock(type: string, position: { x: number; y: number }): string {
+    let id!: string;
+    runInAction(() => {
+      id = this.store.addBlock(type);
+      this.positions.set(id, position);
+    });
+    return id;
+  }
+
+  removeBlock(id: string): void {
+    runInAction(() => {
+      this.store.removeBlock(id);
+      this.positions.delete(id);
+    });
+  }
+
+  getBlockPosition(id: string): { x: number; y: number } | undefined {
+    return this.positions.get(id);
+  }
+
+  setBlockPosition(id: string, position: { x: number; y: number }): void {
+    this.positions.set(id, position);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Edge Operations
+  // ---------------------------------------------------------------------------
+
+  addEdge(source: string, _sourcePort: string, target: string, targetPort: string): string {
+    // Pillar wiring is keyed by target input slot; the source output is implied.
+    return this.store.addEdge(source, target, targetPort);
+  }
+
+  removeEdge(id: string): void {
+    this.store.removeEdge(id);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Optional Operations
+  // ---------------------------------------------------------------------------
+
+  updateBlockParams(id: string, params: Record<string, unknown>): void {
+    runInAction(() => {
+      for (const [key, value] of Object.entries(params)) {
+        this.store.updateConfig(id, key, value);
+      }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private: pillar -> neutral projection
+  // ---------------------------------------------------------------------------
+
+  private toBlockLike(block: PillarBlock): BlockLike {
+    const catalog: SceneCatalogMetadata | undefined = this.store.registry.get(block.type)?.catalog;
+    const inputPorts = new Map<string, InputPortLike>();
+    const outputPorts = new Map<string, OutputPortLike>();
+
+    for (const port of catalog?.ports ?? []) {
+      if (port.direction === 'input') {
+        inputPorts.set(port.id, {
+          id: port.id,
+          label: port.label,
+          typeDisplay: sceneTypeDisplay(port.value),
+        });
+      } else {
+        outputPorts.set(port.id, {
+          id: port.id,
+          label: port.label,
+          typeDisplay: sceneTypeDisplay(port.value),
+        });
+      }
+    }
+
+    const displayName = catalog?.displayName ?? block.type;
+    return {
+      id: block.id,
+      type: block.type,
+      typeLabel: displayName,
+      displayName,
+      params: block.config as Record<string, unknown>,
+      inputPorts,
+      outputPorts,
+      // Inline config controls are deferred (add/remove/wire/move is the spike's
+      // required edit set); config editing arrives with the control-affordance seam.
+      controls: [],
+    };
+  }
+}

--- a/src/ui/graphEditor/UnifiedNode.tsx
+++ b/src/ui/graphEditor/UnifiedNode.tsx
@@ -23,32 +23,81 @@ import { observer } from 'mobx-react-lite';
 import { useGraphEditor } from './GraphEditorContext';
 import { useStores } from '../../stores';
 import type { UnifiedNodeData, PortData } from './nodeDataTransform';
-import type { DefaultSource, PortId, BlockId } from '../../types';
+import type { PortDecoration } from './types';
+import type { PortId, BlockId } from '../../types';
 import { getAnyBlockDefinition, DEFAULT_BLOCK_UI } from '../../blocks/registry';
 import { ParameterControl } from '../reactFlowEditor/ParameterControls';
 import { PortInfoPopover } from '../reactFlowEditor/PortInfoPopover';
 import { usePinPopoverState, type PopoverAnchorPosition } from '../reactFlowEditor/BasePopover';
 import { DisplayNameEditor } from '../components/DisplayNameEditor';
-import {
-  formatProvenanceTooltip,
-  formatCanonicalTypeTooltip,
-  getAdapterBadgeLabel,
-  getUnresolvedWarning,
-} from './portTooltipFormatters';
 import { resolvePortStyle } from './port-style';
 import { graphColors } from './graph-tokens';
-import { isTimeDefaultSource } from '../defaultSourcePresentation';
 import { DockviewContext } from '../dockview';
 import { getBlockOpenBehaviorLabel, hasBlockOpenBehavior, runBlockOpenBehavior } from '../block-ui';
 
 /**
- * Get indicator color based on default source type.
+ * Render an input port's neutral decorations beside its handle.
+ *
+ * [LAW:single-enforcer] This is the one place that maps a decoration kind to
+ * pixels; providers pre-compute the label/color/tooltip. `indicator`
+ * decorations (a default-source dot) hide when the port is connected; badges
+ * and warnings always show.
  */
-function getIndicatorColor(ds: DefaultSource): string {
-  if (isTimeDefaultSource(ds)) {
-    return graphColors.timeRootIndicator;
-  }
-  return graphColors.defaultSourceIndicator;
+function renderInputDecorations(
+  decorations: readonly PortDecoration[],
+  isConnected: boolean,
+  topPercent: number,
+): React.ReactNode {
+  return decorations.map((dec, i) => {
+    if (dec.kind === 'indicator') {
+      if (isConnected) return null;
+      return (
+        <div
+          key={`dec-${i}`}
+          style={{
+            position: 'absolute',
+            left: '-3px',
+            top: `calc(${topPercent}% - 12px)`,
+            width: '6px',
+            height: '6px',
+            borderRadius: '50%',
+            background: dec.color ?? graphColors.defaultSourceIndicator,
+            pointerEvents: 'none',
+          }}
+          title={dec.tooltip}
+        />
+      );
+    }
+
+    const background =
+      dec.kind === 'warning'
+        ? graphColors.unresolvedBadge
+        : dec.color ?? graphColors.adapterBadge;
+    return (
+      <div
+        key={`dec-${i}`}
+        style={{
+          position: 'absolute',
+          left: '-18px',
+          top: `calc(${topPercent}% - 4px)`,
+          width: '12px',
+          height: '12px',
+          borderRadius: '3px',
+          background,
+          color: '#fff',
+          fontSize: '10px',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          pointerEvents: 'none',
+          fontWeight: 'bold',
+        }}
+        title={dec.tooltip}
+      >
+        {dec.label}
+      </div>
+    );
+  });
 }
 
 /**
@@ -301,75 +350,8 @@ export const UnifiedNode: React.FC<NodeProps<UnifiedNodeData>> = observer(({ dat
               }}
             />
 
-            {/* Default Source Indicator */}
-            {!input.isConnected && input.defaultSource && (
-              <div
-                style={{
-                  position: 'absolute',
-                  left: '-3px',
-                  top: `calc(${topPercent}% - 12px)`,
-                  width: '6px',
-                  height: '6px',
-                  borderRadius: '50%',
-                  background: getIndicatorColor(input.defaultSource),
-                  pointerEvents: 'none',
-                }}
-                title={[
-                  formatProvenanceTooltip(input.provenance),
-                  input.resolvedType ? formatCanonicalTypeTooltip(input.resolvedType) : input.typeTooltip,
-                ].join('\n\n')}
-              />
-            )}
-
-            {/* Adapter Badge */}
-            {input.provenance && getAdapterBadgeLabel(input.provenance) && (
-              <div
-                style={{
-                  position: 'absolute',
-                  left: '-18px',
-                  top: `calc(${topPercent}% - 4px)`,
-                  width: '12px',
-                  height: '12px',
-                  borderRadius: '3px',
-                  background: graphColors.adapterBadge,
-                  color: '#fff',
-                  fontSize: '10px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  pointerEvents: 'none',
-                  fontWeight: 'bold',
-                }}
-                title={formatProvenanceTooltip(input.provenance)}
-              >
-                {getAdapterBadgeLabel(input.provenance)}
-              </div>
-            )}
-
-            {/* Unresolved Warning */}
-            {input.provenance && getUnresolvedWarning(input.provenance) && (
-              <div
-                style={{
-                  position: 'absolute',
-                  left: '-18px',
-                  top: `calc(${topPercent}% - 4px)`,
-                  width: '12px',
-                  height: '12px',
-                  borderRadius: '3px',
-                  background: graphColors.unresolvedBadge,
-                  color: '#fff',
-                  fontSize: '10px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  pointerEvents: 'none',
-                  fontWeight: 'bold',
-                }}
-                title={formatProvenanceTooltip(input.provenance)}
-              >
-                {getUnresolvedWarning(input.provenance)}
-              </div>
-            )}
+            {/* Neutral port decorations (default-source dot, adapter badge, warning) */}
+            {renderInputDecorations(input.decorations, input.isConnected, topPercent)}
           </React.Fragment>
         );
       })}

--- a/src/ui/graphEditor/UnifiedNode.tsx
+++ b/src/ui/graphEditor/UnifiedNode.tsx
@@ -48,6 +48,10 @@ function renderInputDecorations(
   isConnected: boolean,
   topPercent: number,
 ): React.ReactNode {
+  // Square badges/warnings share a column; stack them vertically so a port that
+  // carries more than one (e.g. co-emitted adapter badge + unresolved warning)
+  // never renders them on top of each other.
+  let squareIndex = 0;
   return decorations.map((dec, i) => {
     if (dec.kind === 'indicator') {
       if (isConnected) return null;
@@ -69,6 +73,8 @@ function renderInputDecorations(
       );
     }
 
+    const stackOffset = squareIndex * 14;
+    squareIndex += 1;
     const background =
       dec.kind === 'warning'
         ? graphColors.unresolvedBadge
@@ -79,7 +85,7 @@ function renderInputDecorations(
         style={{
           position: 'absolute',
           left: '-18px',
-          top: `calc(${topPercent}% - 4px)`,
+          top: `calc(${topPercent}% - 4px + ${stackOffset}px)`,
           width: '12px',
           height: '12px',
           borderRadius: '3px',

--- a/src/ui/graphEditor/__tests__/PillarPatchAdapter.test.ts
+++ b/src/ui/graphEditor/__tests__/PillarPatchAdapter.test.ts
@@ -66,6 +66,16 @@ describe('PillarPatchAdapter', () => {
     expect(adapter.getBlockPosition(id)).toBeUndefined();
   });
 
+  it('writes block config through updateBlockParams (the inline-control path)', () => {
+    const store = new PillarPatchStore();
+    const adapter = new PillarPatchAdapter(store);
+
+    const id = adapter.addBlock('Constant', { x: 0, y: 0 });
+    adapter.updateBlockParams(id, { value: 0.7 });
+
+    expect(adapter.blocks.get(id)!.params.value).toBe(0.7);
+  });
+
   it('round-trips an edge through removeEdge + addEdge (delegating to the store)', () => {
     const store = new PillarPatchStore();
     const adapter = new PillarPatchAdapter(store);

--- a/src/ui/graphEditor/__tests__/PillarPatchAdapter.test.ts
+++ b/src/ui/graphEditor/__tests__/PillarPatchAdapter.test.ts
@@ -82,5 +82,8 @@ describe('PillarPatchAdapter', () => {
     expect(rewired.sourceBlockId).toBe(sourceBlockId);
     expect(rewired.targetBlockId).toBe(targetBlockId);
     expect(rewired.targetPortId).toBe(targetPortId);
+    // The source output handle is re-derived from the registry (the pillar store
+    // holds only source block identity); it must resolve back to the same port.
+    expect(rewired.sourcePortId).toBe(sourcePortId);
   });
 });

--- a/src/ui/graphEditor/__tests__/PillarPatchAdapter.test.ts
+++ b/src/ui/graphEditor/__tests__/PillarPatchAdapter.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { PillarPatchStore } from '../../../stores/PillarPatchStore';
+import { PillarPatchAdapter } from '../PillarPatchAdapter';
+
+/**
+ * Behavioural coverage for the pillar provider of the neutral GraphDataAdapter.
+ * A fuller cross-era conformance suite lands with oscilla-editor-ux-8lsn.15;
+ * this locks the pillar projection + mutation surface the spike relies on.
+ */
+describe('PillarPatchAdapter', () => {
+  it('projects every pillar block into a self-describing neutral BlockLike', () => {
+    const store = new PillarPatchStore();
+    const adapter = new PillarPatchAdapter(store);
+
+    expect(adapter.blocks.size).toBe(store.patch.blocks.length);
+
+    for (const block of store.patch.blocks) {
+      const like = adapter.blocks.get(block.id)!;
+      expect(like).toBeDefined();
+      expect(like.typeLabel.length).toBeGreaterThan(0);
+      // Every port carries its own label + type display (self-describing).
+      for (const port of [...like.inputPorts.values(), ...like.outputPorts.values()]) {
+        expect(port.label.length).toBeGreaterThan(0);
+        expect(port.typeDisplay?.color).toMatch(/^#/);
+        expect(port.typeDisplay?.compatibilityToken.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('projects pillar edges, anchoring the source to its sole output port', () => {
+    const store = new PillarPatchStore();
+    const adapter = new PillarPatchAdapter(store);
+
+    expect(adapter.edges.length).toBe(store.patch.edges.length);
+
+    for (const edge of store.patch.edges) {
+      const projected = adapter.edges.find((e) => e.id === edge.id)!;
+      expect(projected.sourceBlockId).toBe(edge.source);
+      expect(projected.targetBlockId).toBe(edge.target);
+      // Target port is the authored input slot; source port is a real output handle.
+      expect(projected.targetPortId).toBe(edge.inputSlot);
+      const sourceLike = adapter.blocks.get(edge.source)!;
+      expect(sourceLike.outputPorts.has(projected.sourcePortId)).toBe(true);
+    }
+  });
+
+  it('adds/removes blocks and tracks editor positions (which the store does not hold)', () => {
+    const store = new PillarPatchStore();
+    const adapter = new PillarPatchAdapter(store);
+    const before = adapter.blocks.size;
+
+    const id = adapter.addBlock('Constant', { x: 5, y: 6 });
+    expect(adapter.blocks.size).toBe(before + 1);
+    expect(adapter.getBlockPosition(id)).toEqual({ x: 5, y: 6 });
+
+    const added = adapter.blocks.get(id)!;
+    const output = added.outputPorts.get('value')!;
+    expect(output.label).toBe('Value');
+    expect(output.typeDisplay?.color).toMatch(/^#/);
+
+    adapter.setBlockPosition(id, { x: 9, y: 9 });
+    expect(adapter.getBlockPosition(id)).toEqual({ x: 9, y: 9 });
+
+    adapter.removeBlock(id);
+    expect(adapter.blocks.has(id)).toBe(false);
+    expect(adapter.getBlockPosition(id)).toBeUndefined();
+  });
+
+  it('round-trips an edge through removeEdge + addEdge (delegating to the store)', () => {
+    const store = new PillarPatchStore();
+    const adapter = new PillarPatchAdapter(store);
+
+    const seedEdge = adapter.edges[0];
+    expect(seedEdge).toBeDefined();
+    const { sourceBlockId, sourcePortId, targetBlockId, targetPortId } = seedEdge;
+
+    adapter.removeEdge(seedEdge.id);
+    expect(adapter.edges.some((e) => e.id === seedEdge.id)).toBe(false);
+
+    const newId = adapter.addEdge(sourceBlockId, sourcePortId, targetBlockId, targetPortId);
+    const rewired = adapter.edges.find((e) => e.id === newId)!;
+    expect(rewired.sourceBlockId).toBe(sourceBlockId);
+    expect(rewired.targetBlockId).toBe(targetBlockId);
+    expect(rewired.targetPortId).toBe(targetPortId);
+  });
+});

--- a/src/ui/graphEditor/__tests__/nodeDataTransform.params.test.ts
+++ b/src/ui/graphEditor/__tests__/nodeDataTransform.params.test.ts
@@ -1,140 +1,61 @@
 import { describe, expect, it } from 'vitest';
 import { createNodeFromBlockLike } from '../nodeDataTransform';
-import { getAnyBlockDefinition } from '../../../blocks/registry';
-import { registerAllBlocks } from '../../../blocks/all';
-import type { BlockLike, EdgeLike } from '../types';
+import type { BlockLike, EdgeLike, InputPortLike } from '../types';
 import type { BlockId, PortId } from '../../../types';
 
-registerAllBlocks();
+/**
+ * A self-describing input port whose single inline control mirrors what
+ * PatchStoreAdapter emits for a default-sourced Const input (control id is
+ * `${portId}:value`, targeting the binding source param).
+ */
+function controllablePort(portId: string, label: string, value: number): InputPortLike {
+  return {
+    id: portId,
+    label,
+    controls: [{
+      id: `${portId}:value`,
+      label,
+      value,
+      hint: { kind: 'slider', min: 0, max: 1, step: 0.001 },
+      target: {
+        kind: 'bindingSourceParam',
+        blockId: 'ellipse-1' as BlockId,
+        portId: portId as PortId,
+        sourceBlockType: 'Const',
+        sourceOutputPortId: 'out' as PortId,
+        paramId: 'value',
+      },
+    }],
+  };
+}
 
-function ellipseBlock(params: Record<string, unknown> = {}): BlockLike {
+function ellipseBlock(): BlockLike {
   return {
     id: 'ellipse-1',
     type: 'Ellipse',
+    typeLabel: 'Ellipse',
     displayName: 'Ellipse 1',
-    params,
+    params: {},
     inputPorts: new Map([
-      ['rx', {
-        id: 'rx',
-        combineMode: 'last',
-        binding: {
-          kind: 'resolved',
-          writerCount: 1,
-          sourceKind: 'defaultSource',
-          sourceBlockType: 'Const',
-          sourcePortId: 'out',
-          chain: [],
-          controls: [{
-            id: 'value',
-            label: 'Radius X',
-            value: 0.02,
-            hint: { kind: 'slider', min: 0.005, max: 0.08, step: 0.001 },
-            target: {
-              kind: 'bindingSourceParam',
-              blockId: 'ellipse-1' as BlockId,
-              portId: 'rx' as PortId,
-              sourceBlockType: 'Const',
-              sourceOutputPortId: 'out' as PortId,
-              paramId: 'value',
-            },
-          }],
-        },
-      }],
-      ['ry', {
-        id: 'ry',
-        combineMode: 'last',
-        binding: {
-          kind: 'resolved',
-          writerCount: 1,
-          sourceKind: 'defaultSource',
-          sourceBlockType: 'Const',
-          sourcePortId: 'out',
-          chain: [],
-          controls: [{
-            id: 'value',
-            label: 'Radius Y',
-            value: 0.02,
-            hint: { kind: 'slider', min: 0.005, max: 0.08, step: 0.001 },
-            target: {
-              kind: 'bindingSourceParam',
-              blockId: 'ellipse-1' as BlockId,
-              portId: 'ry' as PortId,
-              sourceBlockType: 'Const',
-              sourceOutputPortId: 'out' as PortId,
-              paramId: 'value',
-            },
-          }],
-        },
-      }],
-      ['rotation', {
-        id: 'rotation',
-        combineMode: 'last',
-        binding: {
-          kind: 'resolved',
-          writerCount: 1,
-          sourceKind: 'defaultSource',
-          sourceBlockType: 'Const',
-          sourcePortId: 'out',
-          chain: [],
-          controls: [{
-            id: 'value',
-            label: 'Rotation',
-            value: 0,
-            hint: { kind: 'slider', min: 0, max: 6.28, step: 0.01 },
-            target: {
-              kind: 'bindingSourceParam',
-              blockId: 'ellipse-1' as BlockId,
-              portId: 'rotation' as PortId,
-              sourceBlockType: 'Const',
-              sourceOutputPortId: 'out' as PortId,
-              paramId: 'value',
-            },
-          }],
-        },
-      }],
-      ['resolution', {
-        id: 'resolution',
-        combineMode: 'last',
-        binding: {
-          kind: 'resolved',
-          writerCount: 1,
-          sourceKind: 'defaultSource',
-          sourceBlockType: 'Const',
-          sourcePortId: 'out',
-          chain: [],
-          controls: [{
-            id: 'value',
-            label: 'Resolution',
-            value: 64,
-            hint: { kind: 'slider', min: 16, max: 128, step: 1 },
-            target: {
-              kind: 'bindingSourceParam',
-              blockId: 'ellipse-1' as BlockId,
-              portId: 'resolution' as PortId,
-              sourceBlockType: 'Const',
-              sourceOutputPortId: 'out' as PortId,
-              paramId: 'value',
-            },
-          }],
-        },
-      }],
+      ['rx', controllablePort('rx', 'Radius X', 0.02)],
+      ['ry', controllablePort('ry', 'Radius Y', 0.02)],
+      ['rotation', controllablePort('rotation', 'Rotation', 0)],
+      ['resolution', controllablePort('resolution', 'Resolution', 64)],
     ]),
     outputPorts: new Map([
-      ['shape', { id: 'shape' }],
-      ['controlPoints', { id: 'controlPoints' }],
+      ['shape', { id: 'shape', label: 'shape' }],
+      ['controlPoints', { id: 'controlPoints', label: 'controlPoints' }],
     ]),
+    controls: [],
   };
 }
 
 describe('createNodeFromBlockLike controllable params', () => {
-  it('projects unconnected exposed const defaults as controllable params', () => {
+  it('projects unconnected exposed inputs\' controls as node params', () => {
     const block = ellipseBlock();
-    const blockDef = getAnyBlockDefinition(block.type);
-    expect(blockDef).toBeDefined();
 
     const node = createNodeFromBlockLike(
       block,
-      blockDef!,
       [],
       new Map([[block.id, block]]),
       { x: 0, y: 0 },
@@ -152,10 +73,12 @@ describe('createNodeFromBlockLike controllable params', () => {
     const source: BlockLike = {
       id: 'const-1',
       type: 'Const',
+      typeLabel: 'Const',
       displayName: 'Const 1',
       params: { value: 0.1 },
       inputPorts: new Map(),
-      outputPorts: new Map([['out', { id: 'out' }]]),
+      outputPorts: new Map([['out', { id: 'out', label: 'out' }]]),
+      controls: [],
     };
     const edge: EdgeLike = {
       id: 'e1',
@@ -164,12 +87,9 @@ describe('createNodeFromBlockLike controllable params', () => {
       targetBlockId: block.id,
       targetPortId: 'rx',
     };
-    const blockDef = getAnyBlockDefinition(block.type);
-    expect(blockDef).toBeDefined();
 
     const node = createNodeFromBlockLike(
       block,
-      blockDef!,
       [edge],
       new Map([
         [source.id, source],

--- a/src/ui/graphEditor/neutral-projection.ts
+++ b/src/ui/graphEditor/neutral-projection.ts
@@ -1,0 +1,40 @@
+/**
+ * neutral-projection - project V1 backend facts into the editor's neutral
+ * presentation vocabulary.
+ *
+ * Shared by the V1 providers (PatchStoreAdapter, CompositeStoreAdapter) so the
+ * V1→neutral mapping lives in exactly one place. [LAW:one-source-of-truth]
+ */
+
+import { canonicalType, FLOAT } from '../../core/canonical-types';
+import type { InferenceCanonicalType } from '../../core/inference-types';
+import type { DefaultSource } from '../../types';
+import { formatTypeForDisplay, formatTypeForTooltip, getTypeColor } from '../reactFlowEditor/typeValidation';
+import { isTimeDefaultSource } from '../defaultSourcePresentation';
+import { graphColors } from './graph-tokens';
+import type { PortTypeDisplay, PortDecoration } from './types';
+
+/** Neutral type shown for a port with no known type (matches V1's float default). */
+export const UNTYPED_TYPE: InferenceCanonicalType = canonicalType(FLOAT);
+
+/** Neutral presentation of a (possibly resolved) V1 canonical type. */
+export function typeDisplayFor(t: InferenceCanonicalType): PortTypeDisplay {
+  const label = formatTypeForDisplay(t);
+  return {
+    label,
+    tooltip: formatTypeForTooltip(t),
+    color: getTypeColor(t.payload),
+    // Display-only grouping token; wiring legality is a separate concern.
+    compatibilityToken: label,
+  };
+}
+
+/** Indicator dot color for a default source (time roots read distinctly). */
+export function indicatorColor(ds: DefaultSource): string {
+  return isTimeDefaultSource(ds) ? graphColors.timeRootIndicator : graphColors.defaultSourceIndicator;
+}
+
+/** A default-source indicator decoration (renderer hides it while connected). */
+export function defaultSourceIndicator(ds: DefaultSource, tooltip: string): PortDecoration {
+  return { kind: 'indicator', color: indicatorColor(ds), tooltip };
+}

--- a/src/ui/graphEditor/nodeDataTransform.ts
+++ b/src/ui/graphEditor/nodeDataTransform.ts
@@ -1,25 +1,25 @@
 /**
  * nodeDataTransform - Transform adapter data to ReactFlow nodes/edges
  *
- * Adapter-agnostic version of nodes.ts transformation logic.
- * Works with BlockLike/EdgeLike instead of Block/Edge from PatchStore.
+ * Works with the neutral adapter vocabulary (BlockLike/EdgeLike and their
+ * self-describing ports) rather than any backend's block/port model.
  *
- * ARCHITECTURAL: Single source of truth is the adapter.
- * This module only transforms data for presentation, never stores state.
+ * ARCHITECTURAL: Single source of truth is the adapter. This module only
+ * transforms data for presentation, never stores state, and NEVER consults a
+ * backend block registry — a BlockLike carries everything needed to render it.
+ * [LAW:composability]
  */
 
 import type { Node, Edge as ReactFlowEdge } from 'reactflow';
-import type { BlockLike, EdgeLike, GraphDataAdapter, ParamData } from './types';
-import type { DefaultSource, UIControlHint } from '../../types';
-import type { BlockId } from '../../types';
-import type { LensAttachment } from '../../graph/Patch';
-import { getAnyBlockDefinition, type AnyBlockDef, type InputDef } from '../../blocks/registry';
-import { FLOAT, canonicalType } from '../../core/canonical-types';
-import type { InferenceCanonicalType, InferencePayloadType } from '../../core/inference-types';
-import { formatTypeForTooltip, getTypeColor } from '../reactFlowEditor/typeValidation';
+import type {
+  BlockLike,
+  EdgeLike,
+  GraphDataAdapter,
+  ParamData,
+  PortDecoration,
+  PortTypeDisplay,
+} from './types';
 import type { OscillaEdgeData } from '../reactFlowEditor/nodes';
-import { lensTargetsConnection } from '../reactFlowEditor/lensUtils';
-import type { PortProvenance } from '../../stores/FrontendResultStore';
 import type { Diagnostic } from '../../diagnostics/types';
 
 /**
@@ -32,27 +32,30 @@ export interface PortConnectionInfo {
   edgeId: string;
 }
 
+/** Neutral fallback color for ports with no resolved type. */
+const UNTYPED_PORT_COLOR = '#888888';
+
 /**
- * Port data for ReactFlow rendering
+ * Port data for ReactFlow rendering. Neutral: carries presentation-ready type
+ * color/tooltip and a decoration list; no backend type objects.
  */
 export interface PortData {
   id: string;
   label: string;
-  defaultSource?: DefaultSource;
-  payloadType: InferencePayloadType;
-  typeTooltip: string;
+  /** Handle/swatch color (from the port's neutral type display). */
   typeColor: string;
+  /** Type tooltip text (from the port's neutral type display). */
+  typeTooltip: string;
+  /** Full neutral type display, when known. */
+  typeDisplay?: PortTypeDisplay;
+  /** Visual annotations painted beside the handle. */
+  decorations: readonly PortDecoration[];
   isConnected: boolean;
   connection?: PortConnectionInfo;
-  uiHint?: UIControlHint;
-  lenses?: readonly LensAttachment[];
-  resolvedType?: InferenceCanonicalType;
-  provenance?: PortProvenance;
 }
 
 /**
  * Custom data stored in each ReactFlow node.
- * Adapter-agnostic version of OscillaNodeData.
  */
 export interface UnifiedNodeData {
   blockId: string;
@@ -70,51 +73,32 @@ export interface UnifiedNodeData {
  */
 export type UnifiedNode = Node<UnifiedNodeData>;
 
-/**
- * Create port data with type information.
- */
-function createPortData(
+function portData(
   id: string,
   label: string,
-  type: InferenceCanonicalType | undefined,
+  typeDisplay: PortTypeDisplay | undefined,
+  decorations: readonly PortDecoration[],
   isConnected: boolean,
-  defaultSource?: DefaultSource,
   connection?: PortConnectionInfo,
-  uiHint?: UIControlHint,
-  lenses?: readonly LensAttachment[],
-  provenance?: PortProvenance
 ): PortData {
-  // For inputs without a type (non-port inputs), use a default
-  const effectiveType: InferenceCanonicalType = type || canonicalType(FLOAT);
-
   return {
     id,
     label,
-    defaultSource,
-    payloadType: effectiveType.payload,
-    typeTooltip: formatTypeForTooltip(effectiveType),
-    typeColor: getTypeColor(effectiveType.payload),
+    typeColor: typeDisplay?.color ?? UNTYPED_PORT_COLOR,
+    typeTooltip: typeDisplay?.tooltip ?? label,
+    typeDisplay,
+    decorations,
     isConnected,
     connection,
-    uiHint,
-    lenses,
-    resolvedType: type,
-    provenance,
   };
 }
 
 /**
- * Create ReactFlow node from adapter BlockLike.
- *
- * @param block - Block from adapter
- * @param blockDef - Block definition from registry
- * @param edges - All edges from adapter (for connection info)
- * @param blocks - All blocks from adapter (for looking up connected block labels)
- * @param position - Position for this node
+ * Create ReactFlow node from a neutral BlockLike. Enumerates ports from the
+ * block itself (self-describing) — no registry lookup.
  */
 export function createNodeFromBlockLike(
   block: BlockLike,
-  blockDef: AnyBlockDef,
   edges: readonly EdgeLike[],
   blocks: ReadonlyMap<string, BlockLike>,
   position: { x: number; y: number }
@@ -124,138 +108,70 @@ export function createNodeFromBlockLike(
   const outputConnections = new Map<string, PortConnectionInfo>();
 
   for (const edge of edges) {
-    // Input connection: edge goes TO this block
-    if (edge.targetBlockId === block.id) {
-      // An input can legally have multiple incoming edges (combine). For UI summary,
-      // keep the first one we encounter to avoid nondeterministic overwrites.
-      if (!inputConnections.has(edge.targetPortId)) {
-        const sourceBlock = blocks.get(edge.sourceBlockId);
-        inputConnections.set(edge.targetPortId, {
-          blockId: edge.sourceBlockId,
-          blockLabel: sourceBlock?.displayName || edge.sourceBlockId,
-          portId: edge.sourcePortId,
-          edgeId: edge.id,
-        });
-      }
+    // Input connection: edge goes TO this block. An input can legally have
+    // multiple incoming edges (combine); keep the first for a stable summary.
+    if (edge.targetBlockId === block.id && !inputConnections.has(edge.targetPortId)) {
+      const sourceBlock = blocks.get(edge.sourceBlockId);
+      inputConnections.set(edge.targetPortId, {
+        blockId: edge.sourceBlockId,
+        blockLabel: sourceBlock?.displayName || edge.sourceBlockId,
+        portId: edge.sourcePortId,
+        edgeId: edge.id,
+      });
     }
 
-    // Output connection: edge goes FROM this block
-    if (edge.sourceBlockId === block.id) {
-      // An output can have many outgoing edges. For UI summary, keep the first.
-      if (!outputConnections.has(edge.sourcePortId)) {
-        const targetBlock = blocks.get(edge.targetBlockId);
-        outputConnections.set(edge.sourcePortId, {
-          blockId: edge.targetBlockId,
-          blockLabel: targetBlock?.displayName || edge.targetBlockId,
-          portId: edge.targetPortId,
-          edgeId: edge.id,
-        });
-      }
+    // Output connection: edge goes FROM this block. Keep the first for summary.
+    if (edge.sourceBlockId === block.id && !outputConnections.has(edge.sourcePortId)) {
+      const targetBlock = blocks.get(edge.targetBlockId);
+      outputConnections.set(edge.sourcePortId, {
+        blockId: edge.targetBlockId,
+        blockLabel: targetBlock?.displayName || edge.targetBlockId,
+        portId: edge.targetPortId,
+        edgeId: edge.id,
+      });
     }
   }
 
-  // Build input ports
+  // Build input ports directly from the self-describing block.
   const inputs: PortData[] = [];
-  for (const [inputId, inputDef] of Object.entries(blockDef.inputs)) {
-    // Skip non-port inputs (internal only)
-    if (inputDef.exposedAsPort === false) continue;
-
-    const portState = block.inputPorts.get(inputId);
-    const defaultSource = portState?.defaultSource || (inputDef as InputDef & { defaultSource?: DefaultSource }).defaultSource;
+  for (const [inputId, port] of block.inputPorts) {
     const connection = inputConnections.get(inputId);
-    const isConnected = connection !== undefined;
-
     inputs.push(
-      createPortData(
+      portData(
         inputId,
-        inputDef.label || inputId, // Fallback to inputId if label undefined
-        portState?.resolvedType ?? inputDef.type,
-        isConnected,
-        defaultSource,
+        port.label,
+        port.typeDisplay,
+        port.decorations ?? [],
+        connection !== undefined,
         connection,
-        (inputDef as InputDef & { uiHint?: UIControlHint }).uiHint,
-        portState?.lenses,
-        portState?.provenance
       )
     );
   }
 
-  // Build output ports
+  // Build output ports directly from the self-describing block.
   const outputs: PortData[] = [];
-  for (const [outputId, outputDef] of Object.entries(blockDef.outputs)) {
-    const outputPortState = block.outputPorts.get(outputId);
+  for (const [outputId, port] of block.outputPorts) {
     const connection = outputConnections.get(outputId);
-    const isConnected = connection !== undefined;
-
     outputs.push(
-      createPortData(
+      portData(
         outputId,
-        outputDef.label || outputId, // Fallback to outputId if label undefined
-        outputPortState?.resolvedType ?? outputDef.type,
-        isConnected,
-        undefined,
-        connection
+        port.label,
+        port.typeDisplay,
+        [],
+        connection !== undefined,
+        connection,
       )
     );
   }
 
-  // Build inline controls from frontend-derived binding semantics for exposed
-  // inputs, plus direct block config for config-only inputs.
-  // [LAW:one-source-of-truth] Binding controls come from the frontend semantic
-  // snapshot; config controls write directly to the owning block params.
-  const paramsById = new Map<string, ParamData>();
-  for (const [inputId, inputDef] of Object.entries(blockDef.inputs)) {
-    const isExposedPort = inputDef.exposedAsPort !== false;
-    const isConnected = inputConnections.has(inputId);
-    if (isExposedPort) {
-      if (isConnected) continue;
-
-      const bindingControls = block.inputPorts.get(inputId)?.binding?.controls ?? [];
-      for (const control of bindingControls) {
-        paramsById.set(`${inputId}:${control.id}`, {
-          id: `${inputId}:${control.id}`,
-          label: control.label,
-          value: control.value,
-          hint: control.hint,
-          target: control.target,
-        });
-      }
-      continue;
-    }
-
-    const value = block.params[inputId] ?? inputDef.defaultValue;
-    if (value === undefined) continue;
-
-    paramsById.set(inputId, {
-      id: inputId,
-      label: inputDef.label || inputId,
-      value,
-      hint: inputDef.uiHint,
-      target: {
-        kind: 'blockParam',
-        blockId: block.id as BlockId,
-        paramId: inputId,
-      },
-    });
+  // Inline controls: block-level config controls, plus per-port controls for
+  // exposed inputs that are currently unconnected. The provider owns which
+  // controls exist and where they write. [LAW:one-source-of-truth]
+  const params: ParamData[] = [...block.controls];
+  for (const [inputId, port] of block.inputPorts) {
+    if (inputConnections.has(inputId)) continue;
+    if (port.controls) params.push(...port.controls);
   }
-
-  // Add extra persisted params not represented by declared block inputs.
-  for (const [paramId, value] of Object.entries(block.params)) {
-    if (paramsById.has(paramId)) continue;
-    if (paramId === 'payloadType') continue;
-    if (paramId in blockDef.inputs) continue;
-    paramsById.set(paramId, {
-      id: paramId,
-      label: paramId,
-      value,
-      target: {
-        kind: 'blockParam',
-        blockId: block.id as BlockId,
-        paramId,
-      },
-    });
-  }
-  const params = Array.from(paramsById.values());
 
   const commentText = block.type === 'Comment'
     ? (typeof block.params.text === 'string'
@@ -272,7 +188,7 @@ export function createNodeFromBlockLike(
     data: {
       blockId: block.id,
       blockType: block.type,
-      label: blockDef.label,
+      label: block.typeLabel,
       displayName: block.displayName,
       commentText,
       inputs,
@@ -283,16 +199,13 @@ export function createNodeFromBlockLike(
 }
 
 /**
- * Create ReactFlow edge from adapter EdgeLike.
- * Populates lens data from target port when blocks are available.
- * Optionally includes diagnostics for error visualization.
+ * Create ReactFlow edge from a neutral EdgeLike.
  */
 export function createEdgeFromEdgeLike(
   edge: EdgeLike,
   blocks?: ReadonlyMap<string, BlockLike>,
   diagnosticsGetter?: (edge: EdgeLike) => Diagnostic[]
 ): ReactFlowEdge<OscillaEdgeData> | null {
-  // Look up lenses from target port
   const sourceBlock = blocks?.get(edge.sourceBlockId);
   const targetBlock = blocks?.get(edge.targetBlockId);
 
@@ -301,18 +214,6 @@ export function createEdgeFromEdgeLike(
   if (sourceBlock && !sourceBlock.outputPorts.has(edge.sourcePortId)) return null;
   if (targetBlock && !targetBlock.inputPorts.has(edge.targetPortId)) return null;
 
-  const targetPort = targetBlock?.inputPorts.get(edge.targetPortId);
-  const lenses = targetPort?.lenses?.filter((lens) =>
-    lensTargetsConnection(
-      lens,
-      edge.sourceBlockId,
-      edge.sourcePortId,
-      sourceBlock?.displayName,
-    ),
-  );
-  const hasLenses = lenses != null && lenses.length > 0;
-
-  // Get diagnostics for this edge
   const diagnostics = diagnosticsGetter ? diagnosticsGetter(edge) : undefined;
 
   return {
@@ -324,70 +225,39 @@ export function createEdgeFromEdgeLike(
     type: 'oscilla',
     animated: false,
     data: {
-      lenses: hasLenses ? lenses : undefined,
       diagnostics,
     },
   };
 }
 
 /**
- * Reconcile nodes from adapter data.
- * Updates existing nodes in-place to preserve position, creates new nodes.
- *
- * @param adapter - Data adapter
- * @param currentNodes - Current ReactFlow nodes
- * @param getBlockPosition - Function to get stored position for a block
- * @param diagnosticsGetter - Optional function to get diagnostics for edges
+ * Reconcile nodes from adapter data. Updates existing nodes in-place to
+ * preserve position, creates new nodes.
  */
 export function reconcileNodesFromAdapter(
   adapter: GraphDataAdapter,
   currentNodes: Node[],
   getBlockPosition: (blockId: string) => { x: number; y: number } | undefined,
   diagnosticsGetter?: (edge: EdgeLike) => Diagnostic[],
-  onProjectionIssue?: (issue: { kind: 'missingBlockDef'; blockId: string; blockType: string }) => void,
 ): { nodes: Node[]; edges: ReactFlowEdge[]; droppedInvalidEdgeIds: readonly string[] } {
-  // Build map of existing nodes by ID for fast lookup
   const existingNodeMap = new Map<string, Node>();
   for (const node of currentNodes) {
     existingNodeMap.set(node.id, node);
   }
 
   const nodes: Node[] = [];
-  const patchBlockIds = new Set<string>();
 
   for (const [blockId, block] of adapter.blocks) {
-    patchBlockIds.add(blockId);
-
-    const blockDef = getAnyBlockDefinition(block.type);
-    if (!blockDef) {
-      // [LAW:single-enforcer] Projection issue reporting is delegated to caller,
-      // so this transform stays pure and does not emit direct side effects.
-      onProjectionIssue?.({ kind: 'missingBlockDef', blockId, blockType: block.type });
-      continue;
-    }
-
-    // Determine position
-    let position: { x: number; y: number };
+    // Determine position: preserve dragged position; else stored; else origin.
     const existingNode = existingNodeMap.get(blockId);
-    if (existingNode) {
-      // Preserve existing position (user may have dragged)
-      position = existingNode.position;
-    } else {
-      // New block - check adapter for stored position
-      const storedPosition = getBlockPosition(blockId);
-      if (storedPosition) {
-        position = storedPosition;
-      } else {
-        // Fallback: place at origin (should be rare)
-        position = { x: 100, y: 100 };
-      }
-    }
+    const position = existingNode?.position
+      ?? getBlockPosition(blockId)
+      ?? { x: 100, y: 100 };
 
-    const node = createNodeFromBlockLike(block, blockDef, adapter.edges, adapter.blocks, position);
-    nodes.push(node);
+    nodes.push(createNodeFromBlockLike(block, adapter.edges, adapter.blocks, position));
   }
 
-  // Create edges (pass blocks for lens data population), filtering invalid endpoints.
+  // Create edges, filtering invalid endpoints.
   const edges: ReactFlowEdge[] = [];
   const droppedInvalidEdgeIds: string[] = [];
   for (const edge of adapter.edges) {

--- a/src/ui/graphEditor/types.ts
+++ b/src/ui/graphEditor/types.ts
@@ -2,62 +2,148 @@
  * GraphDataAdapter - Unified interface for graph data sources
  *
  * Enables the GraphEditorCore to work with different data stores
- * (PatchStore for main graph, CompositeEditorStore for composite editor)
- * through a single unified interface.
+ * (PatchStore for the main V1 graph, CompositeEditorStore for the composite
+ * editor, PillarPatchStore for the pillar/ScenePlan graph) through a single
+ * unified interface.
  *
- * ARCHITECTURAL CONSTRAINT: ONE TYPE PER BEHAVIOR
- * Both stores provide graph CRUD - they are instances of one type,
- * not distinct types. This adapter is that unified type.
+ * ARCHITECTURAL CONSTRAINT: this interface is the SEAM, and it speaks only the
+ * editor's own neutral vocabulary — never any one backend's language. Each
+ * provider (adapter) translates its era-specific model INTO these neutral,
+ * presentation-ready facts; the editor renders them without knowing which
+ * backend produced them. [FRAMING:representation] [LAW:one-way-deps]
+ *
+ * The only genuinely backend-neutral fact about a value is its TYPE (every era
+ * has types). Everything else that used to leak across this seam
+ * (default-source, provenance, lenses, combine-mode, inference binding) is
+ * era-specific and is projected here into one of two presentation-ready shapes:
+ * a decoration (something the editor paints) or a control (something the editor
+ * edits). The provider pre-computes labels/colors/tooltips; the renderer is
+ * pure. [LAW:effects-at-boundaries]
  */
 
-import type { CombineMode, DefaultSource } from '../../types';
-import type { AuthoredInputControl, LensAttachment } from '../../graph/Patch';
-import type { InferenceCanonicalType } from '../../core/inference-types';
-import type { InputBindingSummary, PortProvenance } from '../../stores/FrontendResultStore';
+import type { UIControlHint } from '../../types';
 import type { ControlMutationTarget } from '../../types/control-target';
+
+// =============================================================================
+// Neutral presentation vocabulary
+// =============================================================================
+
+/**
+ * Backend-neutral, presentation-ready description of a port's resolved type.
+ *
+ * A provider translates its era-specific type model (V1 CanonicalType, pillar
+ * scene-port type, …) into this before it crosses the seam. Wiring legality is
+ * a separate concern owned by the type-oracle seam; `compatibilityToken` here
+ * is a display-only grouping key (two ports read as "the same type" iff their
+ * tokens are equal).
+ */
+export interface PortTypeDisplay {
+  /** Short label for the handle / inline display, e.g. "One<float>". */
+  readonly label: string;
+  /** Full hover tooltip text. */
+  readonly tooltip: string;
+  /** Handle / swatch color (any CSS color string). */
+  readonly color: string;
+  /** Opaque display-only wire-compatibility grouping token. */
+  readonly compatibilityToken: string;
+}
+
+/**
+ * A visual annotation the editor paints on a port — an indicator dot, a badge,
+ * a warning glyph, or a transform chip. The provider decides what to show and
+ * how it reads; the renderer only paints it. This is the single neutral shape
+ * that V1 default-source dots, provenance badges/warnings, and lens/transform
+ * chips all project into.
+ */
+export interface PortDecoration {
+  readonly kind: PortDecorationKind;
+  /** Text shown inside a badge/warning, or as a chip label. */
+  readonly label?: string;
+  /** Dot / badge color (any CSS color string). */
+  readonly color?: string;
+  /** Hover tooltip. */
+  readonly tooltip?: string;
+}
+
+/**
+ * `indicator` — a small colored dot beside the handle (e.g. "has a default").
+ * `badge`     — a labeled square badge (e.g. an adapter marker).
+ * `warning`   — a labeled square warning badge (e.g. unresolved).
+ * `transform` — a chip describing an edge/port transform (e.g. a lens step).
+ */
+export type PortDecorationKind = 'indicator' | 'badge' | 'warning' | 'transform';
+
+/**
+ * An inline control the editor renders for a value — a param editor bound to a
+ * mutation target. Era-neutral: the target names WHAT to mutate; the provider's
+ * owning store performs it.
+ */
+export interface ParamData {
+  readonly id: string;
+  readonly label: string;
+  readonly value: unknown;
+  readonly hint?: UIControlHint;
+  readonly target: ControlMutationTarget;
+}
 
 // =============================================================================
 // Common Shape Types
 // =============================================================================
 
 /**
- * Minimal port information needed for rendering.
+ * Minimal input-port information needed for rendering.
+ * Self-describing: carries its own label, type display, decorations and inline
+ * controls so the editor never has to consult a backend registry to render it.
+ * [LAW:composability]
  */
 export interface InputPortLike {
   readonly id: string;
-  readonly combineMode: CombineMode;
-  readonly authoredControl?: AuthoredInputControl;
-  readonly defaultSource?: DefaultSource;
-  readonly lenses?: readonly LensAttachment[];
-  readonly resolvedType?: InferenceCanonicalType;
-  readonly provenance?: PortProvenance;
-  readonly binding?: InputBindingSummary;
+  /** Display label for the port. */
+  readonly label: string;
+  /** Presentation-ready resolved type, when known. */
+  readonly typeDisplay?: PortTypeDisplay;
+  /** Visual annotations (default-source dot, provenance badge, transform chips). */
+  readonly decorations?: readonly PortDecoration[];
+  /** Inline param affordances shown when the port is unconnected. */
+  readonly controls?: readonly ParamData[];
 }
 
 /**
- * Minimal output port information needed for rendering.
+ * Minimal output-port information needed for rendering.
  */
 export interface OutputPortLike {
   readonly id: string;
-  readonly resolvedType?: InferenceCanonicalType;
+  /** Display label for the port. */
+  readonly label: string;
+  /** Presentation-ready resolved type, when known. */
+  readonly typeDisplay?: PortTypeDisplay;
 }
 
 /**
- * Minimal block information needed for rendering.
- * Store-agnostic - can be produced from either PatchStore or CompositeEditorStore data.
+ * Minimal block information needed for rendering. Self-describing: an editor
+ * can render this block and all its ports without consulting any backend
+ * registry.
  */
 export interface BlockLike {
   readonly id: string;
+  /** Backend block-type identifier (registry key / discriminant). */
   readonly type: string;
+  /** Human label for the block type (e.g. "Constant"). */
+  readonly typeLabel: string;
+  /** User-authored display name for this instance. */
   readonly displayName: string;
+  /** Raw config/param values (kept for passthrough / comment text). */
   readonly params: Record<string, unknown>;
   readonly inputPorts: ReadonlyMap<string, InputPortLike>;
   readonly outputPorts: ReadonlyMap<string, OutputPortLike>;
+  /** Block-level inline config controls (config-only params). */
+  readonly controls: readonly ParamData[];
 }
 
 /**
  * Minimal edge information needed for rendering.
- * Store-agnostic - can be produced from either store's edge format.
+ * `decorations` carry any per-edge transform chips (V1 lenses, pillar transform
+ * chains) as neutral annotations.
  */
 export interface EdgeLike {
   readonly id: string;
@@ -65,6 +151,7 @@ export interface EdgeLike {
   readonly sourcePortId: string;
   readonly targetBlockId: string;
   readonly targetPortId: string;
+  readonly decorations?: readonly PortDecoration[];
 }
 
 // =============================================================================
@@ -77,12 +164,13 @@ export interface EdgeLike {
  * Generic over BlockIdT to preserve type safety across different stores:
  * - PatchStore uses BlockId (branded string)
  * - CompositeEditorStore uses InternalBlockId (branded string)
+ * - PillarPatchStore uses plain string ids
  *
- * REACTIVITY: All getters must preserve MobX observability from underlying stores.
- * ReactFlow depends on observability to update when data changes.
+ * REACTIVITY: All getters must preserve MobX observability from underlying
+ * stores. ReactFlow depends on observability to update when data changes.
  *
- * OPTIONAL METHODS: Methods marked with ? are only available for PatchStore
- * (main graph editing). Composite editor has restricted capabilities.
+ * OPTIONAL METHODS: Methods marked with ? are only available for providers that
+ * support that capability (e.g. the composite editor has restricted editing).
  */
 export interface GraphDataAdapter<BlockIdT = string> {
   // -------------------------------------------------------------------------
@@ -90,10 +178,9 @@ export interface GraphDataAdapter<BlockIdT = string> {
   // -------------------------------------------------------------------------
 
   /**
-   * Version number that changes when port data (types, default sources) changes
-   * without structural block/edge changes. MobX reactions should track this
-   * to detect data-only updates from the compiler frontend.
-   * Returns 0 when not available (e.g., CompositeStoreAdapter).
+   * Version number that changes when port data (types, decorations) changes
+   * without structural block/edge changes. MobX reactions track this to detect
+   * data-only updates. Returns 0 / undefined when not applicable.
    */
   readonly dataVersion?: number;
 
@@ -116,33 +203,25 @@ export interface GraphDataAdapter<BlockIdT = string> {
   /**
    * Add a new block to the graph.
    *
-   * @param type - Block type (must be registered in registry)
+   * @param type - Block type (must be registered in the provider's registry)
    * @param position - Initial position in graph editor
    * @returns Generated block ID
    */
   addBlock(type: string, position: { x: number; y: number }): BlockIdT;
 
   /**
-   * Remove a block from the graph.
-   * Connected edges are also removed automatically.
-   *
-   * @param id - Block ID to remove
+   * Remove a block from the graph. Connected edges are removed automatically.
    */
   removeBlock(id: BlockIdT): void;
 
   /**
    * Get the position of a block in the graph editor.
-   *
-   * @param id - Block ID
-   * @returns Position or undefined if block has no position set
+   * @returns Position or undefined if the block has no position set.
    */
   getBlockPosition(id: BlockIdT): { x: number; y: number } | undefined;
 
   /**
    * Set the position of a block in the graph editor.
-   *
-   * @param id - Block ID
-   * @param position - New position
    */
   setBlockPosition(id: BlockIdT, position: { x: number; y: number }): void;
 
@@ -152,11 +231,6 @@ export interface GraphDataAdapter<BlockIdT = string> {
 
   /**
    * Add an edge connecting two blocks.
-   *
-   * @param source - Source block ID
-   * @param sourcePort - Source port ID
-   * @param target - Target block ID
-   * @param targetPort - Target port ID
    * @returns Generated edge ID
    */
   addEdge(
@@ -168,64 +242,22 @@ export interface GraphDataAdapter<BlockIdT = string> {
 
   /**
    * Remove an edge from the graph.
-   *
-   * @param id - Edge ID to remove
    */
   removeEdge(id: string): void;
 
   // -------------------------------------------------------------------------
-  // Optional Operations (PatchStore only)
+  // Optional Operations
   // -------------------------------------------------------------------------
 
   /**
-   * Update block parameters.
-   * Only available for main patch editing (PatchStore).
-   * Composite editor does not support runtime param editing.
-   *
-   * @param id - Block ID
-   * @param params - Parameter updates (partial)
+   * Update block config/param values by id. Only available for providers that
+   * support instance param editing.
    */
   updateBlockParams?(id: BlockIdT, params: Record<string, unknown>): void;
 
   /**
-   * Update block display name.
-   * Only available for main patch editing (PatchStore).
-   *
-   * @param id - Block ID
-   * @param displayName - New display name
-   * @returns Error message if validation fails
+   * Update block display name. Only available for providers that support it.
+   * @returns Error message if validation fails.
    */
   updateBlockDisplayName?(id: BlockIdT, displayName: string): { error?: string };
-
-  /**
-   * Update input port properties.
-   * Only available for main patch editing (PatchStore).
-   *
-   * @param blockId - Block ID
-   * @param portId - Port ID
-   * @param updates - Port property updates
-   */
-  updateInputPort?(
-    blockId: BlockIdT,
-    portId: string,
-    updates: { defaultSource?: DefaultSource; combineMode?: CombineMode }
-  ): void;
-
-  /**
-   * Update input port combine mode.
-   * Only available for main patch editing (PatchStore).
-   *
-   * @param blockId - Block ID
-   * @param portId - Port ID
-   * @param mode - New combine mode
-   */
-  updateInputPortCombineMode?(blockId: BlockIdT, portId: string, mode: CombineMode): void;
-}
-
-export interface ParamData {
-  readonly id: string;
-  readonly label: string;
-  readonly value: unknown;
-  readonly hint?: import('../../types').UIControlHint;
-  readonly target: ControlMutationTarget;
 }

--- a/src/ui/nativeEditor/NativeEditorLayout.tsx
+++ b/src/ui/nativeEditor/NativeEditorLayout.tsx
@@ -54,6 +54,15 @@ type CenterView = 'graph' | 'mature' | 'table';
 
 const CenterPane: React.FC = () => {
   const [view, setView] = useState<CenterView>('graph');
+  // The mature editor mounts on its first activation (not before), so its
+  // initial mount — and GraphEditorCore's one-shot fitView — happens while the
+  // pane is visible with a real size, not while hidden (a display:none element
+  // has a zero rect, which would collapse fitView to minimum zoom). Once
+  // mounted it stays mounted, so adapter-owned positions survive later switches.
+  const [matureActivated, setMatureActivated] = useState(false);
+  useEffect(() => {
+    if (view === 'mature') setMatureActivated(true);
+  }, [view]);
   return (
     <div
       style={{
@@ -80,13 +89,16 @@ const CenterPane: React.FC = () => {
       <div style={{ flex: 1, minHeight: 0 }}>
         {view === 'graph' && <NativeGraphCanvas />}
         {view === 'table' && <ModulationTablePanel />}
-        {/* The mature editor stays mounted (display-toggled) because its node
-            positions live in the adapter's in-memory map; unmounting on tab
-            switch would discard the author's layout. Graph/Table re-derive
-            statelessly, so they mount on demand. [LAW:one-source-of-truth] */}
-        <div style={{ height: '100%', display: view === 'mature' ? undefined : 'none' }}>
-          <NativeMatureGraphCanvas />
-        </div>
+        {/* The mature editor mounts on first activation, then stays mounted
+            (display-toggled) because its node positions live in the adapter's
+            in-memory map; unmounting on tab switch would discard the author's
+            layout. Graph/Table re-derive statelessly, so they mount on demand.
+            [LAW:one-source-of-truth] */}
+        {matureActivated && (
+          <div style={{ height: '100%', display: view === 'mature' ? undefined : 'none' }}>
+            <NativeMatureGraphCanvas />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/ui/nativeEditor/NativeEditorLayout.tsx
+++ b/src/ui/nativeEditor/NativeEditorLayout.tsx
@@ -16,6 +16,7 @@ import React, { useEffect, useRef, useState } from 'react';
 
 import { NativeEditorPanel } from './NativeEditorPanel';
 import { NativeGraphCanvas } from './NativeGraphCanvas';
+import { NativeMatureGraphCanvas } from './NativeMatureGraphCanvas';
 import { ModulationTablePanel } from './ModulationTablePanel';
 
 interface NativeEditorLayoutProps {
@@ -49,7 +50,7 @@ export const NativeEditorLayout: React.FC<NativeEditorLayoutProps> = ({ onCanvas
  * [LAW:one-source-of-truth] The graph and table are alternate projections; the
  *   toggle picks a projection, it does not fork the patch.
  */
-type CenterView = 'graph' | 'table';
+type CenterView = 'graph' | 'mature' | 'table';
 
 const CenterPane: React.FC = () => {
   const [view, setView] = useState<CenterView>('graph');
@@ -73,10 +74,13 @@ const CenterPane: React.FC = () => {
         }}
       >
         <ViewTab label="Graph" active={view === 'graph'} onSelect={() => setView('graph')} />
+        <ViewTab label="Mature" active={view === 'mature'} onSelect={() => setView('mature')} />
         <ViewTab label="Table" active={view === 'table'} onSelect={() => setView('table')} />
       </div>
       <div style={{ flex: 1, minHeight: 0 }}>
-        {view === 'graph' ? <NativeGraphCanvas /> : <ModulationTablePanel />}
+        {view === 'graph' && <NativeGraphCanvas />}
+        {view === 'mature' && <NativeMatureGraphCanvas />}
+        {view === 'table' && <ModulationTablePanel />}
       </div>
     </div>
   );

--- a/src/ui/nativeEditor/NativeEditorLayout.tsx
+++ b/src/ui/nativeEditor/NativeEditorLayout.tsx
@@ -44,11 +44,11 @@ export const NativeEditorLayout: React.FC<NativeEditorLayoutProps> = ({ onCanvas
 };
 
 /**
- * The center pane offers the two views onto the authored patch: the node graph
- * and the modulation table. Both read the same `PillarPatchStore`, so switching
- * is purely a presentation choice — no patch state moves with the toggle.
- * [LAW:one-source-of-truth] The graph and table are alternate projections; the
- *   toggle picks a projection, it does not fork the patch.
+ * The center pane offers alternate views onto the same authored patch. Each
+ * reads the same `PillarPatchStore`, so switching is a presentation choice — no
+ * patch state moves with the toggle.
+ * [LAW:one-source-of-truth] The views are alternate projections of one patch;
+ *   the toggle picks a projection, it does not fork the patch.
  */
 type CenterView = 'graph' | 'mature' | 'table';
 
@@ -79,8 +79,14 @@ const CenterPane: React.FC = () => {
       </div>
       <div style={{ flex: 1, minHeight: 0 }}>
         {view === 'graph' && <NativeGraphCanvas />}
-        {view === 'mature' && <NativeMatureGraphCanvas />}
         {view === 'table' && <ModulationTablePanel />}
+        {/* The mature editor stays mounted (display-toggled) because its node
+            positions live in the adapter's in-memory map; unmounting on tab
+            switch would discard the author's layout. Graph/Table re-derive
+            statelessly, so they mount on demand. [LAW:one-source-of-truth] */}
+        <div style={{ height: '100%', display: view === 'mature' ? undefined : 'none' }}>
+          <NativeMatureGraphCanvas />
+        </div>
       </div>
     </div>
   );

--- a/src/ui/nativeEditor/NativeMatureGraphCanvas.tsx
+++ b/src/ui/nativeEditor/NativeMatureGraphCanvas.tsx
@@ -1,0 +1,56 @@
+/**
+ * src/ui/nativeEditor/NativeMatureGraphCanvas.tsx
+ *
+ * SPIKE (oscilla-editor-ux-8lsn.14): mounts the mature ReactFlow editor
+ * (GraphEditorCore + UnifiedNode) over the pillar patch via PillarPatchAdapter.
+ *
+ * This is the proving surface for the neutral GraphDataAdapter seam: the same
+ * editor that renders the V1 patch here renders and edits the authored pillar
+ * patch. Edits flow to PillarPatchStore, whose `compiled` computed drives the
+ * live ScenePlan preview (RuntimeService) — the loop is closed with no extra
+ * wiring. It reads the same PillarPatchStore as the native Graph/Table views, so
+ * switching tabs is a projection choice. [LAW:one-source-of-truth]
+ *
+ * The mature editor's dockview host is deferred to oscilla-editor-ux-8lsn.20;
+ * here it is one center-pane view alongside the native graph for side-by-side
+ * equality.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import { observer } from 'mobx-react-lite';
+import { useStores } from '../../stores';
+import { PillarPatchAdapter } from '../graphEditor/PillarPatchAdapter';
+import { GraphEditorCore, type GraphEditorCoreHandle } from '../graphEditor/GraphEditorCore';
+
+export const NativeMatureGraphCanvas: React.FC = observer(() => {
+  const { pillarPatch } = useStores();
+  const adapter = useMemo(() => new PillarPatchAdapter(pillarPatch), [pillarPatch]);
+  const coreRef = useRef<GraphEditorCoreHandle | null>(null);
+  const arrangedRef = useRef(false);
+
+  const handleReady = useCallback((handle: GraphEditorCoreHandle) => {
+    coreRef.current = handle;
+  }, []);
+
+  // Seed a left→right ELK layout once nodes exist (PillarPatchStore has no
+  // stored positions; without this every node stacks at the origin). The rAF
+  // lets GraphEditorCore reconcile nodes from the adapter before we arrange.
+  const blockCount = pillarPatch.patch.blocks.length;
+  useEffect(() => {
+    if (arrangedRef.current || blockCount === 0) return;
+    arrangedRef.current = true;
+    const raf = requestAnimationFrame(() => {
+      coreRef.current
+        ?.autoArrange()
+        .then(() => coreRef.current?.zoomToFit())
+        .catch((err: unknown) => console.error('Mature pillar graph layout failed:', err));
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [blockCount]);
+
+  return (
+    <div style={{ height: '100%', width: '100%' }}>
+      <GraphEditorCore ref={coreRef} adapter={adapter} onEditorReady={handleReady} />
+    </div>
+  );
+});

--- a/src/ui/nativeEditor/NativeMatureGraphCanvas.tsx
+++ b/src/ui/nativeEditor/NativeMatureGraphCanvas.tsx
@@ -16,41 +16,27 @@
  * equality.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStores } from '../../stores';
 import { PillarPatchAdapter } from '../graphEditor/PillarPatchAdapter';
-import { GraphEditorCore, type GraphEditorCoreHandle } from '../graphEditor/GraphEditorCore';
+import { GraphEditorCore } from '../graphEditor/GraphEditorCore';
 
 export const NativeMatureGraphCanvas: React.FC = observer(() => {
   const { pillarPatch } = useStores();
   const adapter = useMemo(() => new PillarPatchAdapter(pillarPatch), [pillarPatch]);
-  const coreRef = useRef<GraphEditorCoreHandle | null>(null);
-  const arrangedRef = useRef(false);
 
-  const handleReady = useCallback((handle: GraphEditorCoreHandle) => {
-    coreRef.current = handle;
-  }, []);
-
-  // Seed a left→right ELK layout once nodes exist (PillarPatchStore has no
-  // stored positions; without this every node stacks at the origin). The rAF
-  // lets GraphEditorCore reconcile nodes from the adapter before we arrange.
-  const blockCount = pillarPatch.patch.blocks.length;
-  useEffect(() => {
-    if (arrangedRef.current || blockCount === 0) return;
-    arrangedRef.current = true;
-    const raf = requestAnimationFrame(() => {
-      coreRef.current
-        ?.autoArrange()
-        .then(() => coreRef.current?.zoomToFit())
-        .catch((err: unknown) => console.error('Mature pillar graph layout failed:', err));
-    });
-    return () => cancelAnimationFrame(raf);
-  }, [blockCount]);
-
+  // Layout: PillarPatchAdapter seeds deterministic left→right positions, so the
+  // graph is readable on first paint and GraphEditorCore's own fitView frames
+  // it — no post-mount auto-layout pass, hence no timing/ref race to manage.
+  //
+  // Connection validation: no `patch` is passed, so GraphEditorCore permits any
+  // wire. Pillar wiring validity (type compatibility) is owned by the type-oracle
+  // seam (oscilla-editor-ux-8lsn.17); this spike intentionally leaves it open
+  // rather than duplicate that boundary here.
   return (
     <div style={{ height: '100%', width: '100%' }}>
-      <GraphEditorCore ref={coreRef} adapter={adapter} onEditorReady={handleReady} />
+      <GraphEditorCore adapter={adapter} />
     </div>
   );
 });

--- a/src/ui/reactFlowEditor/OscillaEdge.tsx
+++ b/src/ui/reactFlowEditor/OscillaEdge.tsx
@@ -15,7 +15,7 @@ import { getLensLabel } from './lensUtils';
 import { lensTargetsConnection } from './lensUtils';
 import { BasePopover, POPUP_SURFACE_STYLE, usePinPopoverState } from './BasePopover';
 import type { Diagnostic } from '../../diagnostics/types';
-import type { BlockId } from '../../types';
+import type { BlockId, PortId } from '../../types';
 import { useStores } from '../../stores';
 import { LensParamControls } from '../components/LensParamControls';
 import { graphColors } from '../graphEditor/graph-tokens';
@@ -324,12 +324,19 @@ export const OscillaEdge = observer(function OscillaEdge(
 
   const sourceDisplayName = patch.blocks.get(source as BlockId)?.displayName;
 
+  // Lenses live on the target port; read them straight from the patch store.
+  // (Edge decorations are owned by the edge-decoration seam; the neutral edge
+  // vocabulary does not carry V1 lens attachments.)
+  const targetPortLenses = targetHandle
+    ? patch.blocks.get(target as BlockId)?.inputPorts.get(targetHandle as PortId)?.lenses
+    : undefined;
+
   const edgeLenses = useMemo(
     () =>
-      (data?.lenses ?? []).filter((lens) =>
+      (targetPortLenses ?? []).filter((lens) =>
         lensTargetsConnection(lens, source, sourceHandle ?? '', sourceDisplayName),
       ),
-    [data?.lenses, source, sourceHandle, sourceDisplayName],
+    [targetPortLenses, source, sourceHandle, sourceDisplayName],
   );
 
   const hasLenses = edgeLenses.length > 0;

--- a/src/ui/reactFlowEditor/OscillaEdge.tsx
+++ b/src/ui/reactFlowEditor/OscillaEdge.tsx
@@ -324,9 +324,12 @@ export const OscillaEdge = observer(function OscillaEdge(
 
   const sourceDisplayName = patch.blocks.get(source as BlockId)?.displayName;
 
-  // Lenses live on the target port; read them straight from the patch store.
-  // (Edge decorations are owned by the edge-decoration seam; the neutral edge
-  // vocabulary does not carry V1 lens attachments.)
+  // [LAW:one-way-deps] OscillaEdge reads the V1 PatchStore directly here (as it
+  // already did for `sourceDisplayName`/`adapterCount`) — a pre-existing bypass.
+  // For pillar edges these lookups miss and the chips simply don't render. The
+  // edge-decoration seam (oscilla-editor-ux-8lsn.18) inverts this dependency by
+  // moving all V1 reads behind a neutral per-edge decoration provider; until
+  // then the neutral edge vocabulary deliberately does not carry V1 lenses.
   const targetPortLenses = targetHandle
     ? patch.blocks.get(target as BlockId)?.inputPorts.get(targetHandle as PortId)?.lenses
     : undefined;

--- a/src/ui/reactFlowEditor/PortInfoPopover.tsx
+++ b/src/ui/reactFlowEditor/PortInfoPopover.tsx
@@ -11,7 +11,7 @@ import React, { useEffect } from 'react';
 import { Text, Stack, Group, Badge, Box, Divider } from '@mantine/core';
 import { observer } from 'mobx-react-lite';
 import type { PortData } from '../graphEditor/nodeDataTransform';
-import type { DefaultSource } from '../../types';
+import type { DefaultSource, BlockId, PortId } from '../../types';
 import { useStores, formatDebugValue } from '../../stores';
 import { getLensLabel } from './lensUtils';
 import { BasePopover, POPUP_SURFACE_STYLE, type PopoverAnchorPosition } from './BasePopover';
@@ -51,7 +51,7 @@ export const PortInfoPopover: React.FC<PortInfoPopoverProps> = observer(({
   onClose,
   blockId,
 }) => {
-  const { debug, diagnostics } = useStores();
+  const { debug, diagnostics, frontend, patch } = useStores();
   const debugEnabled = debug.enabled;
 
   useEffect(() => {
@@ -65,6 +65,19 @@ export const PortInfoPopover: React.FC<PortInfoPopoverProps> = observer(({
   if (!port || !anchorPosition) {
     return null;
   }
+
+  // Rich V1 port detail is read straight from the compiler/patch stores here
+  // (this popover is a store-reading surface owned by the type-oracle /
+  // edge-decoration seams; the pillar path simply has no such data and these
+  // sections stay empty). The neutral node vocabulary carries only the type
+  // header (color/tooltip), which is shown regardless of era.
+  const dir = isInput ? 'in' : 'out';
+  const resolvedType = blockId ? frontend.getResolvedPortTypeByIds(blockId, port.id, dir) : undefined;
+  const provenance = blockId ? frontend.getPortProvenanceByIds(blockId, port.id, dir) : undefined;
+  const defaultSource = isInput && blockId ? frontend.getDefaultSourceByIds(blockId, port.id) : undefined;
+  const lenses = isInput && blockId
+    ? patch.blocks.get(blockId as BlockId)?.inputPorts.get(port.id as PortId)?.lenses
+    : undefined;
 
   let debugValue = undefined;
   if (debugEnabled) {
@@ -154,33 +167,33 @@ export const PortInfoPopover: React.FC<PortInfoPopoverProps> = observer(({
                 <Text size="sm" c="white" style={{ fontFamily: 'monospace' }}>
                   {port.typeTooltip}
                 </Text>
-                {port.resolvedType && (
+                {resolvedType && (
                   <Text size="xs" c="dimmed" style={{ fontFamily: 'monospace', whiteSpace: 'pre-line' }}>
-                    {formatCanonicalTypeTooltip(port.resolvedType)}
+                    {formatCanonicalTypeTooltip(resolvedType)}
                   </Text>
                 )}
               </Stack>
             </Group>
           </Box>
 
-          {port.provenance && (
+          {provenance && (
             <Box>
               <Text size="xs" c="dimmed">
                 Provenance
               </Text>
               <Group gap="xs" mt={2}>
-                {getAdapterBadgeLabel(port.provenance) && (
+                {getAdapterBadgeLabel(provenance) && (
                   <Badge size="xs" color="orange" variant="filled">
                     Adapter
                   </Badge>
                 )}
-                {getUnresolvedWarning(port.provenance) && (
+                {getUnresolvedWarning(provenance) && (
                   <Badge size="xs" color="red" variant="filled">
                     Unresolved
                   </Badge>
                 )}
                 <Text size="sm" c="white">
-                  {formatProvenanceTooltip(port.provenance)}
+                  {formatProvenanceTooltip(provenance)}
                 </Text>
               </Group>
             </Box>
@@ -297,29 +310,29 @@ export const PortInfoPopover: React.FC<PortInfoPopoverProps> = observer(({
             );
           })()}
 
-          {isInput && !port.isConnected && port.defaultSource && (
+          {isInput && !port.isConnected && defaultSource && (
             <Box>
               <Text size="xs" c="dimmed">
                 Default Source
               </Text>
               <Badge
                 size="sm"
-                color={getDefaultSourceBadgeColor(port.defaultSource)}
+                color={getDefaultSourceBadgeColor(defaultSource)}
                 variant="light"
                 mt={2}
               >
-                {formatDefaultSourceLabel(port.defaultSource)}
+                {formatDefaultSourceLabel(defaultSource)}
               </Badge>
             </Box>
           )}
 
-          {isInput && port.lenses && port.lenses.length > 0 && (
+          {isInput && lenses && lenses.length > 0 && (
             <Box>
               <Text size="xs" c="dimmed">
                 Lenses
               </Text>
               <Stack gap={4} mt={4}>
-                {port.lenses.map((lens) => (
+                {lenses.map((lens) => (
                   <Stack key={lens.id} gap={2}>
                     <Group gap="xs" wrap="wrap">
                       <Badge size="xs" color="orange" variant="light">

--- a/src/ui/reactFlowEditor/PortInfoPopover.tsx
+++ b/src/ui/reactFlowEditor/PortInfoPopover.tsx
@@ -11,9 +11,8 @@ import React, { useEffect } from 'react';
 import { Text, Stack, Group, Badge, Box, Divider } from '@mantine/core';
 import { observer } from 'mobx-react-lite';
 import type { PortData } from '../graphEditor/nodeDataTransform';
-import type { DefaultSource, BlockId, PortId } from '../../types';
+import type { DefaultSource } from '../../types';
 import { useStores, formatDebugValue } from '../../stores';
-import { getLensLabel } from './lensUtils';
 import { BasePopover, POPUP_SURFACE_STYLE, type PopoverAnchorPosition } from './BasePopover';
 import {
   formatProvenanceTooltip,
@@ -51,7 +50,7 @@ export const PortInfoPopover: React.FC<PortInfoPopoverProps> = observer(({
   onClose,
   blockId,
 }) => {
-  const { debug, diagnostics, frontend, patch } = useStores();
+  const { debug, diagnostics, frontend } = useStores();
   const debugEnabled = debug.enabled;
 
   useEffect(() => {
@@ -75,9 +74,6 @@ export const PortInfoPopover: React.FC<PortInfoPopoverProps> = observer(({
   const resolvedType = blockId ? frontend.getResolvedPortTypeByIds(blockId, port.id, dir) : undefined;
   const provenance = blockId ? frontend.getPortProvenanceByIds(blockId, port.id, dir) : undefined;
   const defaultSource = isInput && blockId ? frontend.getDefaultSourceByIds(blockId, port.id) : undefined;
-  const lenses = isInput && blockId
-    ? patch.blocks.get(blockId as BlockId)?.inputPorts.get(port.id as PortId)?.lenses
-    : undefined;
 
   let debugValue = undefined;
   if (debugEnabled) {
@@ -326,32 +322,12 @@ export const PortInfoPopover: React.FC<PortInfoPopoverProps> = observer(({
             </Box>
           )}
 
-          {isInput && lenses && lenses.length > 0 && (
-            <Box>
-              <Text size="xs" c="dimmed">
-                Lenses
-              </Text>
-              <Stack gap={4} mt={4}>
-                {lenses.map((lens) => (
-                  <Stack key={lens.id} gap={2}>
-                    <Group gap="xs" wrap="wrap">
-                      <Badge size="xs" color="orange" variant="light">
-                        {getLensLabel(lens.lensType)}
-                      </Badge>
-                      <Text size="xs" c="dimmed" style={{ fontFamily: 'monospace' }}>
-                        {lens.sourceAddress.split('.').slice(-2).join('.')}
-                      </Text>
-                    </Group>
-                    {lens.params && Object.keys(lens.params).length > 0 && (
-                      <Text size="xs" c="dimmed" style={{ fontFamily: 'monospace', paddingLeft: '8px' }}>
-                        ({Object.entries(lens.params).map(([k, v]) => `${k}: ${String(v)}`).join(', ')})
-                      </Text>
-                    )}
-                  </Stack>
-                ))}
-              </Stack>
-            </Box>
-          )}
+          {/* Lens detail is shown on the edge (OscillaEdge chips + lens popover);
+              it is not duplicated here. Keeping it out of the port popover also
+              removes this component's only V1 PatchStore read — the remaining
+              frontend.* lookups take string ids and miss gracefully for pillar.
+              Full neutralization of these detail reads is the type-oracle seam
+              (oscilla-editor-ux-8lsn.17). [LAW:one-way-deps] */}
         </Stack>
       </div>
     </BasePopover>


### PR DESCRIPTION
## What & why

The proving ticket for the seams-first editor regroom (`oscilla-editor-ux-8lsn.14`). Two motions, done together:

1. **Strengthen** the `GraphDataAdapter` seam (`src/ui/graphEditor/types.ts`) so it speaks only the editor's own **neutral vocabulary** — it no longer imports any backend's language.
2. **Spike** a `PillarPatchAdapter` and mount the mature ReactFlow editor (`GraphEditorCore` + `UnifiedNode`) over the authored pillar patch with a live `compileScenePlan` preview.

## The spike's discovery

Only *type* is genuinely neutral across eras. Every other `InputPortLike` field was V1-parochial and projects into the ticket's prescribed shapes:

| was (V1) | now (neutral) |
|---|---|
| `resolvedType` (`InferenceCanonicalType`) | `typeDisplay` (label/tooltip/color/compatibilityToken) |
| `provenance` + `defaultSource` + `lenses` | `decorations` (presentation-ready dots/badges/warnings) |
| `binding.controls` + config params | `controls` (`ParamData` inline affordances) |
| `authoredControl` | dropped — vestigial, never crossed the seam |

`BlockLike` is now **self-describing** (ports carry their own label/typeDisplay/decorations/controls), so `nodeDataTransform` no longer consults the V1 registry for structure — the reason pillar blocks used to be dropped. V1 formatting moved **into** `PatchStoreAdapter` so the renderer stays pure.

**Result: the seam carries the pillar model — the failure-escape was not triggered.**

## Acceptance gates (all met)

- ✅ **Pillar renders + edits in-browser** (headless Chrome): mature editor renders the Instance Grid → Color Cycle → Draw Instances chain with correct ports/edges/labels, zero console errors; adding a Constant appears reactively; the live Three preview animates.
- ✅ **V1 boot (`?v1=true`) identical**: full dockview shell + nodes + inline parameter-control sliders (proving neutral `controls` round-trips V1) + zero errors.
- ✅ **`types.ts` imports zero** from `graph/Patch`, `stores/*`, `core/inference-types` (mechanical gate).

## Scope / deferrals (to named siblings, not this ticket's debt)

- Dockview host for the mature editor → `.20` (here it's an additive **"Mature"** center-pane view; the default Graph view is untouched).
- Pillar inline config-control editing → control-affordance seam.
- Rich port popover / edge lens chips read V1 stores directly for now → type-oracle / edge-decoration seams (`.17`/`.18`).
- Full cross-era conformance suite → `.15` (this PR ships a pillar-side smoke suite).

## Verification

- `tsc --noEmit` clean; `eslint` clean on touched files.
- 36 unit tests updated/added and green (nodeDataTransform, control-surface, authored-control, PillarPatchAdapter, native editor).