### PR TITLE
feat(editor-ux 8lsn.16): BlockCatalog seam — palette/insert/replace via one neutral query surface, both eras

### DIFF
--- a/src/ui/block-ui.ts
+++ b/src/ui/block-ui.ts
@@ -2,11 +2,11 @@ import type { DockviewApi } from 'dockview';
 import type { BlockId } from '../types';
 import type {
   AnyBlockDef,
-  BlockOpenBehaviorDef,
   BlockParamEditorDef,
 } from '../blocks/registry';
 import { openExpressionEditorPanel } from './dockview';
 import type { DiagnosticsStore, ExpressionEditorStore } from '../stores';
+import type { CatalogOpenBehavior } from './graphEditor/block-catalog';
 
 export interface RunBlockOpenBehaviorContext {
   readonly blockId: BlockId;
@@ -19,29 +19,31 @@ function unreachableBehavior(behavior: never, message: string): never {
   throw new Error(`${message}: ${JSON.stringify(behavior)}`);
 }
 
-export function hasBlockOpenBehavior(behavior: BlockOpenBehaviorDef): boolean {
-  return behavior.kind !== 'noop';
+// The open behavior is a neutral, per-type fact supplied by the BlockCatalog; a
+// backend without an expression editor reports `{ kind: 'none' }`.
+export function hasBlockOpenBehavior(behavior: CatalogOpenBehavior): boolean {
+  return behavior.kind !== 'none';
 }
 
-export function getBlockOpenBehaviorLabel(behavior: BlockOpenBehaviorDef): string {
-  if (behavior.kind === 'open-expression-editor') {
+export function getBlockOpenBehaviorLabel(behavior: CatalogOpenBehavior): string {
+  if (behavior.kind === 'expressionEditor') {
     return 'Open Expression Editor';
   }
-  if (behavior.kind === 'noop') {
+  if (behavior.kind === 'none') {
     return 'Open';
   }
-  return unreachableBehavior(behavior, 'Unhandled BlockOpenBehaviorDef in getBlockOpenBehaviorLabel');
+  return unreachableBehavior(behavior, 'Unhandled CatalogOpenBehavior in getBlockOpenBehaviorLabel');
 }
 
 export function runBlockOpenBehavior(
-  behavior: BlockOpenBehaviorDef,
+  behavior: CatalogOpenBehavior,
   context: RunBlockOpenBehaviorContext,
 ): void {
-  if (behavior.kind === 'noop') {
+  if (behavior.kind === 'none') {
     return;
   }
 
-  if (behavior.kind === 'open-expression-editor') {
+  if (behavior.kind === 'expressionEditor') {
     context.expressionEditor.openForBlock(context.blockId);
     if (!context.api) {
       context.diagnostics.log({
@@ -53,7 +55,7 @@ export function runBlockOpenBehavior(
     openExpressionEditorPanel(context.api, context.blockId);
     return;
   }
-  return unreachableBehavior(behavior, 'Unhandled BlockOpenBehaviorDef in runBlockOpenBehavior');
+  return unreachableBehavior(behavior, 'Unhandled CatalogOpenBehavior in runBlockOpenBehavior');
 }
 
 export function getBlockParamEditor(

--- a/src/ui/components/BlockLibrary.tsx
+++ b/src/ui/components/BlockLibrary.tsx
@@ -11,7 +11,6 @@ import type { BlockId } from '../../types';
 import { useStores } from '../../stores';
 import { useBlockCatalog } from '../graphEditor/BlockCatalogContext';
 import {
-  type BlockCatalog,
   type CatalogEntry,
   catalogCategories,
   catalogEntriesInCategory,
@@ -93,6 +92,12 @@ function useDebounce<T>(value: T, delay: number): T {
 export const BlockLibrary: React.FC = () => {
   const { selection, diagnostics } = useStores();
   const catalog = useBlockCatalog();
+  // Read the catalog ONCE per render. The V1 catalog reads the mutable registry
+  // fresh on each access, so this snapshot both stays current (runtime-registered
+  // composites appear) and is materialized a single time for every derived view
+  // below. Do NOT memoize on `catalog` — its reference never changes, which would
+  // freeze the library on the first render's registry state. [LAW:effects-at-boundaries]
+  const entries = catalog.entries;
   // State
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearchQuery = useDebounce(searchQuery, SEARCH_DEBOUNCE_MS);
@@ -171,17 +176,17 @@ export const BlockLibrary: React.FC = () => {
 
   // Non-insertable types (e.g. singleton roots) are already excluded by the
   // catalog helpers, so every returned category has insertable entries.
-  const filteredCategories = useMemo(() => catalogCategories(catalog), [catalog]);
+  const filteredCategories = useMemo(() => catalogCategories(entries), [entries]);
 
   // Calculate total results across all categories
   const totalResults = useMemo(() => {
     let count = 0;
     filteredCategories.forEach((category: string) => {
-      const entries = catalogEntriesInCategory(catalog, category);
-      count += searchEntries(entries, debouncedSearchQuery).length;
+      const inCategory = catalogEntriesInCategory(entries, category);
+      count += searchEntries(inCategory, debouncedSearchQuery).length;
     });
     return count;
-  }, [catalog, filteredCategories, debouncedSearchQuery]);
+  }, [entries, filteredCategories, debouncedSearchQuery]);
 
   return (
     <div className="block-library">
@@ -229,7 +234,7 @@ export const BlockLibrary: React.FC = () => {
         {filteredCategories.map((category: string) => (
           <BlockCategorySection
             key={category}
-            catalog={catalog}
+            entries={entries}
             category={category}
             collapsed={collapsedCategories.has(category)}
             searchQuery={debouncedSearchQuery}
@@ -256,7 +261,7 @@ export const BlockLibrary: React.FC = () => {
  * Block Category Section
  */
 interface BlockCategorySectionProps {
-  catalog: BlockCatalog;
+  entries: readonly CatalogEntry[];
   category: BlockCategory;
   collapsed: boolean;
   searchQuery: string;
@@ -268,7 +273,7 @@ interface BlockCategorySectionProps {
 }
 
 const BlockCategorySection: React.FC<BlockCategorySectionProps> = ({
-  catalog,
+  entries,
   category,
   collapsed,
   searchQuery,
@@ -278,11 +283,11 @@ const BlockCategorySection: React.FC<BlockCategorySectionProps> = ({
   focused,
   onFocus,
 }) => {
-  const entries = useMemo(() => catalogEntriesInCategory(catalog, category), [catalog, category]);
+  const inCategory = useMemo(() => catalogEntriesInCategory(entries, category), [entries, category]);
 
   const filteredTypes = useMemo(
-    () => searchEntries(entries, searchQuery),
-    [entries, searchQuery],
+    () => searchEntries(inCategory, searchQuery),
+    [inCategory, searchQuery],
   );
 
   if (filteredTypes.length === 0) return null;

--- a/src/ui/components/BlockLibrary.tsx
+++ b/src/ui/components/BlockLibrary.tsx
@@ -9,12 +9,14 @@ import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import { ActionIcon, rem } from '@mantine/core';
 import type { BlockId } from '../../types';
 import { useStores } from '../../stores';
+import { useBlockCatalog } from '../graphEditor/BlockCatalogContext';
 import {
-  getBlockCategories,
-  getBlockTypesByCategory,
-  type BlockDef,
-} from '../../blocks/registry';
-import { type CompositeBlockDef, isCompositeBlockDef } from '../../blocks/composite-types';
+  type BlockCatalog,
+  type CatalogEntry,
+  catalogCategories,
+  catalogEntriesInCategory,
+  searchEntries,
+} from '../graphEditor/block-catalog';
 import { useEditor } from '../editorCommon';
 import { resolveLocalStorageCapability } from '../../services/local-storage-capability';
 import type { DiagnosticsStore } from '../../stores/DiagnosticsStore';
@@ -22,13 +24,14 @@ import './BlockLibrary.css';
 
 // Type aliases for clarity
 type BlockCategory = string;
-type BlockTypeInfo = BlockDef | CompositeBlockDef;
+type BlockTypeInfo = CatalogEntry;
 
 // LocalStorage key for category collapse state
 const COLLAPSE_STATE_KEY = 'blockLibrary.collapsedCategories';
 
-// Debounce delay for search (ms)
-const SEARCH_DEBOUNCE_MS = 150;
+// Debounce delay for search (ms). Exported so tests can drive the debounce timer
+// deterministically rather than racing it. [LAW:one-source-of-truth]
+export const SEARCH_DEBOUNCE_MS = 150;
 
 /**
  * Load collapsed categories from localStorage.
@@ -89,6 +92,7 @@ function useDebounce<T>(value: T, delay: number): T {
  */
 export const BlockLibrary: React.FC = () => {
   const { selection, diagnostics } = useStores();
+  const catalog = useBlockCatalog();
   // State
   const [searchQuery, setSearchQuery] = useState('');
   const debouncedSearchQuery = useDebounce(searchQuery, SEARCH_DEBOUNCE_MS);
@@ -165,35 +169,19 @@ export const BlockLibrary: React.FC = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [searchQuery, handleSearchClear]);
 
-  const categories = getBlockCategories();
-
-  // Filter out timeRoot blocks (P5: TimeRoot Hidden)
-  const filteredCategories = useMemo(() => {
-    return categories.filter(category => {
-      const types = getBlockTypesByCategory(category);
-      // Check if category has any non-timeRoot blocks
-      return types.some((t: BlockTypeInfo) => t.capability !== 'time');
-    });
-  }, [categories]);
+  // Non-insertable types (e.g. singleton roots) are already excluded by the
+  // catalog helpers, so every returned category has insertable entries.
+  const filteredCategories = useMemo(() => catalogCategories(catalog), [catalog]);
 
   // Calculate total results across all categories
   const totalResults = useMemo(() => {
     let count = 0;
     filteredCategories.forEach((category: string) => {
-      const types = getBlockTypesByCategory(category);
-      // Filter out timeRoot blocks
-      const nonTimeRootTypes = types.filter((t: BlockTypeInfo) => t.capability !== 'time');
-      const filtered = debouncedSearchQuery
-        ? nonTimeRootTypes.filter((t: BlockTypeInfo) =>
-          t.type.toLowerCase().includes(debouncedSearchQuery.toLowerCase()) ||
-          t.label.toLowerCase().includes(debouncedSearchQuery.toLowerCase()) ||
-          (t.description?.toLowerCase().includes(debouncedSearchQuery.toLowerCase()) ?? false)
-        )
-        : nonTimeRootTypes;
-      count += filtered.length;
+      const entries = catalogEntriesInCategory(catalog, category);
+      count += searchEntries(entries, debouncedSearchQuery).length;
     });
     return count;
-  }, [filteredCategories, debouncedSearchQuery]);
+  }, [catalog, filteredCategories, debouncedSearchQuery]);
 
   return (
     <div className="block-library">
@@ -241,6 +229,7 @@ export const BlockLibrary: React.FC = () => {
         {filteredCategories.map((category: string) => (
           <BlockCategorySection
             key={category}
+            catalog={catalog}
             category={category}
             collapsed={collapsedCategories.has(category)}
             searchQuery={debouncedSearchQuery}
@@ -267,6 +256,7 @@ export const BlockLibrary: React.FC = () => {
  * Block Category Section
  */
 interface BlockCategorySectionProps {
+  catalog: BlockCatalog;
   category: BlockCategory;
   collapsed: boolean;
   searchQuery: string;
@@ -278,6 +268,7 @@ interface BlockCategorySectionProps {
 }
 
 const BlockCategorySection: React.FC<BlockCategorySectionProps> = ({
+  catalog,
   category,
   collapsed,
   searchQuery,
@@ -287,21 +278,12 @@ const BlockCategorySection: React.FC<BlockCategorySectionProps> = ({
   focused,
   onFocus,
 }) => {
-  const types = getBlockTypesByCategory(category);
+  const entries = useMemo(() => catalogEntriesInCategory(catalog, category), [catalog, category]);
 
-  // Filter out timeRoot blocks (P5: TimeRoot Hidden)
-  const nonTimeRootTypes = useMemo(() => {
-    return types.filter((t: BlockTypeInfo) => t.capability !== 'time');
-  }, [types]);
-
-  const filteredTypes = useMemo(() => {
-    if (!searchQuery) return nonTimeRootTypes;
-    return nonTimeRootTypes.filter((t: BlockTypeInfo) =>
-      t.type.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      t.label.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      (t.description?.toLowerCase().includes(searchQuery.toLowerCase()) ?? false)
-    );
-  }, [nonTimeRootTypes, searchQuery]);
+  const filteredTypes = useMemo(
+    () => searchEntries(entries, searchQuery),
+    [entries, searchQuery],
+  );
 
   if (filteredTypes.length === 0) return null;
 
@@ -351,14 +333,14 @@ const BlockTypeItem: React.FC<BlockTypeItemProps> = ({
   onClick,
   onDoubleClick,
 }) => {
-  const inputCount = Object.keys(type.inputs).length;
-  const outputCount = Object.keys(type.outputs).length;
-  const isComposite = isCompositeBlockDef(type);
+  const inputCount = type.inputs.length;
+  const outputCount = type.outputs.length;
+  const isComposite = type.form === 'composite';
   const isPrimitive = type.form === 'primitive';
 
-  // For composites, check if it's readonly (library) or user-created
-  const isLibraryComposite = isComposite && type.readonly === true;
-  const isUserComposite = isComposite && !type.readonly;
+  // For composites, a locked (library) definition is not editable; a user one is.
+  const isLibraryComposite = isComposite && !type.editable;
+  const isUserComposite = isComposite && type.editable;
 
   // Determine badge appearance
   let badgeText: string;

--- a/src/ui/components/BlockLibrary.tsx
+++ b/src/ui/components/BlockLibrary.tsx
@@ -5,7 +5,7 @@
  * Click to preview type in inspector, double-click to add block.
  */
 
-import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { ActionIcon, rem } from '@mantine/core';
 import type { BlockId } from '../../types';
 import { useStores } from '../../stores';
@@ -174,19 +174,18 @@ export const BlockLibrary: React.FC = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [searchQuery, handleSearchClear]);
 
-  // Non-insertable types (e.g. singleton roots) are already excluded by the
-  // catalog helpers, so every returned category has insertable entries.
-  const filteredCategories = useMemo(() => catalogCategories(entries), [entries]);
-
-  // Calculate total results across all categories
-  const totalResults = useMemo(() => {
-    let count = 0;
-    filteredCategories.forEach((category: string) => {
-      const inCategory = catalogEntriesInCategory(entries, category);
-      count += searchEntries(inCategory, debouncedSearchQuery).length;
-    });
-    return count;
-  }, [entries, filteredCategories, debouncedSearchQuery]);
+  // Filter each category ONCE — the result is shared by the count and the
+  // sections below, instead of both re-filtering the full entry set per category.
+  // Non-insertable types (singleton roots) are already excluded by the helpers.
+  // No memo: `entries` is a fresh array each render (the live registry read), so
+  // memoizing on it would never cache — it would only add weight. [LAW:effects-at-boundaries]
+  const visibleSections = catalogCategories(entries)
+    .map((category) => ({
+      category,
+      items: searchEntries(catalogEntriesInCategory(entries, category), debouncedSearchQuery),
+    }))
+    .filter((section) => section.items.length > 0);
+  const totalResults = visibleSections.reduce((n, s) => n + s.items.length, 0);
 
   return (
     <div className="block-library">
@@ -231,13 +230,12 @@ export const BlockLibrary: React.FC = () => {
       </div>
 
       <div className="block-library__categories">
-        {filteredCategories.map((category: string) => (
+        {visibleSections.map(({ category, items }) => (
           <BlockCategorySection
             key={category}
-            entries={entries}
             category={category}
+            items={items}
             collapsed={collapsedCategories.has(category)}
-            searchQuery={debouncedSearchQuery}
             onToggle={toggleCategory}
             onBlockClick={handleBlockClick}
             onBlockDoubleClick={handleBlockDoubleClick}
@@ -261,10 +259,10 @@ export const BlockLibrary: React.FC = () => {
  * Block Category Section
  */
 interface BlockCategorySectionProps {
-  entries: readonly CatalogEntry[];
+  /** Pre-filtered entries for this category (search already applied by the parent). */
+  items: readonly CatalogEntry[];
   category: BlockCategory;
   collapsed: boolean;
-  searchQuery: string;
   onToggle: (category: BlockCategory) => void;
   onBlockClick: (type: BlockTypeInfo) => void;
   onBlockDoubleClick: (type: BlockTypeInfo) => void;
@@ -273,25 +271,15 @@ interface BlockCategorySectionProps {
 }
 
 const BlockCategorySection: React.FC<BlockCategorySectionProps> = ({
-  entries,
+  items,
   category,
   collapsed,
-  searchQuery,
   onToggle,
   onBlockClick,
   onBlockDoubleClick,
   focused,
   onFocus,
 }) => {
-  const inCategory = useMemo(() => catalogEntriesInCategory(entries, category), [entries, category]);
-
-  const filteredTypes = useMemo(
-    () => searchEntries(inCategory, searchQuery),
-    [inCategory, searchQuery],
-  );
-
-  if (filteredTypes.length === 0) return null;
-
   return (
     <div
       className={`block-category ${collapsed ? 'collapsed' : ''} ${focused ? 'focused' : ''}`}
@@ -302,12 +290,12 @@ const BlockCategorySection: React.FC<BlockCategorySectionProps> = ({
         <span className="block-category__dot" />
         <span className="block-category__icon">▼</span>
         <h3 className="block-category__title">{category}</h3>
-        <span className="block-category__count">{filteredTypes.length}</span>
+        <span className="block-category__count">{items.length}</span>
       </div>
 
       {!collapsed && (
         <div className="block-category__types">
-          {filteredTypes.map((type: BlockTypeInfo) => (
+          {items.map((type: BlockTypeInfo) => (
             <BlockTypeItem
               key={type.type}
               type={type}

--- a/src/ui/components/BlockLibrary.tsx
+++ b/src/ui/components/BlockLibrary.tsx
@@ -12,8 +12,7 @@ import { useStores } from '../../stores';
 import { useBlockCatalog } from '../graphEditor/BlockCatalogContext';
 import {
   type CatalogEntry,
-  catalogCategories,
-  catalogEntriesInCategory,
+  insertableByCategory,
   searchEntries,
 } from '../graphEditor/block-catalog';
 import { useEditor } from '../editorCommon';
@@ -174,15 +173,16 @@ export const BlockLibrary: React.FC = () => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [searchQuery, handleSearchClear]);
 
-  // Filter each category ONCE — the result is shared by the count and the
-  // sections below, instead of both re-filtering the full entry set per category.
-  // Non-insertable types (singleton roots) are already excluded by the helpers.
-  // No memo: `entries` is a fresh array each render (the live registry read), so
-  // memoizing on it would never cache — it would only add weight. [LAW:effects-at-boundaries]
-  const visibleSections = catalogCategories(entries)
+  // Bucket insertable entries by category in a single pass (non-insertable
+  // singleton roots excluded), then apply the search per category. The result is
+  // shared by the count and the section list. No memo: `entries` is a fresh array
+  // each render (the live registry read), so memoizing on it would never cache —
+  // it would only add weight. [LAW:effects-at-boundaries]
+  const { categories, byCategory } = insertableByCategory(entries);
+  const visibleSections = categories
     .map((category) => ({
       category,
-      items: searchEntries(catalogEntriesInCategory(entries, category), debouncedSearchQuery),
+      items: searchEntries(byCategory.get(category) ?? [], debouncedSearchQuery),
     }))
     .filter((section) => section.items.length > 0);
   const totalResults = visibleSections.reduce((n, s) => n + s.items.length, 0);
@@ -326,6 +326,10 @@ const BlockTypeItem: React.FC<BlockTypeItemProps> = ({
   onClick,
   onDoubleClick,
 }) => {
+  // Counts reflect WIREABLE ports only. The catalog deliberately excludes
+  // config-only inputs (edited inline, never wired) and hidden outputs — those
+  // belong to the controls seam, not the catalog — so this hint is intentionally
+  // the count a graph author can actually connect to. [LAW:decomposition]
   const inputCount = type.inputs.length;
   const outputCount = type.outputs.length;
   const isComposite = type.form === 'composite';

--- a/src/ui/components/ConnectionPicker.tsx
+++ b/src/ui/components/ConnectionPicker.tsx
@@ -9,8 +9,8 @@ import React, { useMemo } from 'react';
 import { Autocomplete, TextField } from '@mui/material';
 import type { BlockId, PortId } from '../../types';
 import type { Patch } from '../../graph/Patch';
-import { requireAnyBlockDef } from '../../blocks/registry';
-import { formatTypeForDisplay } from '../reactFlowEditor/typeValidation';
+import { useBlockCatalog } from '../graphEditor/BlockCatalogContext';
+import { requireCatalogEntry } from '../graphEditor/block-catalog';
 import { colors } from '../theme';
 import { useStores } from '../../stores';
 import { getCompatiblePortsForPort } from '../authoring/semanticQueries';
@@ -56,6 +56,7 @@ export const ConnectionPicker: React.FC<ConnectionPickerProps> = function Connec
   onCancel,
 }: ConnectionPickerProps) {
   const { frontend } = useStores();
+  const catalog = useBlockCatalog();
 
   // Build list of compatible ports
   const portOptions = useMemo(() => {
@@ -68,23 +69,22 @@ export const ConnectionPicker: React.FC<ConnectionPickerProps> = function Connec
     )
       .map((candidate): PortOption => {
         const block = patch.blocks.get(candidate.blockId)!;
-        const blockDef = requireAnyBlockDef(block.type);
+        const entry = requireCatalogEntry(catalog, block.type);
         const searchDirection = direction === 'input' ? 'output' : 'input';
-        const portDef = searchDirection === 'input'
-          ? blockDef.inputs[candidate.portId]
-          : blockDef.outputs[candidate.portId];
+        const ports = searchDirection === 'input' ? entry.inputs : entry.outputs;
+        const port = ports.find((p) => p.id === candidate.portId);
 
         return {
           blockId: candidate.blockId,
           blockName: candidate.blockLabel,
           portId: candidate.portId,
           portLabel: candidate.portLabel,
-          typeDisplay: portDef?.type ? formatTypeForDisplay(portDef.type) : '',
+          typeDisplay: port?.typeDisplay.label ?? '',
           isCompatible: true,
         };
       })
       .sort((a, b) => a.blockName.localeCompare(b.blockName));
-  }, [patch, frontend, targetBlockId, targetPortId, direction]);
+  }, [patch, frontend, targetBlockId, targetPortId, direction, catalog]);
 
   return (
     <div style={{ marginTop: '8px' }}>

--- a/src/ui/components/__tests__/BlockLibrary.test.tsx
+++ b/src/ui/components/__tests__/BlockLibrary.test.tsx
@@ -1,14 +1,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { autorun } from 'mobx';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { MantineProvider } from '@mantine/core';
 import { useEffect } from 'react';
 
-import { BlockLibrary } from '../BlockLibrary';
+import { BlockLibrary, SEARCH_DEBOUNCE_MS } from '../BlockLibrary';
 import { EditorProvider, useEditor, type EditorHandle } from '../../editorCommon';
 import { RootStore, StoreProvider } from '../../../stores';
-import { getBlockCategories, getBlockTypesByCategory } from '../../../blocks/registry';
+import { registerAllBlocks } from '../../../blocks/all';
+import { BlockCatalogProvider } from '../../graphEditor/BlockCatalogContext';
+import { v1BlockCatalog } from '../../graphEditor/V1BlockCatalog';
+import { catalogCategories, catalogEntriesInCategory } from '../../graphEditor/block-catalog';
+
+registerAllBlocks();
 
 function readComputed<T>(reader: () => T): T {
   let value!: T;
@@ -69,20 +74,19 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
   return (
     <MantineProvider>
       <StoreProvider store={testStore}>
-        <EditorProvider>
-          <InjectEditorHandle handle={mockEditorHandle} />
-          {children}
-        </EditorProvider>
+        <BlockCatalogProvider catalog={v1BlockCatalog}>
+          <EditorProvider>
+            <InjectEditorHandle handle={mockEditorHandle} />
+            {children}
+          </EditorProvider>
+        </BlockCatalogProvider>
       </StoreProvider>
     </MantineProvider>
   );
 }
 
 function getVisibleCategories(): string[] {
-  return getBlockCategories().filter((category: string) => {
-    const types = getBlockTypesByCategory(category);
-    return types.some((t: any) => t.capability !== 'time');
-  });
+  return [...catalogCategories(v1BlockCatalog)];
 }
 
 describe('BlockLibrary', () => {
@@ -95,15 +99,27 @@ describe('BlockLibrary', () => {
     vi.clearAllMocks();
   });
 
-  it('filters blocks from search input (case-insensitive)', async () => {
-    render(<BlockLibrary />, { wrapper: TestWrapper });
+  it('filters blocks from search input (case-insensitive)', () => {
+    // The search box debounces input (a setTimeout). Drive that timer explicitly
+    // so the assertion never races a real 150ms timeout under machine load — the
+    // result must be a function of the input, not of wall-clock timing.
+    // [LAW:no-ambient-temporal-coupling]
+    vi.useFakeTimers();
+    try {
+      render(<BlockLibrary />, { wrapper: TestWrapper });
 
-    const searchInput = screen.getByPlaceholderText('Search blocks...');
-    fireEvent.change(searchInput, { target: { value: 'SINE' } });
+      const searchInput = screen.getByPlaceholderText('Search blocks...');
+      fireEvent.change(searchInput, { target: { value: 'SINE' } });
 
-    await waitFor(() => {
+      // Settle the debounce deterministically, then flush the state update.
+      act(() => {
+        vi.advanceTimersByTime(SEARCH_DEBOUNCE_MS + 50);
+      });
+
       expect(screen.getByText(/\bresults?\b/i)).toBeInTheDocument();
-    });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('adds a block to the patch on double click', async () => {
@@ -112,8 +128,8 @@ describe('BlockLibrary', () => {
     const categories = getVisibleCategories();
     expect(categories.length).toBeGreaterThan(0);
 
-    const types = getBlockTypesByCategory(categories[0]!);
-    const firstVisible = types.find((t: any) => t.capability !== 'time');
+    const entries = catalogEntriesInCategory(v1BlockCatalog, categories[0]!);
+    const firstVisible = entries[0];
     expect(firstVisible).toBeTruthy();
 
     const beforeCount = readComputed(() => testStore.patch.blocks.size);

--- a/src/ui/components/__tests__/BlockLibrary.test.tsx
+++ b/src/ui/components/__tests__/BlockLibrary.test.tsx
@@ -11,7 +11,7 @@ import { RootStore, StoreProvider } from '../../../stores';
 import { registerAllBlocks } from '../../../blocks/all';
 import { BlockCatalogProvider } from '../../graphEditor/BlockCatalogContext';
 import { v1BlockCatalog } from '../../graphEditor/V1BlockCatalog';
-import { catalogCategories, catalogEntriesInCategory } from '../../graphEditor/block-catalog';
+import { insertableByCategory } from '../../graphEditor/block-catalog';
 
 registerAllBlocks();
 
@@ -86,7 +86,7 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
 }
 
 function getVisibleCategories(): string[] {
-  return [...catalogCategories(v1BlockCatalog.entries)];
+  return [...insertableByCategory(v1BlockCatalog.entries).categories];
 }
 
 describe('BlockLibrary', () => {
@@ -128,7 +128,7 @@ describe('BlockLibrary', () => {
     const categories = getVisibleCategories();
     expect(categories.length).toBeGreaterThan(0);
 
-    const entries = catalogEntriesInCategory(v1BlockCatalog.entries, categories[0]!);
+    const entries = insertableByCategory(v1BlockCatalog.entries).byCategory.get(categories[0]!) ?? [];
     const firstVisible = entries[0];
     expect(firstVisible).toBeTruthy();
 

--- a/src/ui/components/__tests__/BlockLibrary.test.tsx
+++ b/src/ui/components/__tests__/BlockLibrary.test.tsx
@@ -86,7 +86,7 @@ function TestWrapper({ children }: { children: React.ReactNode }) {
 }
 
 function getVisibleCategories(): string[] {
-  return [...catalogCategories(v1BlockCatalog)];
+  return [...catalogCategories(v1BlockCatalog.entries)];
 }
 
 describe('BlockLibrary', () => {
@@ -128,7 +128,7 @@ describe('BlockLibrary', () => {
     const categories = getVisibleCategories();
     expect(categories.length).toBeGreaterThan(0);
 
-    const entries = catalogEntriesInCategory(v1BlockCatalog, categories[0]!);
+    const entries = catalogEntriesInCategory(v1BlockCatalog.entries, categories[0]!);
     const firstVisible = entries[0];
     expect(firstVisible).toBeTruthy();
 

--- a/src/ui/components/app/App.tsx
+++ b/src/ui/components/app/App.tsx
@@ -15,6 +15,9 @@ import { MantineProvider, createTheme as createMantineTheme, virtualColor } from
 import '@mantine/core/styles.css';
 import { Toolbar } from './Toolbar';
 import { EditorProvider, type EditorHandle, useEditor } from '../../editorCommon';
+import { BlockCatalogProvider } from '../../graphEditor/BlockCatalogContext';
+import { v1BlockCatalog } from '../../graphEditor/V1BlockCatalog';
+import { sceneBlockCatalog } from '../../graphEditor/SceneBlockCatalog';
 import { DockviewProvider } from '../../dockview';
 import type { DockviewApi } from 'dockview';
 import { useGlobalHotkeys, type HotkeyFeedback } from '../../hotkeys';
@@ -221,8 +224,11 @@ export const App: React.FC<AppProps> = ({ onCanvasReady, onStoreReady, onStatsSi
           <TestPreviewPanel onCanvasReady={handleCanvasReady} />
         ) : nativeEditor ? (
           /* Native ScenePlan editor: authoring surface + live Three preview */
-          <NativeEditorLayout onCanvasReady={handleCanvasReady} />
+          <BlockCatalogProvider catalog={sceneBlockCatalog}>
+            <NativeEditorLayout onCanvasReady={handleCanvasReady} />
+          </BlockCatalogProvider>
         ) : (
+          <BlockCatalogProvider catalog={v1BlockCatalog}>
           <EditorProvider>
           {/* Capture EditorContext methods */}
           <EditorContextCapture
@@ -264,6 +270,7 @@ export const App: React.FC<AppProps> = ({ onCanvasReady, onStoreReady, onStatsSi
           />
           <EngineDebugOverlay />
         </EditorProvider>
+          </BlockCatalogProvider>
         )}
       </ExternalWriteBusContext.Provider>
     </MantineProvider>

--- a/src/ui/graphEditor/BlockCatalogContext.tsx
+++ b/src/ui/graphEditor/BlockCatalogContext.tsx
@@ -1,0 +1,34 @@
+/**
+ * BlockCatalogContext - injects the era's BlockCatalog into the editor tree.
+ *
+ * Parallel to how the GraphDataAdapter is era-selected: the V1 boot provides the
+ * V1 registry projection, the native boot provides the scene registry
+ * projection, and the consumers (block library, connection picker, replacement
+ * menu) read whichever one is in scope via `useBlockCatalog()` — none of them
+ * knows which backend it is browsing. [LAW:one-way-deps]
+ */
+
+import React, { createContext, useContext } from 'react';
+import type { BlockCatalog } from './block-catalog';
+
+const BlockCatalogContext = createContext<BlockCatalog | null>(null);
+
+export const BlockCatalogProvider: React.FC<{
+  catalog: BlockCatalog;
+  children: React.ReactNode;
+}> = ({ catalog, children }) => (
+  <BlockCatalogContext.Provider value={catalog}>{children}</BlockCatalogContext.Provider>
+);
+
+/**
+ * Read the in-scope catalog. Throws when no provider is present rather than
+ * silently falling back to one era — a missing provider is a wiring bug, not a
+ * default. [LAW:no-silent-failure]
+ */
+export function useBlockCatalog(): BlockCatalog {
+  const catalog = useContext(BlockCatalogContext);
+  if (!catalog) {
+    throw new Error('useBlockCatalog must be used within a BlockCatalogProvider');
+  }
+  return catalog;
+}

--- a/src/ui/graphEditor/PillarPatchAdapter.ts
+++ b/src/ui/graphEditor/PillarPatchAdapter.ts
@@ -15,36 +15,15 @@
 import { makeObservable, computed, observable, runInAction } from 'mobx';
 import type { PillarPatchStore } from '../../stores/PillarPatchStore';
 import type { PillarBlock } from '../../pillars/types/graph';
-import type { SceneCatalogMetadata, SceneValueKind } from '../../pillars/scene/scene-block';
+import type { SceneCatalogMetadata } from '../../pillars/scene/scene-block';
 import type {
   GraphDataAdapter,
   BlockLike,
   EdgeLike,
   InputPortLike,
   OutputPortLike,
-  PortTypeDisplay,
 } from './types';
-
-/** Neutral swatch color per scene value kind (parallels the V1 payload palette). */
-const SCENE_VALUE_COLORS: Record<SceneValueKind, string> = {
-  instanceBundle: '#f59e0b',
-  geometry: '#a78bfa',
-  materialShell: '#38bdf8',
-  texture: '#f472b6',
-  camera: '#8b5cf6',
-  color: '#ec4899',
-  scalar: '#5a9fd4',
-  mask: '#10b981',
-};
-
-function sceneTypeDisplay(value: SceneValueKind): PortTypeDisplay {
-  return {
-    label: value,
-    tooltip: value,
-    color: SCENE_VALUE_COLORS[value] ?? '#888888',
-    compatibilityToken: value,
-  };
-}
+import { sceneTypeDisplay } from './scene-projection';
 
 /**
  * Adapter exposing PillarPatchStore through the neutral GraphDataAdapter.

--- a/src/ui/graphEditor/SceneBlockCatalog.ts
+++ b/src/ui/graphEditor/SceneBlockCatalog.ts
@@ -39,19 +39,40 @@ function toCatalogEntry(catalog: SceneCatalogMetadata): CatalogEntry {
   };
 }
 
-/** Build the scene catalog from a scene registry's catalog metadata. */
+/**
+ * Build the scene catalog from a thunk that yields the scene registry's catalog
+ * metadata. The projection is built lazily on first access and cached once:
+ * unlike the V1 registry, the scene block set (`ALL_SCENE_BLOCKS`) is a static
+ * module constant with no runtime registration, so a single snapshot is always
+ * complete — the caching strategy matches the registry's (im)mutability.
+ *
+ * Deferring the build also decouples the boots: `App.tsx` imports this singleton
+ * for the native path, but the scene registry is only constructed when that path
+ * first reads the catalog, so a scene-registry build error can never take down
+ * the V1 editor. [LAW:no-ambient-temporal-coupling]
+ */
 export function createSceneBlockCatalog(
-  catalogMetadata: readonly SceneCatalogMetadata[],
+  loadCatalog: () => readonly SceneCatalogMetadata[],
 ): BlockCatalog {
-  const entries: readonly CatalogEntry[] = catalogMetadata.map(toCatalogEntry);
-  const byType = new Map<string, CatalogEntry>(entries.map((e) => [e.type, e]));
+  let cache: { entries: readonly CatalogEntry[]; byType: Map<string, CatalogEntry> } | null = null;
+
+  const build = (): { entries: readonly CatalogEntry[]; byType: Map<string, CatalogEntry> } => {
+    if (cache === null) {
+      const entries: readonly CatalogEntry[] = loadCatalog().map(toCatalogEntry);
+      cache = { entries, byType: new Map(entries.map((e) => [e.type, e])) };
+    }
+    return cache;
+  };
+
   return {
-    entries,
-    getEntry: (type) => byType.get(type),
+    get entries() {
+      return build().entries;
+    },
+    getEntry: (type) => build().byType.get(type),
   };
 }
 
-/** The scene catalog is a static projection of the boot-time scene registry. */
+/** The scene catalog, built lazily from the static scene registry. */
 export const sceneBlockCatalog: BlockCatalog = createSceneBlockCatalog(
-  buildSceneRegistry(ALL_SCENE_BLOCKS).catalog,
+  () => buildSceneRegistry(ALL_SCENE_BLOCKS).catalog,
 );

--- a/src/ui/graphEditor/SceneBlockCatalog.ts
+++ b/src/ui/graphEditor/SceneBlockCatalog.ts
@@ -1,0 +1,57 @@
+/**
+ * SceneBlockCatalog — the pillar scene registry projected into the neutral
+ * BlockCatalog.
+ *
+ * The pillar-era counterpart of V1BlockCatalog: it translates each
+ * `SceneCatalogMetadata` into a neutral `CatalogEntry` so the same editor
+ * library / picker / replacement menu can browse and insert scene blocks. The
+ * scene era has no composites, no expression editor, and no singleton roots, so
+ * every entry reports the neutral defaults (`form: 'primitive'`,
+ * `openBehavior: {kind:'none'}`, `insertable: true`). [LAW:dataflow-not-control-flow]
+ */
+
+import { buildSceneRegistry, type SceneCatalogMetadata } from '../../pillars/scene/scene-block';
+import { ALL_SCENE_BLOCKS } from '../../pillars/scene';
+import { sceneTypeDisplay } from './scene-projection';
+import type { BlockCatalog, CatalogEntry, CatalogPort } from './block-catalog';
+
+function ports(catalog: SceneCatalogMetadata, direction: 'input' | 'output'): readonly CatalogPort[] {
+  return catalog.ports
+    .filter((port) => port.direction === direction)
+    .map((port) => ({
+      id: port.id,
+      label: port.label,
+      typeDisplay: sceneTypeDisplay(port.value),
+    }));
+}
+
+function toCatalogEntry(catalog: SceneCatalogMetadata): CatalogEntry {
+  return {
+    type: catalog.type,
+    label: catalog.displayName,
+    category: catalog.category,
+    form: 'primitive',
+    editable: true,
+    insertable: true,
+    openBehavior: { kind: 'none' },
+    inputs: ports(catalog, 'input'),
+    outputs: ports(catalog, 'output'),
+  };
+}
+
+/** Build the scene catalog from a scene registry's catalog metadata. */
+export function createSceneBlockCatalog(
+  catalogMetadata: readonly SceneCatalogMetadata[],
+): BlockCatalog {
+  const entries: readonly CatalogEntry[] = catalogMetadata.map(toCatalogEntry);
+  const byType = new Map<string, CatalogEntry>(entries.map((e) => [e.type, e]));
+  return {
+    entries,
+    getEntry: (type) => byType.get(type),
+  };
+}
+
+/** The scene catalog is a static projection of the boot-time scene registry. */
+export const sceneBlockCatalog: BlockCatalog = createSceneBlockCatalog(
+  buildSceneRegistry(ALL_SCENE_BLOCKS).catalog,
+);

--- a/src/ui/graphEditor/UnifiedNode.tsx
+++ b/src/ui/graphEditor/UnifiedNode.tsx
@@ -25,7 +25,11 @@ import { useStores } from '../../stores';
 import type { UnifiedNodeData, PortData } from './nodeDataTransform';
 import type { PortDecoration } from './types';
 import type { PortId, BlockId } from '../../types';
-import { getAnyBlockDefinition, DEFAULT_BLOCK_UI } from '../../blocks/registry';
+import { useBlockCatalog } from './BlockCatalogContext';
+import type { CatalogOpenBehavior } from './block-catalog';
+
+/** Neutral default for a type absent from the catalog: it opens nothing. */
+const NO_OPEN_BEHAVIOR: CatalogOpenBehavior = { kind: 'none' };
 import { ParameterControl } from '../reactFlowEditor/ParameterControls';
 import { PortInfoPopover } from '../reactFlowEditor/PortInfoPopover';
 import { usePinPopoverState, type PopoverAnchorPosition } from '../reactFlowEditor/BasePopover';
@@ -190,8 +194,9 @@ export const UnifiedNode: React.FC<NodeProps<UnifiedNodeData>> = observer(({ dat
   const { adapter, enableParamEditing, onPortContextMenu, selection, portHighlight } = useGraphEditor();
   const { diagnostics, expressionEditor } = useStores();
   const dockview = React.useContext(DockviewContext);
-  const blockUi = getAnyBlockDefinition(data.blockType)?.ui ?? DEFAULT_BLOCK_UI;
-  const canRunOpenBehavior = hasBlockOpenBehavior(blockUi.openBehavior);
+  const catalog = useBlockCatalog();
+  const openBehavior = catalog.getEntry(data.blockType)?.openBehavior ?? NO_OPEN_BEHAVIOR;
+  const canRunOpenBehavior = hasBlockOpenBehavior(openBehavior);
 
   const portPopover = usePinPopoverState<PortPopoverData>({
     isSame: (a, b) => a.port.id === b.port.id && a.isInput === b.isInput,
@@ -265,13 +270,13 @@ export const UnifiedNode: React.FC<NodeProps<UnifiedNodeData>> = observer(({ dat
   const handleOpenBehavior = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault();
     event.stopPropagation();
-    runBlockOpenBehavior(blockUi.openBehavior, {
+    runBlockOpenBehavior(openBehavior, {
       blockId: data.blockId as BlockId,
       api: dockview?.api ?? null,
       diagnostics,
       expressionEditor,
     });
-  }, [blockUi.openBehavior, data.blockId, diagnostics, dockview?.api, expressionEditor]);
+  }, [openBehavior, data.blockId, diagnostics, dockview?.api, expressionEditor]);
 
   return (
     <div
@@ -410,8 +415,8 @@ export const UnifiedNode: React.FC<NodeProps<UnifiedNodeData>> = observer(({ dat
         {canRunOpenBehavior && (
           <button
             type="button"
-            aria-label={getBlockOpenBehaviorLabel(blockUi.openBehavior)}
-            title={getBlockOpenBehaviorLabel(blockUi.openBehavior)}
+            aria-label={getBlockOpenBehaviorLabel(openBehavior)}
+            title={getBlockOpenBehaviorLabel(openBehavior)}
             onClick={handleOpenBehavior}
             style={{
               display: 'inline-flex',

--- a/src/ui/graphEditor/UnifiedNode.tsx
+++ b/src/ui/graphEditor/UnifiedNode.tsx
@@ -26,10 +26,7 @@ import type { UnifiedNodeData, PortData } from './nodeDataTransform';
 import type { PortDecoration } from './types';
 import type { PortId, BlockId } from '../../types';
 import { useBlockCatalog } from './BlockCatalogContext';
-import type { CatalogOpenBehavior } from './block-catalog';
-
-/** Neutral default for a type absent from the catalog: it opens nothing. */
-const NO_OPEN_BEHAVIOR: CatalogOpenBehavior = { kind: 'none' };
+import { NO_OPEN_BEHAVIOR } from './block-catalog';
 import { ParameterControl } from '../reactFlowEditor/ParameterControls';
 import { PortInfoPopover } from '../reactFlowEditor/PortInfoPopover';
 import { usePinPopoverState, type PopoverAnchorPosition } from '../reactFlowEditor/BasePopover';

--- a/src/ui/graphEditor/V1BlockCatalog.ts
+++ b/src/ui/graphEditor/V1BlockCatalog.ts
@@ -14,6 +14,7 @@
 import {
   getBlockCategories,
   getBlockTypesByCategory,
+  getAnyBlockDefinition,
   type BlockDef,
   type BlockOpenBehaviorDef,
   type InputDef,
@@ -82,31 +83,28 @@ function toCatalogEntry(def: AnyDef): CatalogEntry {
  * (categories → types), so the neutral entry set is the same set the editor
  * always showed. [LAW:one-source-of-truth]
  *
- * The projection is built lazily on first access, not at construction: the V1
- * registry is a mutable global populated by `registerAllBlocks()` at boot, so a
- * catalog captured at module-import time could snapshot an empty registry.
- * Deferring to first read guarantees registration has run. [LAW:no-silent-failure]
+ * The projection reads the registry FRESH on every access — it holds no snapshot.
+ * The V1 registry is a mutable global: `registerAllBlocks()` populates it at boot
+ * and `registerComposite()` adds user-authored composites at runtime. A cached
+ * snapshot would both risk capturing an empty registry (if built before boot
+ * registration) and silently omit runtime composites forever. Reading fresh
+ * mirrors the old per-render registry reads and stays correct as the registry
+ * grows. Lookup uses the registry's own O(1) index rather than materializing the
+ * whole catalog. [LAW:no-silent-failure]
  */
 export function createV1BlockCatalog(): BlockCatalog {
-  let cache: { entries: readonly CatalogEntry[]; byType: Map<string, CatalogEntry> } | null = null;
-
-  const build = (): { entries: readonly CatalogEntry[]; byType: Map<string, CatalogEntry> } => {
-    if (cache === null) {
-      const entries: readonly CatalogEntry[] = getBlockCategories()
+  return {
+    get entries(): readonly CatalogEntry[] {
+      return getBlockCategories()
         .flatMap((category) => getBlockTypesByCategory(category))
         .map(toCatalogEntry);
-      cache = { entries, byType: new Map(entries.map((e) => [e.type, e])) };
-    }
-    return cache;
-  };
-
-  return {
-    get entries() {
-      return build().entries;
     },
-    getEntry: (type) => build().byType.get(type),
+    getEntry: (type) => {
+      const def = getAnyBlockDefinition(type);
+      return def ? toCatalogEntry(def) : undefined;
+    },
   };
 }
 
-/** The V1 catalog is a lazy projection of the boot-time registry. */
+/** The V1 catalog is a live projection of the registry (no snapshot). */
 export const v1BlockCatalog: BlockCatalog = createV1BlockCatalog();

--- a/src/ui/graphEditor/V1BlockCatalog.ts
+++ b/src/ui/graphEditor/V1BlockCatalog.ts
@@ -1,0 +1,112 @@
+/**
+ * V1BlockCatalog — the V1 registry projected into the neutral BlockCatalog.
+ *
+ * This is the ONE file in `src/ui` permitted to read the V1 block registry for
+ * catalog queries. The registry-read code that used to live inline in the block
+ * library, connection picker, and replacement menu is MOVED here — moved, not
+ * rewritten — and translated once into neutral `CatalogEntry` facts.
+ * [LAW:single-enforcer] [LAW:carrying-cost]
+ *
+ * A grep gate (`block-catalog-registry-gate.test.ts`) enforces that no other
+ * editor file imports the registry's catalog functions.
+ */
+
+import {
+  getBlockCategories,
+  getBlockTypesByCategory,
+  type BlockDef,
+  type BlockOpenBehaviorDef,
+  type InputDef,
+  type OutputDef,
+} from '../../blocks/registry';
+import { type CompositeBlockDef, isCompositeBlockDef } from '../../blocks/composite-types';
+import { typeDisplayFor } from './neutral-projection';
+import type {
+  BlockCatalog,
+  CatalogEntry,
+  CatalogOpenBehavior,
+  CatalogPort,
+} from './block-catalog';
+
+type AnyDef = BlockDef | CompositeBlockDef;
+
+/** Map the V1 open-behavior descriptor to the neutral one. */
+function toOpenBehavior(behavior: BlockOpenBehaviorDef): CatalogOpenBehavior {
+  return behavior.kind === 'open-expression-editor'
+    ? { kind: 'expressionEditor' }
+    : { kind: 'none' };
+}
+
+/** Wireable input ports only — config-only inputs never cross the seam. */
+function inputPorts(def: AnyDef): readonly CatalogPort[] {
+  return Object.entries(def.inputs)
+    .filter(([, input]: [string, InputDef]) => input.exposedAsPort !== false)
+    .map(([id, input]: [string, InputDef]) => ({
+      id,
+      label: input.label ?? id,
+      typeDisplay: typeDisplayFor(input.type),
+    }));
+}
+
+/** Visible output ports only — hidden outputs never cross the seam. */
+function outputPorts(def: AnyDef): readonly CatalogPort[] {
+  return Object.entries(def.outputs)
+    .filter(([, output]: [string, OutputDef]) => !output.hidden)
+    .map(([id, output]: [string, OutputDef]) => ({
+      id,
+      label: output.label ?? id,
+      typeDisplay: typeDisplayFor(output.type),
+    }));
+}
+
+function toCatalogEntry(def: AnyDef): CatalogEntry {
+  const composite = isCompositeBlockDef(def);
+  return {
+    type: def.type,
+    label: def.label,
+    description: def.description,
+    category: def.category,
+    form: def.form,
+    // Only library composites are locked; primitives + user composites are editable.
+    editable: composite ? def.readonly !== true : true,
+    // A V1 time root is a singleton — not palette-insertable, not a replacement candidate.
+    insertable: def.capability !== 'time',
+    openBehavior: toOpenBehavior(def.ui.openBehavior),
+    inputs: inputPorts(def),
+    outputs: outputPorts(def),
+  };
+}
+
+/**
+ * Build the V1 catalog. Enumerates the registry exactly as the block library did
+ * (categories → types), so the neutral entry set is the same set the editor
+ * always showed. [LAW:one-source-of-truth]
+ *
+ * The projection is built lazily on first access, not at construction: the V1
+ * registry is a mutable global populated by `registerAllBlocks()` at boot, so a
+ * catalog captured at module-import time could snapshot an empty registry.
+ * Deferring to first read guarantees registration has run. [LAW:no-silent-failure]
+ */
+export function createV1BlockCatalog(): BlockCatalog {
+  let cache: { entries: readonly CatalogEntry[]; byType: Map<string, CatalogEntry> } | null = null;
+
+  const build = (): { entries: readonly CatalogEntry[]; byType: Map<string, CatalogEntry> } => {
+    if (cache === null) {
+      const entries: readonly CatalogEntry[] = getBlockCategories()
+        .flatMap((category) => getBlockTypesByCategory(category))
+        .map(toCatalogEntry);
+      cache = { entries, byType: new Map(entries.map((e) => [e.type, e])) };
+    }
+    return cache;
+  };
+
+  return {
+    get entries() {
+      return build().entries;
+    },
+    getEntry: (type) => build().byType.get(type),
+  };
+}
+
+/** The V1 catalog is a lazy projection of the boot-time registry. */
+export const v1BlockCatalog: BlockCatalog = createV1BlockCatalog();

--- a/src/ui/graphEditor/V1BlockCatalog.ts
+++ b/src/ui/graphEditor/V1BlockCatalog.ts
@@ -31,11 +31,22 @@ import type {
 
 type AnyDef = BlockDef | CompositeBlockDef;
 
-/** Map the V1 open-behavior descriptor to the neutral one. */
+/**
+ * Map the V1 open-behavior descriptor to the neutral one. Exhaustive: a new
+ * `BlockOpenBehaviorDef` kind is a compile error here (the `never` default), not
+ * a value silently collapsed to `none`. [LAW:no-silent-failure]
+ */
 function toOpenBehavior(behavior: BlockOpenBehaviorDef): CatalogOpenBehavior {
-  return behavior.kind === 'open-expression-editor'
-    ? { kind: 'expressionEditor' }
-    : { kind: 'none' };
+  switch (behavior.kind) {
+    case 'open-expression-editor':
+      return { kind: 'expressionEditor' };
+    case 'noop':
+      return { kind: 'none' };
+    default: {
+      const unhandled: never = behavior;
+      throw new Error(`Unhandled BlockOpenBehaviorDef: ${JSON.stringify(unhandled)}`);
+    }
+  }
 }
 
 /** Wireable input ports only — config-only inputs never cross the seam. */
@@ -58,6 +69,25 @@ function outputPorts(def: AnyDef): readonly CatalogPort[] {
       label: output.label ?? id,
       typeDisplay: typeDisplayFor(output.type),
     }));
+}
+
+/**
+ * One projected `CatalogEntry` per registry def, keyed by the def OBJECT (which
+ * the registry holds stable). This keeps two guarantees at once: the same block
+ * type always yields the same `CatalogEntry` instance — so `entries` and
+ * `getEntry` are identity-consistent and a hot per-node `getEntry` is O(1) after
+ * the first projection instead of re-allocating port arrays every render — while
+ * a newly-registered composite (a new def object) still projects fresh, and a
+ * removed one is garbage-collected with its def. [LAW:one-source-of-truth]
+ */
+const projectionByDef = new WeakMap<AnyDef, CatalogEntry>();
+
+function project(def: AnyDef): CatalogEntry {
+  const cached = projectionByDef.get(def);
+  if (cached) return cached;
+  const entry = toCatalogEntry(def);
+  projectionByDef.set(def, entry);
+  return entry;
 }
 
 function toCatalogEntry(def: AnyDef): CatalogEntry {
@@ -97,11 +127,11 @@ export function createV1BlockCatalog(): BlockCatalog {
     get entries(): readonly CatalogEntry[] {
       return getBlockCategories()
         .flatMap((category) => getBlockTypesByCategory(category))
-        .map(toCatalogEntry);
+        .map(project);
     },
     getEntry: (type) => {
       const def = getAnyBlockDefinition(type);
-      return def ? toCatalogEntry(def) : undefined;
+      return def ? project(def) : undefined;
     },
   };
 }

--- a/src/ui/graphEditor/__tests__/block-catalog-conformance.contract.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog-conformance.contract.ts
@@ -118,28 +118,29 @@ export function assertKnownTypePresent(c: CatalogConformanceCase): void {
  */
 export function assertDerivedViewsCohere(c: CatalogConformanceCase): void {
   const catalog = c.setup();
-  const insertable = insertableEntries(catalog);
-  const allTypes = new Set(catalog.entries.map((e) => e.type));
+  const entries = catalog.entries;
+  const insertable = insertableEntries(entries);
+  const allTypes = new Set(entries.map((e) => e.type));
   for (const entry of insertable) {
     expect(allTypes.has(entry.type), `${c.name}: insertable entry ${entry.type} is a real entry`).toBe(true);
     expect(entry.insertable, `${c.name}: insertableEntries yields only insertable entries`).toBe(true);
   }
 
-  for (const category of catalogCategories(catalog)) {
+  for (const category of catalogCategories(entries)) {
     expect(
-      catalogEntriesInCategory(catalog, category).length,
+      catalogEntriesInCategory(entries, category).length,
       `${c.name}: category ${category} has entries`,
     ).toBeGreaterThan(0);
   }
 
   expect(
-    searchEntries(catalog.entries, '').length,
+    searchEntries(entries, '').length,
     `${c.name}: empty search returns every entry`,
-  ).toBe(catalog.entries.length);
+  ).toBe(entries.length);
 
   const sample = insertable[0];
   if (sample) {
-    const hits = searchEntries(catalog.entries, sample.label);
+    const hits = searchEntries(entries, sample.label);
     expect(
       hits.some((e) => e.type === sample.type),
       `${c.name}: searching an entry's own label finds it`,

--- a/src/ui/graphEditor/__tests__/block-catalog-conformance.contract.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog-conformance.contract.ts
@@ -1,0 +1,158 @@
+/**
+ * block-catalog-conformance.contract — the BlockCatalog contract, stated once,
+ * as executable assertions.
+ *
+ * This file IS the specification of what makes a catalog "editor-usable". Every
+ * provider (V1BlockCatalog, SceneBlockCatalog, and any future backend) is checked
+ * against this one contract; a behavior this file does not assert is not part of
+ * the contract, and a provider that passes every assertion here is presumed
+ * drop-in for the block library, connection picker, and replacement menu.
+ * [LAW:single-enforcer] [LAW:verifiable-goals]
+ *
+ * DECOMPOSITION: a `CatalogConformanceCase` is the seam. It carries the whole
+ * truth a provider must supply to be checkable — how to build the catalog, and a
+ * block type its registry is known to contain. The `assert*` functions below know
+ * only the neutral vocabulary (`BlockCatalog` / `CatalogEntry`); they never import
+ * a store, a registry, or an era-specific type. This is what lets one contract
+ * check heterogeneous providers. [LAW:decomposition] [LAW:one-way-deps]
+ *
+ * The `assert*` functions are also the negative control's instrument: aimed at a
+ * deliberately-broken catalog they must throw, proving the suite has teeth rather
+ * than vacuously passing.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  type BlockCatalog,
+  type CatalogEntry,
+  type CatalogEntryForm,
+  catalogCategories,
+  catalogEntriesInCategory,
+  insertableEntries,
+  requireCatalogEntry,
+  searchEntries,
+} from '../block-catalog';
+
+const VALID_FORMS: readonly CatalogEntryForm[] = ['primitive', 'macro', 'composite'];
+
+/** Everything a provider must supply to be run through the conformance contract. */
+export interface CatalogConformanceCase {
+  readonly name: string;
+  /** Build the catalog under test. */
+  setup(): BlockCatalog;
+  /** A block type this provider is known to contain (proves non-empty, real content). */
+  readonly knownType: string;
+}
+
+/** A well-formed port carries a label and a presentation-ready type display. */
+function assertPortWellFormed(entry: CatalogEntry, port: CatalogEntry['inputs'][number], name: string): void {
+  expect(port.id.length, `${name}: ${entry.type} port carries an id`).toBeGreaterThan(0);
+  expect(port.label.length, `${name}: ${entry.type} port ${port.id} carries a label`).toBeGreaterThan(0);
+  expect(
+    port.typeDisplay.label.length,
+    `${name}: ${entry.type} port ${port.id} type label`,
+  ).toBeGreaterThan(0);
+  expect(
+    port.typeDisplay.color.length,
+    `${name}: ${entry.type} port ${port.id} type color`,
+  ).toBeGreaterThan(0);
+  expect(
+    port.typeDisplay.compatibilityToken.length,
+    `${name}: ${entry.type} port ${port.id} compatibility token`,
+  ).toBeGreaterThan(0);
+}
+
+/** The catalog contains real block types (a usable palette is never empty). */
+export function assertCatalogNonEmpty(c: CatalogConformanceCase): void {
+  const catalog = c.setup();
+  expect(catalog.entries.length, `${c.name}: catalog must contain entries`).toBeGreaterThan(0);
+}
+
+/** Every entry and every port is self-describing — no registry needed to render it. */
+export function assertEntriesSelfDescribing(c: CatalogConformanceCase): void {
+  const catalog = c.setup();
+  for (const entry of catalog.entries) {
+    expect(entry.type.length, `${c.name}: entry carries a type`).toBeGreaterThan(0);
+    expect(entry.label.length, `${c.name}: entry ${entry.type} carries a label`).toBeGreaterThan(0);
+    expect(entry.category.length, `${c.name}: entry ${entry.type} carries a category`).toBeGreaterThan(0);
+    expect(VALID_FORMS, `${c.name}: entry ${entry.type} has a valid form`).toContain(entry.form);
+    expect(
+      ['none', 'expressionEditor'],
+      `${c.name}: entry ${entry.type} has a valid open behavior`,
+    ).toContain(entry.openBehavior.kind);
+    for (const port of [...entry.inputs, ...entry.outputs]) {
+      assertPortWellFormed(entry, port, c.name);
+    }
+  }
+}
+
+/** getEntry round-trips every entry by its own type, and rejects unknown types. */
+export function assertLookupRoundtrips(c: CatalogConformanceCase): void {
+  const catalog = c.setup();
+  for (const entry of catalog.entries) {
+    expect(
+      catalog.getEntry(entry.type)?.type,
+      `${c.name}: getEntry(${entry.type}) round-trips`,
+    ).toBe(entry.type);
+  }
+  expect(
+    catalog.getEntry('__no_such_block_type__'),
+    `${c.name}: getEntry of an unknown type is undefined`,
+  ).toBeUndefined();
+}
+
+/** The provider's declared known type resolves — the catalog holds real content. */
+export function assertKnownTypePresent(c: CatalogConformanceCase): void {
+  const catalog = c.setup();
+  const entry = requireCatalogEntry(catalog, c.knownType);
+  expect(entry.type, `${c.name}: known type ${c.knownType} resolves`).toBe(c.knownType);
+}
+
+/**
+ * The derived views (insertable filter, category grouping, search) cohere with
+ * the entry set they are computed from. [LAW:one-source-of-truth]
+ */
+export function assertDerivedViewsCohere(c: CatalogConformanceCase): void {
+  const catalog = c.setup();
+  const insertable = insertableEntries(catalog);
+  const allTypes = new Set(catalog.entries.map((e) => e.type));
+  for (const entry of insertable) {
+    expect(allTypes.has(entry.type), `${c.name}: insertable entry ${entry.type} is a real entry`).toBe(true);
+    expect(entry.insertable, `${c.name}: insertableEntries yields only insertable entries`).toBe(true);
+  }
+
+  for (const category of catalogCategories(catalog)) {
+    expect(
+      catalogEntriesInCategory(catalog, category).length,
+      `${c.name}: category ${category} has entries`,
+    ).toBeGreaterThan(0);
+  }
+
+  expect(
+    searchEntries(catalog.entries, '').length,
+    `${c.name}: empty search returns every entry`,
+  ).toBe(catalog.entries.length);
+
+  const sample = insertable[0];
+  if (sample) {
+    const hits = searchEntries(catalog.entries, sample.label);
+    expect(
+      hits.some((e) => e.type === sample.type),
+      `${c.name}: searching an entry's own label finds it`,
+    ).toBe(true);
+  }
+}
+
+/**
+ * Register the whole contract against one provider. A future backend is drop-in
+ * verifiable: build a CatalogConformanceCase for it and call this.
+ */
+export function runCatalogConformanceSuite(c: CatalogConformanceCase): void {
+  describe(`BlockCatalog conformance: ${c.name}`, () => {
+    it('exposes a non-empty catalog', () => assertCatalogNonEmpty(c));
+    it('projects self-describing entries and ports', () => assertEntriesSelfDescribing(c));
+    it('getEntry round-trips and rejects unknown types', () => assertLookupRoundtrips(c));
+    it('contains the declared known type', () => assertKnownTypePresent(c));
+    it('derived views cohere with the entry set', () => assertDerivedViewsCohere(c));
+  });
+}

--- a/src/ui/graphEditor/__tests__/block-catalog-conformance.contract.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog-conformance.contract.ts
@@ -26,8 +26,7 @@ import {
   type BlockCatalog,
   type CatalogEntry,
   type CatalogEntryForm,
-  catalogCategories,
-  catalogEntriesInCategory,
+  insertableByCategory,
   insertableEntries,
   requireCatalogEntry,
   searchEntries,
@@ -126,9 +125,10 @@ export function assertDerivedViewsCohere(c: CatalogConformanceCase): void {
     expect(entry.insertable, `${c.name}: insertableEntries yields only insertable entries`).toBe(true);
   }
 
-  for (const category of catalogCategories(entries)) {
+  const { categories, byCategory } = insertableByCategory(entries);
+  for (const category of categories) {
     expect(
-      catalogEntriesInCategory(entries, category).length,
+      (byCategory.get(category) ?? []).length,
       `${c.name}: category ${category} has entries`,
     ).toBeGreaterThan(0);
   }

--- a/src/ui/graphEditor/__tests__/block-catalog-conformance.contract.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog-conformance.contract.ts
@@ -53,6 +53,10 @@ function assertPortWellFormed(entry: CatalogEntry, port: CatalogEntry['inputs'][
     `${name}: ${entry.type} port ${port.id} type label`,
   ).toBeGreaterThan(0);
   expect(
+    port.typeDisplay.tooltip.length,
+    `${name}: ${entry.type} port ${port.id} type tooltip`,
+  ).toBeGreaterThan(0);
+  expect(
     port.typeDisplay.color.length,
     `${name}: ${entry.type} port ${port.id} type color`,
   ).toBeGreaterThan(0);

--- a/src/ui/graphEditor/__tests__/block-catalog-conformance.test.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog-conformance.test.ts
@@ -81,6 +81,43 @@ const brokenCase: CatalogConformanceCase = {
   setup: () => brokenCatalog,
 };
 
+/**
+ * A catalog whose entry is well-formed at the entry level but carries a port with
+ * an empty tooltip — otherwise every field is populated. This isolates the
+ * port-level type-display checks (which the fully-broken entry above never reaches,
+ * because it fails on the entry label first) and proves the per-field port
+ * assertions — including tooltip — actually have teeth. [LAW:verifiable-goals]
+ */
+const brokenPortCatalog: BlockCatalog = {
+  entries: [
+    {
+      type: 'BadPort',
+      label: 'Bad Port',
+      category: 'X',
+      form: 'primitive',
+      editable: true,
+      insertable: true,
+      openBehavior: { kind: 'none' },
+      inputs: [
+        {
+          id: 'in',
+          label: 'In',
+          // Every field populated EXCEPT tooltip — the field the new assertion guards.
+          typeDisplay: { label: 'float', tooltip: '', color: '#fff', compatibilityToken: 'float' },
+        },
+      ],
+      outputs: [],
+    },
+  ],
+  getEntry: (type) => (type === 'BadPort' ? brokenPortCatalog.entries[0] : undefined),
+};
+
+const brokenPortCase: CatalogConformanceCase = {
+  name: 'BrokenPortCatalog',
+  knownType: 'BadPort',
+  setup: () => brokenPortCatalog,
+};
+
 describe('catalog conformance contract rejects a non-conforming catalog (negative control)', () => {
   it('rejects entries that are not self-describing', () => {
     expect(() => assertEntriesSelfDescribing(brokenCase)).toThrow();
@@ -92,5 +129,9 @@ describe('catalog conformance contract rejects a non-conforming catalog (negativ
 
   it('rejects a catalog missing its declared known type', () => {
     expect(() => assertKnownTypePresent(brokenCase)).toThrow();
+  });
+
+  it('rejects a port whose type-display tooltip is empty', () => {
+    expect(() => assertEntriesSelfDescribing(brokenPortCase)).toThrow();
   });
 });

--- a/src/ui/graphEditor/__tests__/block-catalog-conformance.test.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog-conformance.test.ts
@@ -1,0 +1,96 @@
+/**
+ * block-catalog-conformance.test — the BlockCatalog contract run against every
+ * provider, plus a negative control proving the contract rejects.
+ *
+ * The contract itself lives in ./block-catalog-conformance.contract. Here we
+ * supply one `CatalogConformanceCase` per provider and run the shared suite over
+ * each. A future backend becomes drop-in verifiable by adding one case below.
+ * [LAW:verifiable-goals]
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { registerAllBlocks } from '../../../blocks/all';
+import { v1BlockCatalog } from '../V1BlockCatalog';
+import { sceneBlockCatalog } from '../SceneBlockCatalog';
+import type { BlockCatalog, CatalogEntry } from '../block-catalog';
+
+import {
+  assertEntriesSelfDescribing,
+  assertKnownTypePresent,
+  assertLookupRoundtrips,
+  runCatalogConformanceSuite,
+  type CatalogConformanceCase,
+} from './block-catalog-conformance.contract';
+
+// The V1 catalog is a lazy projection of the mutable registry; make sure it is
+// populated before the suite reads it.
+registerAllBlocks();
+
+// =============================================================================
+// One case per provider — same neutral contract, two different backends.
+// =============================================================================
+
+const v1Case: CatalogConformanceCase = {
+  name: 'V1BlockCatalog',
+  knownType: 'Const',
+  setup: () => v1BlockCatalog,
+};
+
+const sceneCase: CatalogConformanceCase = {
+  name: 'SceneBlockCatalog',
+  knownType: 'Constant',
+  setup: () => sceneBlockCatalog,
+};
+
+runCatalogConformanceSuite(v1Case);
+runCatalogConformanceSuite(sceneCase);
+
+// =============================================================================
+// Negative control — a deliberately-broken catalog the contract MUST reject.
+//
+// If the assertions passed this, they would be vacuous. Each `expect(...).toThrow`
+// pins a distinct invariant to the assertion that enforces it. [LAW:verifiable-goals]
+// =============================================================================
+
+/**
+ * Violates the contract: a non-empty catalog whose single entry has an empty
+ * label and an empty-typeDisplay port, and whose getEntry never resolves — so
+ * nothing is self-describing, nothing round-trips, and no known type is present.
+ */
+const brokenEntry: CatalogEntry = {
+  type: 'Broken',
+  label: '', // violation: not self-describing
+  category: 'X',
+  form: 'primitive',
+  editable: true,
+  insertable: true,
+  openBehavior: { kind: 'none' },
+  inputs: [{ id: 'in', label: '', typeDisplay: { label: '', tooltip: '', color: '', compatibilityToken: '' } }],
+  outputs: [],
+};
+
+const brokenCatalog: BlockCatalog = {
+  entries: [brokenEntry],
+  getEntry: () => undefined, // violation: real entries never resolve
+};
+
+const brokenCase: CatalogConformanceCase = {
+  name: 'BrokenCatalog',
+  knownType: 'Broken',
+  setup: () => brokenCatalog,
+};
+
+describe('catalog conformance contract rejects a non-conforming catalog (negative control)', () => {
+  it('rejects entries that are not self-describing', () => {
+    expect(() => assertEntriesSelfDescribing(brokenCase)).toThrow();
+  });
+
+  it('rejects a getEntry that does not round-trip real entries', () => {
+    expect(() => assertLookupRoundtrips(brokenCase)).toThrow();
+  });
+
+  it('rejects a catalog missing its declared known type', () => {
+    expect(() => assertKnownTypePresent(brokenCase)).toThrow();
+  });
+});

--- a/src/ui/graphEditor/__tests__/block-catalog-registry-gate.test.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog-registry-gate.test.ts
@@ -1,0 +1,62 @@
+/**
+ * block-catalog-registry-gate — the seam's grep gate.
+ *
+ * The point of the BlockCatalog seam is that the editor's palette/insertion
+ * consumers never read a backend block registry directly — they browse, define,
+ * and suggest through the neutral catalog. This test enforces that mechanically
+ * for the four consumers this ticket converted: each imports nothing from
+ * `blocks/registry`, and each imports the neutral catalog module instead (proving
+ * it went *through* the seam rather than dropping the feature).
+ *
+ * SCOPE: this is the catalog seam's gate, not the whole editor's. Other files in
+ * `src/ui` still read the registry for OTHER concerns owned by sibling seams —
+ * the type oracle (wiring compatibility), edge decorations (lenses), the
+ * inspector, parameter controls, and the GraphDataAdapters' own instance
+ * projection. Severing those is each of those tickets' job; fusing them here
+ * would be a decomposition error. The epic-wide "no registry imports in src/ui"
+ * gate lands when the last of those seams closes. [LAW:decomposition]
+ * [LAW:single-enforcer] [LAW:verifiable-goals]
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join, sep } from 'path';
+
+// src/ui — this file lives at src/ui/graphEditor/__tests__.
+const UI_ROOT = join(__dirname, '..', '..');
+
+/** The consumers this seam converted — none may touch the registry any more. */
+const CONVERTED_CONSUMERS = [
+  join('components', 'BlockLibrary.tsx'),
+  join('components', 'ConnectionPicker.tsx'),
+  join('reactFlowEditor', 'menus', 'blockReplacement.ts'),
+  join('reactFlowEditor', 'menus', 'BlockContextMenu.tsx'),
+];
+
+function read(rel: string): string {
+  return readFileSync(join(UI_ROOT, rel), 'utf8');
+}
+
+describe('BlockCatalog seam — registry coupling gate', () => {
+  it('the four converted consumers import nothing from blocks/registry', () => {
+    const offenders: string[] = [];
+    for (const rel of CONVERTED_CONSUMERS) {
+      if (/from\s+['"][^'"]*blocks\/registry['"]/.test(read(rel))) {
+        offenders.push(rel.split(sep).join('/'));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the four converted consumers browse through the neutral catalog seam', () => {
+    const missing: string[] = [];
+    for (const rel of CONVERTED_CONSUMERS) {
+      // Each consumer must reach the catalog — directly (block-catalog) or via
+      // the injected provider (BlockCatalogContext).
+      if (!/graphEditor\/(block-catalog|BlockCatalogContext)/.test(read(rel))) {
+        missing.push(rel.split(sep).join('/'));
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/src/ui/graphEditor/__tests__/block-catalog.test.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog.test.ts
@@ -14,7 +14,7 @@ import {
   type CatalogEntry,
   searchEntries,
   insertableEntries,
-  catalogCategories,
+  insertableByCategory,
 } from '../block-catalog';
 
 function entry(over: Partial<CatalogEntry> & { type: string }): CatalogEntry {
@@ -67,8 +67,10 @@ describe('derived views', () => {
     expect(insertableEntries(entries).map((e) => e.type)).toEqual(['Sin', 'Mul']);
   });
 
-  it('catalogCategories is sorted, unique, and over insertable entries only', () => {
-    // "Source" (Const) is non-insertable, so it must not appear.
-    expect(catalogCategories(entries)).toEqual(['Math']);
+  it('insertableByCategory groups only insertable entries under sorted categories', () => {
+    const { categories, byCategory } = insertableByCategory(entries);
+    // "Source" (Const) is non-insertable, so its category must not appear.
+    expect(categories).toEqual(['Math']);
+    expect((byCategory.get('Math') ?? []).map((e) => e.type)).toEqual(['Sin', 'Mul']);
   });
 });

--- a/src/ui/graphEditor/__tests__/block-catalog.test.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog.test.ts
@@ -64,14 +64,11 @@ describe('searchEntries', () => {
 
 describe('derived views', () => {
   it('insertableEntries excludes non-insertable entries', () => {
-    expect(insertableEntries({ entries, getEntry: () => undefined }).map((e) => e.type)).toEqual([
-      'Sin',
-      'Mul',
-    ]);
+    expect(insertableEntries(entries).map((e) => e.type)).toEqual(['Sin', 'Mul']);
   });
 
   it('catalogCategories is sorted, unique, and over insertable entries only', () => {
     // "Source" (Const) is non-insertable, so it must not appear.
-    expect(catalogCategories({ entries, getEntry: () => undefined })).toEqual(['Math']);
+    expect(catalogCategories(entries)).toEqual(['Math']);
   });
 });

--- a/src/ui/graphEditor/__tests__/block-catalog.test.ts
+++ b/src/ui/graphEditor/__tests__/block-catalog.test.ts
@@ -1,0 +1,77 @@
+/**
+ * block-catalog.test — unit coverage for the catalog's derived-view helpers,
+ * with the search semantics pinned deliberately.
+ *
+ * `searchEntries` trims the query: leading/trailing whitespace from real input
+ * (a pasted or fat-fingered "Sin ") still matches, and a whitespace-only query is
+ * treated as no filter (returns everything), the same as an empty query. These
+ * are intentional choices, asserted here so they cannot silently regress.
+ * [LAW:verifiable-goals]
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  type CatalogEntry,
+  searchEntries,
+  insertableEntries,
+  catalogCategories,
+} from '../block-catalog';
+
+function entry(over: Partial<CatalogEntry> & { type: string }): CatalogEntry {
+  return {
+    label: over.type,
+    category: 'Math',
+    form: 'primitive',
+    editable: true,
+    insertable: true,
+    openBehavior: { kind: 'none' },
+    inputs: [],
+    outputs: [],
+    ...over,
+  };
+}
+
+const entries: readonly CatalogEntry[] = [
+  entry({ type: 'Sin', label: 'Sine', description: 'sine wave' }),
+  entry({ type: 'Mul', label: 'Multiply' }),
+  entry({ type: 'Const', label: 'Constant', category: 'Source', insertable: false }),
+];
+
+describe('searchEntries', () => {
+  it('returns every entry for an empty query', () => {
+    expect(searchEntries(entries, '')).toHaveLength(entries.length);
+  });
+
+  it('treats a whitespace-only query as no filter (returns all)', () => {
+    expect(searchEntries(entries, '   ')).toHaveLength(entries.length);
+  });
+
+  it('trims surrounding whitespace so a real query with stray spaces still matches', () => {
+    const hits = searchEntries(entries, '  Sine  ').map((e) => e.type);
+    expect(hits).toEqual(['Sin']);
+  });
+
+  it('matches case-insensitively across type, label, and description', () => {
+    expect(searchEntries(entries, 'SINE').map((e) => e.type)).toEqual(['Sin']); // label "Sine" + desc
+    expect(searchEntries(entries, 'const').map((e) => e.type)).toEqual(['Const']); // type/label
+    expect(searchEntries(entries, 'MULTIPLY').map((e) => e.type)).toEqual(['Mul']); // label
+  });
+
+  it('returns nothing when no field matches', () => {
+    expect(searchEntries(entries, 'zzz-no-such-block')).toEqual([]);
+  });
+});
+
+describe('derived views', () => {
+  it('insertableEntries excludes non-insertable entries', () => {
+    expect(insertableEntries({ entries, getEntry: () => undefined }).map((e) => e.type)).toEqual([
+      'Sin',
+      'Mul',
+    ]);
+  });
+
+  it('catalogCategories is sorted, unique, and over insertable entries only', () => {
+    // "Source" (Const) is non-insertable, so it must not appear.
+    expect(catalogCategories({ entries, getEntry: () => undefined })).toEqual(['Math']);
+  });
+});

--- a/src/ui/graphEditor/block-catalog.ts
+++ b/src/ui/graphEditor/block-catalog.ts
@@ -141,21 +141,30 @@ export function insertableEntries(entries: readonly CatalogEntry[]): readonly Ca
   return entries.filter((e) => e.insertable);
 }
 
-/** Sorted, unique category names over the insertable entries. */
-export function catalogCategories(entries: readonly CatalogEntry[]): readonly string[] {
-  const seen = new Set<string>();
-  for (const entry of insertableEntries(entries)) {
-    seen.add(entry.category);
-  }
-  return [...seen].sort();
+/** Insertable entries bucketed by category, plus the sorted category list. */
+export interface CategorizedEntries {
+  /** Sorted, unique category names that have at least one insertable entry. */
+  readonly categories: readonly string[];
+  /** Category name → its insertable entries, in registration order. */
+  readonly byCategory: ReadonlyMap<string, readonly CatalogEntry[]>;
 }
 
-/** Insertable entries within one category, in registration order. */
-export function catalogEntriesInCategory(
-  entries: readonly CatalogEntry[],
-  category: string,
-): readonly CatalogEntry[] {
-  return insertableEntries(entries).filter((e) => e.category === category);
+/**
+ * Group insertable entries by category in a SINGLE pass. This is the one place
+ * the palette needs both "which categories exist" and "which entries are in each"
+ * — computing them together avoids re-filtering `insertable` and re-scanning the
+ * whole array once per category (which the separate category helpers did).
+ * [LAW:one-source-of-truth]
+ */
+export function insertableByCategory(entries: readonly CatalogEntry[]): CategorizedEntries {
+  const byCategory = new Map<string, CatalogEntry[]>();
+  for (const entry of entries) {
+    if (!entry.insertable) continue;
+    const list = byCategory.get(entry.category);
+    if (list) list.push(entry);
+    else byCategory.set(entry.category, [entry]);
+  }
+  return { categories: [...byCategory.keys()].sort(), byCategory };
 }
 
 /**

--- a/src/ui/graphEditor/block-catalog.ts
+++ b/src/ui/graphEditor/block-catalog.ts
@@ -39,6 +39,13 @@ export type CatalogOpenBehavior =
   | { readonly kind: 'expressionEditor' };
 
 /**
+ * The neutral default open behavior — what a type reports when it is absent from
+ * the catalog, or the era has no open action. One canonical value so the node
+ * button and the context menu can never disagree. [LAW:one-source-of-truth]
+ */
+export const NO_OPEN_BEHAVIOR: CatalogOpenBehavior = { kind: 'none' };
+
+/**
  * A wireable port on a catalog entry, projected for insertion/display. Only
  * ports the editor actually surfaces cross the seam — config-only inputs
  * (edited inline, never wired) and hidden outputs are a registry-internal detail

--- a/src/ui/graphEditor/block-catalog.ts
+++ b/src/ui/graphEditor/block-catalog.ts
@@ -116,8 +116,16 @@ export interface BlockCatalog {
 }
 
 // =============================================================================
-// Derived views (one source of truth: `catalog.entries`)
+// Derived views — pure functions over an entry array
 // =============================================================================
+//
+// These take a `readonly CatalogEntry[]`, not a `BlockCatalog`, so a caller reads
+// the (possibly live) catalog ONCE at its boundary and derives every view from
+// that single snapshot. The V1 catalog reads the mutable registry fresh on each
+// `.entries` access; if these helpers each re-read `catalog.entries` they would
+// re-materialize the whole projection N times per render. Taking the array keeps
+// the live read at the boundary and the derivations pure and cheap.
+// [LAW:effects-at-boundaries] [LAW:one-source-of-truth]
 
 /** Look up an entry, throwing if the type is unknown (parity with `requireAnyBlockDef`). */
 export function requireCatalogEntry(catalog: BlockCatalog, type: string): CatalogEntry {
@@ -129,22 +137,25 @@ export function requireCatalogEntry(catalog: BlockCatalog, type: string): Catalo
 }
 
 /** Entries the editor lets the user add (singleton roots excluded). */
-export function insertableEntries(catalog: BlockCatalog): readonly CatalogEntry[] {
-  return catalog.entries.filter((e) => e.insertable);
+export function insertableEntries(entries: readonly CatalogEntry[]): readonly CatalogEntry[] {
+  return entries.filter((e) => e.insertable);
 }
 
 /** Sorted, unique category names over the insertable entries. */
-export function catalogCategories(catalog: BlockCatalog): readonly string[] {
+export function catalogCategories(entries: readonly CatalogEntry[]): readonly string[] {
   const seen = new Set<string>();
-  for (const entry of insertableEntries(catalog)) {
+  for (const entry of insertableEntries(entries)) {
     seen.add(entry.category);
   }
   return [...seen].sort();
 }
 
 /** Insertable entries within one category, in registration order. */
-export function catalogEntriesInCategory(catalog: BlockCatalog, category: string): readonly CatalogEntry[] {
-  return insertableEntries(catalog).filter((e) => e.category === category);
+export function catalogEntriesInCategory(
+  entries: readonly CatalogEntry[],
+  category: string,
+): readonly CatalogEntry[] {
+  return insertableEntries(entries).filter((e) => e.category === category);
 }
 
 /**

--- a/src/ui/graphEditor/block-catalog.ts
+++ b/src/ui/graphEditor/block-catalog.ts
@@ -1,0 +1,160 @@
+/**
+ * BlockCatalog — the editor's neutral answer to "what block types exist?"
+ *
+ * This is the palette/insertion seam, the sibling of GraphDataAdapter: where the
+ * adapter answers "what is IN the graph" (block/edge instances), the catalog
+ * answers "what block types could I ADD" (browse, define, suggest). Both eras —
+ * the V1 registry and the pillar scene registry — become coequal providers of
+ * this one query surface, so the editor's library, connection picker, and
+ * replacement menu never consult a backend registry directly.
+ * [FRAMING:representation] [LAW:one-way-deps]
+ *
+ * ARCHITECTURAL CONSTRAINT: like GraphDataAdapter, this interface speaks only the
+ * editor's neutral vocabulary. Each provider translates its era-specific block
+ * definitions INTO these presentation-ready facts (`CatalogEntry`); the consumers
+ * render/insert without knowing which backend produced them. A backend without a
+ * concept (composites, expression editors, singleton roots) simply reports the
+ * neutral default (`form: 'primitive'`, `openBehavior: {kind:'none'}`,
+ * `insertable: true`). [LAW:dataflow-not-control-flow]
+ *
+ * The catalog is a projection of a STATIC registry (both eras register their
+ * blocks at boot), so — unlike GraphDataAdapter — it carries no live graph and
+ * needs no MobX reactivity.
+ */
+
+import type { PortTypeDisplay } from './types';
+
+// =============================================================================
+// Neutral catalog vocabulary
+// =============================================================================
+
+/**
+ * How an authored block instance "opens" — the per-type action offered in the
+ * block context menu. Neutral: an era without an expression editor reports
+ * `{ kind: 'none' }`. The run/label logic lives in `block-ui`; the catalog only
+ * states which behavior a type has.
+ */
+export type CatalogOpenBehavior =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'expressionEditor' };
+
+/**
+ * A wireable port on a catalog entry, projected for insertion/display. Only
+ * ports the editor actually surfaces cross the seam — config-only inputs
+ * (edited inline, never wired) and hidden outputs are a registry-internal detail
+ * and are filtered out by the provider. [LAW:decomposition]
+ */
+export interface CatalogPort {
+  readonly id: string;
+  readonly label: string;
+  /** Presentation-ready display of the port's declared type. */
+  readonly typeDisplay: PortTypeDisplay;
+}
+
+/** The structural flavor of a catalog entry (drives the library's badge). */
+export type CatalogEntryForm = 'primitive' | 'macro' | 'composite';
+
+/**
+ * A block type available in the editor, projected to neutral display + insertion
+ * facts. This is the whole truth a consumer needs to browse, define, and suggest
+ * a block type without touching a backend registry. [LAW:composability]
+ */
+export interface CatalogEntry {
+  /** Registry key / discriminant — the argument to `addBlock`. */
+  readonly type: string;
+  /** Human label for the type (e.g. "Constant"). */
+  readonly label: string;
+  /** Longer prose used in search + tooltip. */
+  readonly description?: string;
+  /** Grouping name for the library (a free string; providers may use their own). */
+  readonly category: string;
+  /** Structural flavor. A backend without composites reports 'primitive'. */
+  readonly form: CatalogEntryForm;
+  /**
+   * Whether the type's definition is user-editable. False for locked library
+   * composites; true for primitives and user composites. Drives the library's
+   * lock/edit badge only.
+   */
+  readonly editable: boolean;
+  /**
+   * Whether the type can be freely added to / replaced into a graph. False for
+   * singleton roots (a V1 time root); the library hides these and the
+   * replacement menu excludes them.
+   */
+  readonly insertable: boolean;
+  /** Per-type open action offered in the context menu. */
+  readonly openBehavior: CatalogOpenBehavior;
+  /** Wireable input ports (config-only inputs excluded). */
+  readonly inputs: readonly CatalogPort[];
+  /** Wireable output ports (hidden outputs excluded). */
+  readonly outputs: readonly CatalogPort[];
+}
+
+// =============================================================================
+// BlockCatalog interface
+// =============================================================================
+
+/**
+ * The editor-owned catalog query surface. A provider supplies the full set of
+ * known entries and a keyed lookup; every other view (categories, grouping,
+ * search, insertable filtering) is derived by the free helpers below so those
+ * derivations live in exactly one place rather than N provider implementations.
+ * [LAW:one-source-of-truth]
+ */
+export interface BlockCatalog {
+  /** Every known block type, projected to neutral facts. */
+  readonly entries: readonly CatalogEntry[];
+  /** Lookup by type discriminant. */
+  getEntry(type: string): CatalogEntry | undefined;
+}
+
+// =============================================================================
+// Derived views (one source of truth: `catalog.entries`)
+// =============================================================================
+
+/** Look up an entry, throwing if the type is unknown (parity with `requireAnyBlockDef`). */
+export function requireCatalogEntry(catalog: BlockCatalog, type: string): CatalogEntry {
+  const entry = catalog.getEntry(type);
+  if (!entry) {
+    throw new Error(`Unknown block type: "${type}" is not in the catalog`);
+  }
+  return entry;
+}
+
+/** Entries the editor lets the user add (singleton roots excluded). */
+export function insertableEntries(catalog: BlockCatalog): readonly CatalogEntry[] {
+  return catalog.entries.filter((e) => e.insertable);
+}
+
+/** Sorted, unique category names over the insertable entries. */
+export function catalogCategories(catalog: BlockCatalog): readonly string[] {
+  const seen = new Set<string>();
+  for (const entry of insertableEntries(catalog)) {
+    seen.add(entry.category);
+  }
+  return [...seen].sort();
+}
+
+/** Insertable entries within one category, in registration order. */
+export function catalogEntriesInCategory(catalog: BlockCatalog, category: string): readonly CatalogEntry[] {
+  return insertableEntries(catalog).filter((e) => e.category === category);
+}
+
+/**
+ * Case-insensitive substring match over type / label / description. Empty query
+ * returns the input unchanged. [LAW:dataflow-not-control-flow] — the same filter
+ * runs every call; the query value carries the variability.
+ */
+export function searchEntries(
+  entries: readonly CatalogEntry[],
+  query: string,
+): readonly CatalogEntry[] {
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return entries;
+  return entries.filter(
+    (e) =>
+      e.type.toLowerCase().includes(q) ||
+      e.label.toLowerCase().includes(q) ||
+      (e.description?.toLowerCase().includes(q) ?? false),
+  );
+}

--- a/src/ui/graphEditor/scene-projection.ts
+++ b/src/ui/graphEditor/scene-projection.ts
@@ -1,0 +1,34 @@
+/**
+ * scene-projection - project pillar/scene facts into the editor's neutral
+ * presentation vocabulary.
+ *
+ * Shared by the pillar providers (PillarPatchAdapter, SceneBlockCatalog) so the
+ * scene→neutral mapping lives in exactly one place. The sibling of
+ * `neutral-projection` (which does the same for the V1 backend).
+ * [LAW:one-source-of-truth]
+ */
+
+import type { SceneValueKind } from '../../pillars/scene/scene-block';
+import type { PortTypeDisplay } from './types';
+
+/** Neutral swatch color per scene value kind (parallels the V1 payload palette). */
+const SCENE_VALUE_COLORS: Record<SceneValueKind, string> = {
+  instanceBundle: '#f59e0b',
+  geometry: '#a78bfa',
+  materialShell: '#38bdf8',
+  texture: '#f472b6',
+  camera: '#8b5cf6',
+  color: '#ec4899',
+  scalar: '#5a9fd4',
+  mask: '#10b981',
+};
+
+/** Neutral presentation of a scene value kind (a port's type on the pillar side). */
+export function sceneTypeDisplay(value: SceneValueKind): PortTypeDisplay {
+  return {
+    label: value,
+    tooltip: value,
+    color: SCENE_VALUE_COLORS[value] ?? '#888888',
+    compatibilityToken: value,
+  };
+}

--- a/src/ui/reactFlowEditor/__tests__/blockReplacement.test.ts
+++ b/src/ui/reactFlowEditor/__tests__/blockReplacement.test.ts
@@ -6,6 +6,7 @@ import {
   findCompatibleReplacementPlans,
   isCompatibleBlockReplacement,
 } from '../menus/blockReplacement';
+import { v1BlockCatalog } from '../../graphEditor/V1BlockCatalog';
 
 registerAllBlocks();
 
@@ -22,7 +23,7 @@ describe('blockReplacement helpers', () => {
       b.wire(target, 'out', sink, 'input');
     });
 
-    const compatible = findCompatibleReplacementPlans(patch, target);
+    const compatible = findCompatibleReplacementPlans(v1BlockCatalog, patch, target);
     const types = compatible.map((item) => item.blockType);
 
     expect(types).toContain('Subtract');
@@ -37,6 +38,6 @@ describe('blockReplacement helpers', () => {
       b.wire(source, 'out', target, 'a');
     });
 
-    expect(isCompatibleBlockReplacement(patch, target, 'Const')).toBe(false);
+    expect(isCompatibleBlockReplacement(v1BlockCatalog, patch, target, 'Const')).toBe(false);
   });
 });

--- a/src/ui/reactFlowEditor/menus/BlockContextMenu.tsx
+++ b/src/ui/reactFlowEditor/menus/BlockContextMenu.tsx
@@ -22,12 +22,9 @@ import { useStores } from '../../../stores';
 import { ContextMenu, type ContextMenuItem } from '../ContextMenu';
 import { findCompatibleReplacementPlans } from './blockReplacement';
 import { useBlockCatalog } from '../../graphEditor/BlockCatalogContext';
-import type { CatalogOpenBehavior } from '../../graphEditor/block-catalog';
+import { NO_OPEN_BEHAVIOR } from '../../graphEditor/block-catalog';
 import { DockviewContext } from '../../dockview';
 import { getBlockOpenBehaviorLabel, hasBlockOpenBehavior, runBlockOpenBehavior } from '../../block-ui';
-
-/** Neutral default for a type absent from the catalog: it opens nothing. */
-const NO_OPEN_BEHAVIOR: CatalogOpenBehavior = { kind: 'none' };
 
 export interface BlockContextMenuProps {
   blockId: BlockId;

--- a/src/ui/reactFlowEditor/menus/BlockContextMenu.tsx
+++ b/src/ui/reactFlowEditor/menus/BlockContextMenu.tsx
@@ -21,9 +21,13 @@ import type { BlockId } from '../../../types';
 import { useStores } from '../../../stores';
 import { ContextMenu, type ContextMenuItem } from '../ContextMenu';
 import { findCompatibleReplacementPlans } from './blockReplacement';
-import { getAnyBlockDefinition, DEFAULT_BLOCK_UI } from '../../../blocks/registry';
+import { useBlockCatalog } from '../../graphEditor/BlockCatalogContext';
+import type { CatalogOpenBehavior } from '../../graphEditor/block-catalog';
 import { DockviewContext } from '../../dockview';
 import { getBlockOpenBehaviorLabel, hasBlockOpenBehavior, runBlockOpenBehavior } from '../../block-ui';
+
+/** Neutral default for a type absent from the catalog: it opens nothing. */
+const NO_OPEN_BEHAVIOR: CatalogOpenBehavior = { kind: 'none' };
 
 export interface BlockContextMenuProps {
   blockId: BlockId;
@@ -40,25 +44,26 @@ export const BlockContextMenu: React.FC<BlockContextMenuProps> = ({
 }) => {
   const { patch, layout, selection, diagnostics, expressionEditor } = useStores();
   const dockview = React.useContext(DockviewContext);
+  const catalog = useBlockCatalog();
 
   const items = useMemo<ContextMenuItem[]>(() => {
     const block = patch.blocks.get(blockId);
     if (!block) return [];
-    const blockUi = getAnyBlockDefinition(block.type)?.ui ?? DEFAULT_BLOCK_UI;
+    const openBehavior = catalog.getEntry(block.type)?.openBehavior ?? NO_OPEN_BEHAVIOR;
 
     // Count connected edges
     const connectedEdges = patch.edges.filter(
       (edge) => edge.from.blockId === blockId || edge.to.blockId === blockId
     );
     const hasConnections = connectedEdges.length > 0;
-    const replacementPlans = findCompatibleReplacementPlans(patch.patch, blockId);
+    const replacementPlans = findCompatibleReplacementPlans(catalog, patch.patch, blockId);
 
-    const openItems: ContextMenuItem[] = hasBlockOpenBehavior(blockUi.openBehavior)
+    const openItems: ContextMenuItem[] = hasBlockOpenBehavior(openBehavior)
       ? [{
-          label: getBlockOpenBehaviorLabel(blockUi.openBehavior),
+          label: getBlockOpenBehaviorLabel(openBehavior),
           icon: <OpenIcon fontSize="small" />,
           action: () => {
-            runBlockOpenBehavior(blockUi.openBehavior, {
+            runBlockOpenBehavior(openBehavior, {
               blockId,
               api: dockview?.api ?? null,
               diagnostics,
@@ -173,7 +178,7 @@ export const BlockContextMenu: React.FC<BlockContextMenuProps> = ({
         danger: true,
       },
     ];
-  }, [blockId, diagnostics, dockview?.api, expressionEditor, layout, onCenter, patch, selection]);
+  }, [blockId, catalog, diagnostics, dockview?.api, expressionEditor, layout, onCenter, patch, selection]);
 
   return <ContextMenu items={items} anchorPosition={anchorPosition} onClose={onClose} />;
 };

--- a/src/ui/reactFlowEditor/menus/blockReplacement.ts
+++ b/src/ui/reactFlowEditor/menus/blockReplacement.ts
@@ -2,6 +2,7 @@ import type { BlockId, Patch } from '../../../types';
 import type { Endpoint } from '../../../graph/Patch';
 import {
   type BlockCatalog,
+  type CatalogEntry,
   insertableEntries,
   requireCatalogEntry,
 } from '../../graphEditor/block-catalog';
@@ -54,19 +55,19 @@ function canConnect(
 }
 
 function buildReplacementPlanForType(
-  catalog: BlockCatalog,
+  candidate: CatalogEntry,
   patch: Patch,
   blockId: BlockId,
-  nextType: string,
 ): CompatibleReplacementPlan | null {
+  const nextType = candidate.type;
   const block = patch.blocks.get(blockId);
   if (!block) return null;
   if (block.type === nextType) return null;
-  const candidate = requireCatalogEntry(catalog, nextType);
-  // The `insertable` check is load-bearing for the public `isCompatibleBlockReplacement`
-  // entry point, where `nextType` is an arbitrary caller-supplied string. It is
-  // redundant (always true) on the `findCompatibleReplacementPlans` path, which
-  // already iterates `insertableEntries` — but this helper serves both callers.
+  // The `insertable` check is the single enforcer of insertability for the public
+  // `isCompatibleBlockReplacement` entry point, where the entry is resolved from an
+  // arbitrary caller-supplied type. The `findCompatibleReplacementPlans` path
+  // pre-filters `insertableEntries` purely as an optimization (don't attempt futile
+  // candidates), not as a second enforcer. [LAW:single-enforcer]
   if (block.role?.kind === 'timeRoot' || !candidate.insertable) return null;
   const replacementPatch = withReplacementType(patch, blockId, nextType);
   const connectedEdges = patch.edges.filter(
@@ -148,7 +149,7 @@ export function isCompatibleBlockReplacement(
   blockId: BlockId,
   nextType: string,
 ): boolean {
-  return buildReplacementPlanForType(catalog, patch, blockId, nextType) !== null;
+  return buildReplacementPlanForType(requireCatalogEntry(catalog, nextType), patch, blockId) !== null;
 }
 
 export function findCompatibleReplacementPlans(
@@ -162,9 +163,10 @@ export function findCompatibleReplacementPlans(
   }
 
   // [LAW:one-source-of-truth] Replacement candidates are the catalog's insertable
-  // entries — the same view the block library browses. Read `entries` once.
+  // entries — the same view the block library browses. Read `entries` once and
+  // pass each entry straight through; the plan builder needs no second lookup.
   return insertableEntries(catalog.entries)
-    .map((entry) => buildReplacementPlanForType(catalog, patch, blockId, entry.type))
+    .map((entry) => buildReplacementPlanForType(entry, patch, blockId))
     .filter((plan): plan is CompatibleReplacementPlan => plan !== null)
     .sort((a, b) => a.blockLabel.localeCompare(b.blockLabel));
 }

--- a/src/ui/reactFlowEditor/menus/blockReplacement.ts
+++ b/src/ui/reactFlowEditor/menus/blockReplacement.ts
@@ -1,6 +1,10 @@
 import type { BlockId, Patch } from '../../../types';
 import type { Endpoint } from '../../../graph/Patch';
-import { getBlockCategories, getBlockTypesByCategory, requireAnyBlockDef } from '../../../blocks/registry';
+import {
+  type BlockCatalog,
+  insertableEntries,
+  requireCatalogEntry,
+} from '../../graphEditor/block-catalog';
 import { validateSemanticConnection } from '../../authoring/semanticQueries';
 
 export interface ReplacementEdgePlan {
@@ -50,6 +54,7 @@ function canConnect(
 }
 
 function buildReplacementPlanForType(
+  catalog: BlockCatalog,
   patch: Patch,
   blockId: BlockId,
   nextType: string,
@@ -57,18 +62,14 @@ function buildReplacementPlanForType(
   const block = patch.blocks.get(blockId);
   if (!block) return null;
   if (block.type === nextType) return null;
-  const candidateDef = requireAnyBlockDef(nextType);
-  if (block.role?.kind === 'timeRoot' || candidateDef.capability === 'time') return null;
+  const candidate = requireCatalogEntry(catalog, nextType);
+  if (block.role?.kind === 'timeRoot' || !candidate.insertable) return null;
   const replacementPatch = withReplacementType(patch, blockId, nextType);
   const connectedEdges = patch.edges.filter(
     (edge) => edge.from.blockId === blockId || edge.to.blockId === blockId
   );
-  const candidateInputPortIds = Object.entries(candidateDef.inputs)
-    .filter(([, inputDef]) => inputDef.exposedAsPort !== false)
-    .map(([portId]) => portId);
-  const candidateOutputPortIds = Object.entries(candidateDef.outputs)
-    .filter(([, outputDef]) => !outputDef.hidden)
-    .map(([portId]) => portId);
+  const candidateInputPortIds = candidate.inputs.map((port) => port.id);
+  const candidateOutputPortIds = candidate.outputs.map((port) => port.id);
 
   const rewiredEdges: ReplacementEdgePlan[] = [];
 
@@ -131,30 +132,35 @@ function buildReplacementPlanForType(
   }
 
   return {
-    blockType: candidateDef.type,
-    blockLabel: candidateDef.label || candidateDef.type,
+    blockType: candidate.type,
+    blockLabel: candidate.label || candidate.type,
     rewiredEdges,
   };
 }
 
-export function isCompatibleBlockReplacement(patch: Patch, blockId: BlockId, nextType: string): boolean {
-  return buildReplacementPlanForType(patch, blockId, nextType) !== null;
+export function isCompatibleBlockReplacement(
+  catalog: BlockCatalog,
+  patch: Patch,
+  blockId: BlockId,
+  nextType: string,
+): boolean {
+  return buildReplacementPlanForType(catalog, patch, blockId, nextType) !== null;
 }
 
-export function findCompatibleReplacementPlans(patch: Patch, blockId: BlockId): CompatibleReplacementPlan[] {
+export function findCompatibleReplacementPlans(
+  catalog: BlockCatalog,
+  patch: Patch,
+  blockId: BlockId,
+): CompatibleReplacementPlan[] {
   const block = patch.blocks.get(blockId);
   if (!block || block.role?.kind === 'timeRoot') {
     return [];
   }
 
-  const categories = getBlockCategories();
-  const allDefs = categories.flatMap((category) => getBlockTypesByCategory(category));
-
-  // [LAW:one-source-of-truth] Replacement candidates are derived from the
-  // canonical registry view used by the editor library.
-  return allDefs
-    .filter((def) => def.capability !== 'time')
-    .map((def) => buildReplacementPlanForType(patch, blockId, def.type))
+  // [LAW:one-source-of-truth] Replacement candidates are the catalog's insertable
+  // entries — the same view the block library browses.
+  return insertableEntries(catalog)
+    .map((entry) => buildReplacementPlanForType(catalog, patch, blockId, entry.type))
     .filter((plan): plan is CompatibleReplacementPlan => plan !== null)
     .sort((a, b) => a.blockLabel.localeCompare(b.blockLabel));
 }

--- a/src/ui/reactFlowEditor/menus/blockReplacement.ts
+++ b/src/ui/reactFlowEditor/menus/blockReplacement.ts
@@ -63,6 +63,10 @@ function buildReplacementPlanForType(
   if (!block) return null;
   if (block.type === nextType) return null;
   const candidate = requireCatalogEntry(catalog, nextType);
+  // The `insertable` check is load-bearing for the public `isCompatibleBlockReplacement`
+  // entry point, where `nextType` is an arbitrary caller-supplied string. It is
+  // redundant (always true) on the `findCompatibleReplacementPlans` path, which
+  // already iterates `insertableEntries` — but this helper serves both callers.
   if (block.role?.kind === 'timeRoot' || !candidate.insertable) return null;
   const replacementPatch = withReplacementType(patch, blockId, nextType);
   const connectedEdges = patch.edges.filter(
@@ -158,8 +162,8 @@ export function findCompatibleReplacementPlans(
   }
 
   // [LAW:one-source-of-truth] Replacement candidates are the catalog's insertable
-  // entries — the same view the block library browses.
-  return insertableEntries(catalog)
+  // entries — the same view the block library browses. Read `entries` once.
+  return insertableEntries(catalog.entries)
     .map((entry) => buildReplacementPlanForType(catalog, patch, blockId, entry.type))
     .filter((plan): plan is CompatibleReplacementPlan => plan !== null)
     .sort((a, b) => a.blockLabel.localeCompare(b.blockLabel));


### PR DESCRIPTION
## What

Cuts the editor-owned **BlockCatalog** interface (browse / define / suggest) at the catalog-query joint, so the editor's palette/insert/replace surfaces never read a backend block registry directly. Both eras become **coequal providers of one neutral query surface**:

- `V1BlockCatalog` — the **only** `src/ui` file that reads the V1 registry's catalog functions; the registry-read code is *moved* here, not rewritten.
- `SceneBlockCatalog` — projects the pillar scene registry.

The four consumers the ticket names — **BlockLibrary, ConnectionPicker, blockReplacement, BlockContextMenu** — now browse through the neutral catalog, injected per-boot via `BlockCatalogContext` (`v1BlockCatalog` vs `sceneBlockCatalog`). `openBehavior` became a neutral `CatalogOpenBehavior`, so `BlockContextMenu` and `UnifiedNode` read it from the catalog instead of the registry. Shared scene→neutral projection extracted to `scene-projection` (sibling of `neutral-projection`).

## Enforcement (mirrors the .15 adapter-conformance pattern)

- **`block-catalog-conformance`** — the contract run over both providers + a broken-catalog negative control proving the assertions have teeth.
- **`block-catalog-registry-gate`** — the four consumers import nothing from `blocks/registry` and each browses through the seam. (Scope note: the epic-wide "no registry imports in `src/ui`" gate lands when the sibling seams — type oracle .17, lenses .18, inspector .19, controls .23 — close; fusing them here would be a decomposition error.)

## Flake fix

Also fixed an ambient-timing flake in BlockLibrary's search test: the 150ms debounce is now driven explicitly with fake timers instead of racing `waitFor` under machine load. `[LAW:no-ambient-temporal-coupling]`

## Verification

- `typecheck` + `lint` clean.
- Tests green: catalog conformance, registry gate, adapter conformance, blockReplacement, BlockLibrary, PillarPatchAdapter (58 pass, 3 expected skips).
- Screenshots of **both boots**, 0 console errors:
  - **V1**: BlockLibrary shows **119 items across 14 categories** (catalog-fed); search `sin` → **18 items**.
  - **Native** (Graph + Mature tabs): scene renders, `UnifiedNode` + `sceneBlockCatalog` render the graph with ports, "No problems — patch renders".

Ticket: `oscilla-editor-ux-8lsn.16`

https://claude.ai/code/session_01EGosPatPPdVDtmaYt9RXMR