### PR TITLE
test(editor-ux 8lsn.15): adapter conformance suite across all three GraphDataAdapters

### DIFF
--- a/src/ui/graphEditor/__tests__/adapter-conformance.contract.ts
+++ b/src/ui/graphEditor/__tests__/adapter-conformance.contract.ts
@@ -1,0 +1,274 @@
+/**
+ * adapter-conformance.contract — the GraphDataAdapter contract, stated once, as
+ * executable assertions.
+ *
+ * This file IS the specification of what makes an adapter "editor-compatible".
+ * Every provider (PatchStoreAdapter, CompositeStoreAdapter, PillarPatchAdapter,
+ * and any future backend) is checked against this one contract; a behavior this
+ * file does not assert is not part of the contract, and a provider that passes
+ * every assertion here is presumed drop-in for GraphEditorCore.
+ * [LAW:single-enforcer] [LAW:verifiable-goals]
+ *
+ * DECOMPOSITION: a `ConformanceCase` is the seam. It carries the whole truth a
+ * provider must supply to be checkable — how to build a freshly-seeded adapter,
+ * a block type its registry accepts, and which optional capabilities it claims.
+ * The `assert*` functions below know only the neutral vocabulary (BlockLike /
+ * EdgeLike / GraphDataAdapter); they never import a store or an era-specific
+ * type. This is what lets one contract check three heterogeneous providers.
+ * [LAW:decomposition] [LAW:one-way-deps]
+ *
+ * The `assert*` functions are also the negative control's instrument: aimed at a
+ * deliberately-broken adapter they must throw, proving the suite has teeth
+ * rather than vacuously passing.
+ */
+
+import { reaction } from 'mobx';
+import { describe, expect, it } from 'vitest';
+import type { GraphDataAdapter } from '../types';
+
+/**
+ * Everything a provider must supply to be run through the conformance contract.
+ *
+ * `setup()` builds a fresh, seeded store and returns a factory over it. Calling
+ * the factory twice yields two adapters over the SAME store — the delegation
+ * assertion relies on this to prove mutations reach the owning store rather than
+ * adapter-local shadow state. Each `assert*` call invokes `setup()` once, so the
+ * assertions are mutually isolated.
+ */
+export interface ConformanceCase<Id = string> {
+  readonly name: string;
+  /** Build a fresh adapter over a freshly-seeded store (>=2 blocks, >=1 edge). */
+  setup(): { newAdapter(): GraphDataAdapter<Id> };
+  /** A block type this provider's registry accepts (exercises addBlock). */
+  readonly addableType: string;
+  /**
+   * Capabilities declared as values, not sniffed at runtime: the suite selects
+   * capability-gated tests from these flags at registration time rather than
+   * branching inside an assertion. [LAW:dataflow-not-control-flow]
+   */
+  readonly capabilities: {
+    /** `updateBlockParams` present and writes through. */
+    readonly params: boolean;
+    /** `updateBlockDisplayName` present and writes through. */
+    readonly displayName: boolean;
+  };
+}
+
+// The neutral EdgeLike names blocks by plain string; a provider's BlockIdT is a
+// branded string. The two are the same value at runtime; this bridges the brand
+// at the one seam where neutral ids re-enter a typed adapter call. [LAW:types-are-the-program]
+function asId<Id>(neutralId: string): Id {
+  return neutralId as unknown as Id;
+}
+
+/**
+ * Every edge resolves to real handles on real blocks. This is the exact
+ * predicate `createEdgeFromEdgeLike` uses to decide whether a projected edge
+ * survives into ReactFlow, so an adapter that fails it silently loses edges.
+ */
+function assertAllEdgesAnchor<Id>(adapter: GraphDataAdapter<Id>, name: string): void {
+  for (const edge of adapter.edges) {
+    const source = adapter.blocks.get(asId<Id>(edge.sourceBlockId));
+    const target = adapter.blocks.get(asId<Id>(edge.targetBlockId));
+    expect(source, `${name}: edge ${edge.id} source block ${edge.sourceBlockId} exists`).toBeDefined();
+    expect(target, `${name}: edge ${edge.id} target block ${edge.targetBlockId} exists`).toBeDefined();
+    expect(
+      source!.outputPorts.has(edge.sourcePortId),
+      `${name}: edge ${edge.id} anchors to real source handle ${edge.sourcePortId}`,
+    ).toBe(true);
+    expect(
+      target!.inputPorts.has(edge.targetPortId),
+      `${name}: edge ${edge.id} anchors to real target handle ${edge.targetPortId}`,
+    ).toBe(true);
+  }
+}
+
+/** Blocks render without a registry: every block and port is self-describing. */
+export function assertBlocksSelfDescribing<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+  expect(adapter.blocks.size, `${c.name}: seed must contain blocks`).toBeGreaterThan(0);
+
+  for (const [id, block] of adapter.blocks) {
+    expect(block.id, `${c.name}: BlockLike.id matches its map key`).toBe(id);
+    expect(block.type.length, `${c.name}: block ${String(id)} carries a type`).toBeGreaterThan(0);
+    expect(block.typeLabel.length, `${c.name}: block ${String(id)} carries a typeLabel`).toBeGreaterThan(0);
+    expect(typeof block.displayName, `${c.name}: block ${String(id)} carries a displayName`).toBe('string');
+
+    for (const port of [...block.inputPorts.values(), ...block.outputPorts.values()]) {
+      expect(port.label.length, `${c.name}: port ${port.id} carries a label`).toBeGreaterThan(0);
+      if (port.typeDisplay) {
+        expect(port.typeDisplay.color.length, `${c.name}: port ${port.id} type color`).toBeGreaterThan(0);
+        expect(
+          port.typeDisplay.compatibilityToken.length,
+          `${c.name}: port ${port.id} compatibility token`,
+        ).toBeGreaterThan(0);
+      }
+    }
+  }
+}
+
+/** The seed's edges all anchor to real handles. */
+export function assertEdgesAnchorToRealHandles<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+  expect(adapter.edges.length, `${c.name}: seed must contain >=1 edge`).toBeGreaterThan(0);
+  assertAllEdgesAnchor(adapter, c.name);
+}
+
+/** addBlock is immediately readable, addressable by the id it returns, and records position. */
+export function assertAddBlockReadableAndBranded<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+  const before = adapter.blocks.size;
+  const position = { x: 123, y: 456 };
+
+  const id = adapter.addBlock(c.addableType, position);
+
+  expect(adapter.blocks.size, `${c.name}: addBlock grows the projection`).toBe(before + 1);
+  const added = adapter.blocks.get(id);
+  expect(added, `${c.name}: added block is immediately readable`).toBeDefined();
+  // Branded-id discipline: the id you are handed is the id you address it by.
+  expect(added!.id, `${c.name}: added block addressable by returned id`).toBe(id);
+  expect(adapter.getBlockPosition(id), `${c.name}: addBlock records the drop position`).toEqual(position);
+}
+
+/** removeBlock leaves no dangling edge refs and clears the block's position. */
+export function assertRemoveBlockCoherent<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+  const id = adapter.addBlock(c.addableType, { x: 0, y: 0 });
+  expect(adapter.blocks.has(id)).toBe(true);
+
+  adapter.removeBlock(id);
+
+  expect(adapter.blocks.has(id), `${c.name}: removed block gone from projection`).toBe(false);
+  expect(adapter.getBlockPosition(id), `${c.name}: removed block position cleared`).toBeUndefined();
+  for (const edge of adapter.edges) {
+    expect(edge.sourceBlockId, `${c.name}: no edge dangles from removed block`).not.toBe(String(id));
+    expect(edge.targetBlockId, `${c.name}: no edge dangles to removed block`).not.toBe(String(id));
+  }
+  assertAllEdgesAnchor(adapter, c.name);
+}
+
+/** A block's editor position round-trips through the adapter. */
+export function assertPositionRoundtrips<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+  const id = adapter.addBlock(c.addableType, { x: 1, y: 2 });
+  adapter.setBlockPosition(id, { x: 77, y: 88 });
+  expect(adapter.getBlockPosition(id), `${c.name}: position round-trips`).toEqual({ x: 77, y: 88 });
+}
+
+/** removeEdge leaves no dangling refs; a subsequent addEdge yields a well-formed edge. */
+export function assertEdgeMutationCoherent<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+  const seed = adapter.edges[0];
+  expect(seed, `${c.name}: seed must contain >=1 edge`).toBeDefined();
+
+  adapter.removeEdge(seed.id);
+  expect(adapter.edges.some((e) => e.id === seed.id), `${c.name}: removed edge id is gone`).toBe(false);
+  assertAllEdgesAnchor(adapter, c.name);
+
+  const newId = adapter.addEdge(
+    asId<Id>(seed.sourceBlockId),
+    seed.sourcePortId,
+    asId<Id>(seed.targetBlockId),
+    seed.targetPortId,
+  );
+  expect(adapter.edges.some((e) => e.id === newId), `${c.name}: re-added edge is present`).toBe(true);
+  assertAllEdgesAnchor(adapter, c.name);
+}
+
+/** A mutation through one adapter is visible through a fresh adapter over the same store. */
+export function assertMutationsDelegateToStore<Id>(c: ConformanceCase<Id>): void {
+  const { newAdapter } = c.setup();
+  const writer = newAdapter();
+  const reader = newAdapter(); // same underlying store
+
+  const id = writer.addBlock(c.addableType, { x: 0, y: 0 });
+
+  expect(
+    reader.blocks.has(id),
+    `${c.name}: mutation reaches the owning store (visible via a fresh adapter), not adapter-local shadow state`,
+  ).toBe(true);
+}
+
+/** Mutations invalidate MobX-tracked reads so ReactFlow re-renders. */
+export function assertReactivity<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+
+  // Track a structural signature, not a count: a same-cardinality edit (remove
+  // one, auto-materialize another) still changes identity and must be observed.
+  let blockSignals = 0;
+  const disposeBlocks = reaction(
+    () => [...adapter.blocks.keys()].map(String).join('|'),
+    () => {
+      blockSignals += 1;
+    },
+  );
+  adapter.addBlock(c.addableType, { x: 0, y: 0 });
+  expect(blockSignals, `${c.name}: block mutation triggers a MobX reaction`).toBeGreaterThan(0);
+  disposeBlocks();
+
+  let edgeSignals = 0;
+  const disposeEdges = reaction(
+    () => adapter.edges.map((e) => e.id).join('|'),
+    () => {
+      edgeSignals += 1;
+    },
+  );
+  const seed = adapter.edges[0];
+  expect(seed, `${c.name}: seed must contain >=1 edge`).toBeDefined();
+  adapter.removeEdge(seed.id);
+  expect(edgeSignals, `${c.name}: edge mutation triggers a MobX reaction`).toBeGreaterThan(0);
+  disposeEdges();
+
+  if (adapter.dataVersion !== undefined) {
+    expect(typeof adapter.dataVersion, `${c.name}: dataVersion is numeric when present`).toBe('number');
+  }
+}
+
+/** updateBlockParams writes through to the store and is reflected in the projection. */
+export function assertParamEditingDelegates<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+  expect(adapter.updateBlockParams, `${c.name}: declared params capability requires updateBlockParams`).toBeDefined();
+
+  const id = adapter.addBlock(c.addableType, { x: 0, y: 0 });
+  adapter.updateBlockParams!(id, { value: 0.7 });
+
+  expect(adapter.blocks.get(id)?.params.value, `${c.name}: param write reflected in projection`).toBe(0.7);
+}
+
+/** updateBlockDisplayName writes through to the store and is reflected in the projection. */
+export function assertDisplayNameDelegates<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+  expect(
+    adapter.updateBlockDisplayName,
+    `${c.name}: declared displayName capability requires updateBlockDisplayName`,
+  ).toBeDefined();
+
+  const id = adapter.addBlock(c.addableType, { x: 0, y: 0 });
+  const result = adapter.updateBlockDisplayName!(id, 'Renamed');
+
+  expect(result.error, `${c.name}: valid rename has no error`).toBeUndefined();
+  expect(adapter.blocks.get(id)?.displayName, `${c.name}: rename reflected in projection`).toBe('Renamed');
+}
+
+/**
+ * Register the whole contract against one provider. A future 4th provider is
+ * drop-in verifiable: build a ConformanceCase for it and call this.
+ */
+export function runConformanceSuite<Id>(c: ConformanceCase<Id>): void {
+  describe(`GraphDataAdapter conformance: ${c.name}`, () => {
+    it('projects self-describing blocks', () => assertBlocksSelfDescribing(c));
+    it('edges anchor to real handles', () => assertEdgesAnchorToRealHandles(c));
+    it('addBlock is immediately readable and branded-id addressable', () => assertAddBlockReadableAndBranded(c));
+    it('removeBlock leaves no dangling refs and clears position', () => assertRemoveBlockCoherent(c));
+    it('block position round-trips', () => assertPositionRoundtrips(c));
+    it('edge remove/add is coherent', () => assertEdgeMutationCoherent(c));
+    it('mutations delegate to the owning store (no shadow state)', () => assertMutationsDelegateToStore(c));
+    it('mutations preserve MobX reactivity', () => assertReactivity(c));
+
+    const paramsIt = c.capabilities.params ? it : it.skip;
+    paramsIt('updateBlockParams writes through to the store', () => assertParamEditingDelegates(c));
+
+    const displayNameIt = c.capabilities.displayName ? it : it.skip;
+    displayNameIt('updateBlockDisplayName writes through to the store', () => assertDisplayNameDelegates(c));
+  });
+}

--- a/src/ui/graphEditor/__tests__/adapter-conformance.test.ts
+++ b/src/ui/graphEditor/__tests__/adapter-conformance.test.ts
@@ -1,0 +1,188 @@
+/**
+ * adapter-conformance.test — the GraphDataAdapter contract run against every
+ * provider, plus a negative control proving the contract rejects.
+ *
+ * The contract itself lives in ./adapter-conformance.contract. Here we supply
+ * one `ConformanceCase` per provider (seeding it in that provider's own
+ * vocabulary) and run the shared suite over each. A future backend becomes
+ * drop-in verifiable by adding one case below. [LAW:verifiable-goals]
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { PatchStore } from '../../../stores/PatchStore';
+import { LayoutStore } from '../../../stores/LayoutStore';
+import { FrontendResultStore } from '../../../stores/FrontendResultStore';
+import { CompositeEditorStore } from '../../../stores/CompositeEditorStore';
+import { PillarPatchStore } from '../../../stores/PillarPatchStore';
+import type { BlockId } from '../../../types';
+import type { InternalBlockId } from '../../../blocks/composite-types';
+
+import { PatchStoreAdapter } from '../PatchStoreAdapter';
+import { CompositeStoreAdapter } from '../CompositeStoreAdapter';
+import { PillarPatchAdapter } from '../PillarPatchAdapter';
+import type { GraphDataAdapter, BlockLike, EdgeLike } from '../types';
+
+import {
+  assertAddBlockReadableAndBranded,
+  assertBlocksSelfDescribing,
+  assertEdgesAnchorToRealHandles,
+  assertMutationsDelegateToStore,
+  assertReactivity,
+  runConformanceSuite,
+  type ConformanceCase,
+} from './adapter-conformance.contract';
+
+// =============================================================================
+// One case per provider — provider-specific seeding, era-specific vocabulary.
+// =============================================================================
+
+const patchStoreCase: ConformanceCase<BlockId> = {
+  name: 'PatchStoreAdapter',
+  addableType: 'Const',
+  capabilities: { params: true, displayName: true },
+  setup() {
+    const patchStore = new PatchStore();
+    const layoutStore = new LayoutStore();
+    const frontendStore = new FrontendResultStore();
+
+    // Seed a Const -> Ellipse.rx wiring (>=2 blocks, >=1 edge).
+    const constId = patchStore.addBlock('Const', { value: 0.5 });
+    const ellipseId = patchStore.addBlock('Ellipse', {});
+    patchStore.addEdge(
+      { kind: 'port', blockId: constId, slotId: 'out' },
+      { kind: 'port', blockId: ellipseId, slotId: 'rx' },
+    );
+
+    return { newAdapter: () => new PatchStoreAdapter(patchStore, layoutStore, frontendStore) };
+  },
+};
+
+const compositeStoreCase: ConformanceCase<InternalBlockId> = {
+  name: 'CompositeStoreAdapter',
+  addableType: 'Noise',
+  capabilities: { params: false, displayName: false },
+  setup() {
+    const store = new CompositeEditorStore();
+
+    const noiseId = store.addBlock('Noise', { x: 0, y: 0 });
+    const lagId = store.addBlock('Lag', { x: 200, y: 0 });
+    store.addEdge({ fromBlock: noiseId, fromPort: 'out', toBlock: lagId, toPort: 'target' });
+
+    return { newAdapter: () => new CompositeStoreAdapter(store) };
+  },
+};
+
+const pillarPatchCase: ConformanceCase<string> = {
+  name: 'PillarPatchAdapter',
+  addableType: 'Constant',
+  capabilities: { params: true, displayName: false },
+  setup() {
+    // PillarPatchStore self-seeds the grid-of-squares patch (3 blocks, 2 edges).
+    const store = new PillarPatchStore();
+    return { newAdapter: () => new PillarPatchAdapter(store) };
+  },
+};
+
+runConformanceSuite(patchStoreCase);
+runConformanceSuite(compositeStoreCase);
+runConformanceSuite(pillarPatchCase);
+
+// =============================================================================
+// Negative control — a deliberately-broken adapter the contract MUST reject.
+//
+// If the assertions passed this, they would be vacuous. Each `expect(...).toThrow`
+// pins a distinct invariant to the assertion that enforces it. [LAW:verifiable-goals]
+// =============================================================================
+
+/**
+ * Violates the contract on every axis: a block with an empty typeLabel and a
+ * mismatched id; an edge whose target handle does not exist; mutations that are
+ * no-ops (so nothing is readable, nothing delegates, nothing reacts). It is a
+ * plain object graph with no MobX observability.
+ */
+class BrokenAdapter implements GraphDataAdapter<string> {
+  private readonly block: BlockLike = {
+    id: 'real-id',
+    type: 'Broken',
+    typeLabel: '', // violation: not self-describing
+    displayName: 'Broken',
+    params: {},
+    inputPorts: new Map([['in', { id: 'in', label: 'In' }]]),
+    outputPorts: new Map([['out', { id: 'out', label: 'Out' }]]),
+    controls: [],
+  };
+
+  get blocks(): ReadonlyMap<string, BlockLike> {
+    // Key deliberately disagrees with block.id — breaks branded-id discipline.
+    return new Map([['wrong-key', this.block]]);
+  }
+
+  get edges(): readonly EdgeLike[] {
+    // Target handle 'nope' is not a real input port — the edge would be dropped.
+    return [
+      {
+        id: 'e0',
+        sourceBlockId: 'wrong-key',
+        sourcePortId: 'out',
+        targetBlockId: 'wrong-key',
+        targetPortId: 'nope',
+      },
+    ];
+  }
+
+  addBlock(_type: string, _position: { x: number; y: number }): string {
+    return 'ghost'; // no-op: never actually added
+  }
+
+  removeBlock(_id: string): void {
+    /* no-op */
+  }
+
+  getBlockPosition(_id: string): { x: number; y: number } | undefined {
+    return undefined;
+  }
+
+  setBlockPosition(_id: string, _position: { x: number; y: number }): void {
+    /* no-op */
+  }
+
+  addEdge(_s: string, _sp: string, _t: string, _tp: string): string {
+    return 'ghost-edge'; // no-op
+  }
+
+  removeEdge(_id: string): void {
+    /* no-op */
+  }
+}
+
+const brokenCase: ConformanceCase<string> = {
+  name: 'BrokenAdapter',
+  addableType: 'X',
+  capabilities: { params: false, displayName: false },
+  setup() {
+    return { newAdapter: () => new BrokenAdapter() };
+  },
+};
+
+describe('conformance contract rejects a non-conforming adapter (negative control)', () => {
+  it('rejects blocks that are not self-describing', () => {
+    expect(() => assertBlocksSelfDescribing(brokenCase)).toThrow();
+  });
+
+  it('rejects edges that do not anchor to real handles', () => {
+    expect(() => assertEdgesAnchorToRealHandles(brokenCase)).toThrow();
+  });
+
+  it('rejects addBlock that is not immediately readable', () => {
+    expect(() => assertAddBlockReadableAndBranded(brokenCase)).toThrow();
+  });
+
+  it('rejects mutations that do not delegate to a shared store', () => {
+    expect(() => assertMutationsDelegateToStore(brokenCase)).toThrow();
+  });
+
+  it('rejects mutations that break MobX reactivity', () => {
+    expect(() => assertReactivity(brokenCase)).toThrow();
+  });
+});


### PR DESCRIPTION
## What

The GraphDataAdapter contract, stated **once** as executable assertions and run parameterized over all three providers — plus a deliberately-broken adapter the same assertions must reject.

Closes **oscilla-editor-ux-8lsn.15** (follows the merged nt8lsn.14 spike).

## Design

- `adapter-conformance.contract.ts` — the single specification. Assertions speak only the neutral editor vocabulary (`BlockLike`/`EdgeLike`/`GraphDataAdapter`); they import no store and no era-specific type. `[LAW:single-enforcer]`
- A `ConformanceCase` is the seam: each provider supplies one, seeding a store in its own era's language and declaring which optional capabilities it claims. A 4th backend becomes drop-in verifiable by adding one case. `[LAW:decomposition]` `[LAW:verifiable-goals]`
- `adapter-conformance.test.ts` — three cases (PatchStore / Composite / Pillar) + the negative control.

## Invariants enforced per instance

- blocks self-describing (renderable without a registry)
- edges anchor to real handles — the exact predicate `createEdgeFromEdgeLike` uses to keep vs. drop a projected edge
- addBlock immediately readable + branded-id addressable
- removeBlock leaves no dangling refs and clears position
- block position round-trips
- edge remove/add coherent (no dangling; re-add well-formed)
- **mutations delegate to the owning store** — proven via a *fresh adapter over the same store*, so adapter-local shadow state fails
- MobX reactivity preserved on every mutation
- capability-gated: `updateBlockParams` / `updateBlockDisplayName` write-through (run only where the provider declares support)

## Negative control

A `BrokenAdapter` (empty typeLabel, mismatched id, dangling edge handle, no-op non-observable mutations) is rejected on all five pinned axes — the suite is not vacuous. `[LAW:verifiable-goals]`

## Deliberate deviation from ticket prose

The epic says "dataVersion advances on every mutation." That is **not true of the design** — `PatchStoreAdapter.dataVersion` reads `frontendStore.snapshot.patchRevision`, advanced by a *compile*, not a raw store mutation. Encoding it would bake a false invariant into the contract. The universal reactivity invariant is enforced as "a MobX reaction over `blocks`/`edges` fires on mutation"; `dataVersion` is checked numeric-when-present. `[LAW:no-silent-failure]`

## Verification

```
npx vitest run src/ui/graphEditor/   # 40 passed | 3 skipped
npx tsc --noEmit                      # clean
```
The 3 skips are the capability-gated tests for providers that don't support them (Composite: params+displayName; Pillar: displayName).