### PR TITLE
TypeOracle seam — wiring compatibility + type display, both eras (nt8lsn.17)

### DIFF
--- a/src/ui/components/CompositeEditor.tsx
+++ b/src/ui/components/CompositeEditor.tsx
@@ -24,6 +24,7 @@ import { getCompositeDefinition } from '../../blocks/registry';
 import { GraphEditorCore, type GraphEditorCoreHandle } from '../graphEditor/GraphEditorCore';
 import type { PortContextMenuRequest } from '../graphEditor/GraphEditorContext';
 import { CompositeStoreAdapter } from '../graphEditor/CompositeStoreAdapter';
+import { permissiveTypeOracle } from '../graphEditor/type-oracle';
 import { ContextMenu, type ContextMenuItem } from '../reactFlowEditor/ContextMenu';
 import { CompositeEditorDslSidebar } from './CompositeEditorDslSidebar';
 import { useEditor, type EditorHandle } from '../editorCommon';
@@ -525,8 +526,10 @@ export const CompositeEditor = observer(function CompositeEditor() {
             portHighlight={null}
             diagnostics={null}
             debug={null}
-            frontend={null}
-            patch={null}
+            // The composite editor edits a subgraph definition with no
+            // instance-level type resolution, so it imposes no wiring constraints
+            // — stated as an explicit permissive oracle, not a hidden null-patch.
+            oracle={permissiveTypeOracle}
             onNodeContextMenu={handleNodeContextMenu}
             onEdgeContextMenu={handleEdgeContextMenu}
             onPortContextMenu={handlePortContextMenu}

--- a/src/ui/graphEditor/GraphEditorCore.tsx
+++ b/src/ui/graphEditor/GraphEditorCore.tsx
@@ -46,14 +46,13 @@ import { UnifiedNode as UnifiedNodeComponent } from './UnifiedNode';
 import { OscillaEdge } from '../reactFlowEditor/OscillaEdge';
 import type { OscillaEdgeData } from '../reactFlowEditor/nodes';
 import { getLayoutedElements } from '../reactFlowEditor/layout';
-import { validateSemanticConnection } from '../authoring/semanticQueries';
+import type { TypeOracle } from './type-oracle';
+import { verdictPermits } from './type-oracle';
 // import { ErrorBadgeOverlay } from './ErrorBadgeOverlay'; // DISABLED: Errors now shown in port popovers
 import type { SelectionStore } from '../../stores/SelectionStore';
 import type { PortHighlightStore } from '../../stores/PortHighlightStore';
 import type { DiagnosticsStore } from '../../stores/DiagnosticsStore';
 import type { DebugStore } from '../../stores/DebugStore';
-import type { FrontendResultStore } from '../../stores/FrontendResultStore';
-import type { Patch } from '../../graph/Patch';
 import { blockId } from '../../types';
 import './GraphEditorCore.css';
 
@@ -98,10 +97,13 @@ export interface GraphEditorCoreProps {
   portHighlight?: PortHighlightStore | null;
   diagnostics?: DiagnosticsStore | null;
   debug?: DebugStore | null;
-  frontend?: FrontendResultStore | null;
 
-  /** Optional patch (for connection validation - needed by validateConnection) */
-  patch?: Patch | null;
+  /**
+   * The era's type authority for wiring legality. Every mount supplies one — a V1
+   * oracle, a scene oracle, or the explicit permissive oracle — so the drag gate
+   * always asks the oracle and never falls back to "permit everything" implicitly.
+   */
+  oracle: TypeOracle;
 
   /** Custom node types map (default: { unified: UnifiedNode }) */
   nodeTypes?: NodeTypes;
@@ -183,8 +185,7 @@ export const GraphEditorCoreInner = observer(
         portHighlight = null,
         diagnostics = null,
         debug = null,
-        frontend = null,
-        patch = null,
+        oracle,
         nodeTypes: customNodeTypes,
         onEditorReady,
         onNodeContextMenu,
@@ -377,25 +378,23 @@ export const GraphEditorCoreInner = observer(
       );
 
       /**
-       * Validate connection before allowing it.
-       * Uses patch + registry for type checking.
+       * Validate a connection before allowing it. The oracle is the single
+       * authority; both eras supply one, so a wire is judged by exactly what that
+       * era's compiler accepts — no "no patch → permit everything" escape hatch.
+       * [LAW:one-source-of-truth] [LAW:dataflow-not-control-flow]
        */
       const isValidConnection = useCallback(
         (connection: Connection) => {
           if (!connection.source || !connection.target) return false;
-          if (!patch) return true; // No patch - skip validation
-
-          const result = validateSemanticConnection(
-            patch,
-            connection.source,
-            connection.sourceHandle || '',
-            connection.target,
-            connection.targetHandle || '',
-            { frontend: frontend ?? undefined },
+          if (!connection.sourceHandle || !connection.targetHandle) return false;
+          return verdictPermits(
+            oracle.canConnect(
+              { blockId: connection.source, portId: connection.sourceHandle },
+              { blockId: connection.target, portId: connection.targetHandle },
+            ),
           );
-          return result.valid;
         },
-        [frontend, patch]
+        [oracle]
       );
 
       // -------------------------------------------------------------------------

--- a/src/ui/graphEditor/SceneTypeOracle.ts
+++ b/src/ui/graphEditor/SceneTypeOracle.ts
@@ -52,8 +52,11 @@ export class SceneTypeOracle implements TypeOracle {
       case 'unsupported':
         return { kind: 'rejected', reason: `${verdict.value} has no ScenePlan realization` };
       default: {
+        // A new PortCompatibility kind is a compile error here (the `never`
+        // assignment) and, if ever reached at runtime, fails loudly rather than
+        // returning undefined or masquerading as a rejection. [LAW:no-silent-failure]
         const _exhaustive: never = verdict;
-        return _exhaustive;
+        throw new Error(`Unhandled scene port compatibility: ${JSON.stringify(_exhaustive)}`);
       }
     }
   }

--- a/src/ui/graphEditor/SceneTypeOracle.ts
+++ b/src/ui/graphEditor/SceneTypeOracle.ts
@@ -1,0 +1,65 @@
+/**
+ * SceneTypeOracle — the pillar provider of the TypeOracle seam.
+ *
+ * Wraps the pillar's own compatibility algebra (`compareScenePorts` over
+ * `SceneValueKind`) and its display projection (`sceneTypeDisplay`), resolving a
+ * port reference to its declared value kind through the scene registry. This is
+ * the provider that CLOSES the pillar wiring gap: before it, the mature ReactFlow
+ * editor mounted the pillar patch with no `patch`, so the drag gate permitted any
+ * wire. Now the same gate asks this oracle, and a pillar wire is judged by exactly
+ * the algebra `validateScenePatch` reports against. [LAW:one-source-of-truth]
+ */
+
+import type { PillarPatchStore } from '../../stores/PillarPatchStore';
+import { compareScenePorts } from '../../pillars/scene/port-compatibility';
+import type { SceneValueKind } from '../../pillars/scene/scene-block';
+import { sceneTypeDisplay } from './scene-projection';
+import type { PortTypeDisplay } from './types';
+import type {
+  ConnectionVerdict,
+  PortDirection,
+  PortRef,
+  TypeOracle,
+} from './type-oracle';
+
+export class SceneTypeOracle implements TypeOracle {
+  constructor(private readonly store: PillarPatchStore) {}
+
+  /** Resolve a port reference to its declared scene value kind, if it exists. */
+  private kindOf(ref: PortRef, direction: PortDirection): SceneValueKind | undefined {
+    const block = this.store.patch.blocks.find((b) => b.id === ref.blockId);
+    if (!block) return undefined;
+    const port = this.store.registry
+      .get(block.type)
+      ?.catalog.ports.find((p) => p.id === ref.portId && p.direction === direction);
+    return port?.value;
+  }
+
+  canConnect(source: PortRef, target: PortRef): ConnectionVerdict {
+    const from = this.kindOf(source, 'output');
+    const to = this.kindOf(target, 'input');
+    if (!from || !to) {
+      return { kind: 'rejected', reason: 'Unknown port' };
+    }
+    const verdict = compareScenePorts(from, to);
+    switch (verdict.kind) {
+      case 'compatible':
+        return { kind: 'allowed' };
+      case 'adaptationNeeded':
+        return { kind: 'allowedViaAdapter', adapterLabel: verdict.via };
+      case 'mismatch':
+        return { kind: 'rejected', reason: `Cannot wire ${verdict.from} → ${verdict.to}` };
+      case 'unsupported':
+        return { kind: 'rejected', reason: `${verdict.value} has no ScenePlan realization` };
+      default: {
+        const _exhaustive: never = verdict;
+        return _exhaustive;
+      }
+    }
+  }
+
+  describePort(ref: PortRef, direction: PortDirection): PortTypeDisplay | undefined {
+    const kind = this.kindOf(ref, direction);
+    return kind ? sceneTypeDisplay(kind) : undefined;
+  }
+}

--- a/src/ui/graphEditor/V1TypeOracle.ts
+++ b/src/ui/graphEditor/V1TypeOracle.ts
@@ -1,0 +1,53 @@
+/**
+ * V1TypeOracle — the V1 provider of the TypeOracle seam.
+ *
+ * Wraps the SAME authority the V1 editor already uses to gate connections
+ * (`validateSemanticConnection` → the compiler-frontend `maySatisfyConnectionTypes`
+ * over frontend-resolved types) and the SAME projection the adapters use for
+ * display (`typeDisplayFor`). It adds no type opinion of its own — it only
+ * translates that authority into the neutral verdict/display vocabulary, so the
+ * drag gate is exactly what the V1 compiler would accept. [LAW:one-source-of-truth]
+ */
+
+import type { Patch } from '../../graph/Patch';
+import type { BlockId, PortId } from '../../types';
+import type { FrontendResultStore } from '../../stores/FrontendResultStore';
+import { validateSemanticConnection } from '../authoring/semanticQueries';
+import { typeDisplayFor } from './neutral-projection';
+import type { PortTypeDisplay } from './types';
+import type {
+  ConnectionVerdict,
+  PortDirection,
+  PortRef,
+  TypeOracle,
+} from './type-oracle';
+
+export class V1TypeOracle implements TypeOracle {
+  constructor(
+    private readonly patch: Patch,
+    private readonly frontend: FrontendResultStore | null,
+  ) {}
+
+  canConnect(source: PortRef, target: PortRef): ConnectionVerdict {
+    const result = validateSemanticConnection(
+      this.patch,
+      source.blockId,
+      source.portId,
+      target.blockId,
+      target.portId,
+      { frontend: this.frontend ?? undefined },
+    );
+    return result.valid
+      ? { kind: 'allowed' }
+      : { kind: 'rejected', reason: result.reason ?? 'Incompatible connection' };
+  }
+
+  describePort(ref: PortRef, direction: PortDirection): PortTypeDisplay | undefined {
+    const type = this.frontend?.getResolvedPortTypeByIds(
+      ref.blockId as BlockId,
+      ref.portId as PortId,
+      direction === 'input' ? 'in' : 'out',
+    );
+    return type ? typeDisplayFor(type) : undefined;
+  }
+}

--- a/src/ui/graphEditor/__tests__/type-oracle-conformance.contract.ts
+++ b/src/ui/graphEditor/__tests__/type-oracle-conformance.contract.ts
@@ -1,0 +1,112 @@
+/**
+ * type-oracle-conformance.contract — the TypeOracle contract, stated once, as
+ * executable assertions.
+ *
+ * This file IS the specification of what makes an oracle "editor-usable". Every
+ * provider (V1TypeOracle, SceneTypeOracle, the permissive oracle, and any future
+ * backend) is checked against this one contract; a behavior this file does not
+ * assert is not part of the contract, and a provider that passes every assertion
+ * here is presumed drop-in for the editor's wiring gate and type display.
+ * [LAW:single-enforcer] [LAW:verifiable-goals]
+ *
+ * DECOMPOSITION: a `TypeOracleConformanceCase` is the seam of the test. It carries
+ * the whole truth a provider must supply to be checkable — the oracle, plus a wire
+ * its era is known to permit, a wire its era is known to reject, and a port it is
+ * known to type. The `assert*` functions below know only the neutral vocabulary
+ * (`TypeOracle` / `ConnectionVerdict` / `PortTypeDisplay`); they never import a
+ * store, a registry, or an era-specific type. That is what lets one contract check
+ * heterogeneous providers. [LAW:decomposition] [LAW:one-way-deps]
+ *
+ * The `assert*` functions are also the negative control's instrument: aimed at a
+ * deliberately-broken oracle they must throw, proving the suite has teeth rather
+ * than vacuously passing.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  verdictPermits,
+  type ConnectionVerdict,
+  type PortDirection,
+  type PortRef,
+  type TypeOracle,
+} from '../type-oracle';
+
+const VALID_VERDICT_KINDS: readonly ConnectionVerdict['kind'][] = [
+  'allowed',
+  'allowedViaAdapter',
+  'rejected',
+];
+
+/** Everything a provider must supply to be run through the conformance contract. */
+export interface TypeOracleConformanceCase {
+  readonly name: string;
+  /** The oracle under test, over a graph the provider has seeded. */
+  readonly oracle: TypeOracle;
+  /** A wire (output → input) this era is known to permit. */
+  readonly permitted: { readonly source: PortRef; readonly target: PortRef };
+  /** A wire (output → input) this era is known to reject. */
+  readonly rejected: { readonly source: PortRef; readonly target: PortRef };
+  /** A port this era is known to carry a type for. */
+  readonly knownPort: { readonly ref: PortRef; readonly direction: PortDirection };
+}
+
+/** A verdict is always one of the three discriminated shapes, each fully formed. */
+function assertVerdictWellFormed(v: ConnectionVerdict, label: string): void {
+  expect(VALID_VERDICT_KINDS, `${label}: verdict has a valid kind`).toContain(v.kind);
+  if (v.kind === 'allowedViaAdapter') {
+    expect(v.adapterLabel.length, `${label}: adapter verdict names its adapter`).toBeGreaterThan(0);
+  }
+  if (v.kind === 'rejected') {
+    expect(v.reason.length, `${label}: rejected verdict carries a reason`).toBeGreaterThan(0);
+  }
+}
+
+/** The known-good wire is permitted, and the verdict is well formed. */
+export function assertPermitsKnownGoodWire(c: TypeOracleConformanceCase): void {
+  const v = c.oracle.canConnect(c.permitted.source, c.permitted.target);
+  assertVerdictWellFormed(v, `${c.name}: permitted wire`);
+  expect(verdictPermits(v), `${c.name}: known-good wire is permitted`).toBe(true);
+}
+
+/** The known-bad wire is rejected with a reason, and the verdict is well formed. */
+export function assertRejectsKnownBadWire(c: TypeOracleConformanceCase): void {
+  const v = c.oracle.canConnect(c.rejected.source, c.rejected.target);
+  assertVerdictWellFormed(v, `${c.name}: rejected wire`);
+  expect(verdictPermits(v), `${c.name}: known-bad wire is not permitted`).toBe(false);
+}
+
+/** A known port describes to a fully-formed, presentation-ready type. */
+export function assertDescribesKnownPort(c: TypeOracleConformanceCase): void {
+  const display = c.oracle.describePort(c.knownPort.ref, c.knownPort.direction);
+  expect(display, `${c.name}: known port has a type display`).toBeDefined();
+  if (!display) return;
+  expect(display.label.length, `${c.name}: type display label`).toBeGreaterThan(0);
+  expect(display.tooltip.length, `${c.name}: type display tooltip`).toBeGreaterThan(0);
+  expect(display.color.length, `${c.name}: type display color`).toBeGreaterThan(0);
+  expect(
+    display.compatibilityToken.length,
+    `${c.name}: type display compatibility token`,
+  ).toBeGreaterThan(0);
+}
+
+/** An unknown port has no type — the oracle reports absence, never invents one. */
+export function assertUndefinedForUnknownPort(c: TypeOracleConformanceCase): void {
+  const display = c.oracle.describePort(
+    { blockId: '__no_such_block__', portId: '__no_such_port__' },
+    'input',
+  );
+  expect(display, `${c.name}: unknown port has no type display`).toBeUndefined();
+}
+
+/**
+ * Register the whole contract against one provider. A future backend is drop-in
+ * verifiable: build a TypeOracleConformanceCase for it and call this.
+ */
+export function runTypeOracleConformanceSuite(c: TypeOracleConformanceCase): void {
+  describe(`TypeOracle conformance: ${c.name}`, () => {
+    it('permits a known-good wire', () => assertPermitsKnownGoodWire(c));
+    it('rejects a known-bad wire', () => assertRejectsKnownBadWire(c));
+    it('describes a known port', () => assertDescribesKnownPort(c));
+    it('reports no type for an unknown port', () => assertUndefinedForUnknownPort(c));
+  });
+}

--- a/src/ui/graphEditor/__tests__/type-oracle-conformance.test.ts
+++ b/src/ui/graphEditor/__tests__/type-oracle-conformance.test.ts
@@ -1,0 +1,147 @@
+/**
+ * type-oracle-conformance.test — the TypeOracle contract run against every
+ * provider, plus a negative control proving the contract rejects.
+ *
+ * The contract itself lives in ./type-oracle-conformance.contract. Here we supply
+ * one `TypeOracleConformanceCase` per provider (seeding it in that provider's own
+ * vocabulary, with a wire the era is known to permit and one it is known to reject)
+ * and run the shared suite over each. A future backend becomes drop-in verifiable
+ * by adding one case below. [LAW:verifiable-goals]
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { registerAllBlocks } from '../../../blocks/all';
+import { buildPatch } from '../../../graph';
+import { compileFrontend } from '../../../compiler/frontend';
+import { FrontendResultStore } from '../../../stores/FrontendResultStore';
+import { PillarPatchStore } from '../../../stores/PillarPatchStore';
+import type { BlockId } from '../../../types';
+
+import { V1TypeOracle } from '../V1TypeOracle';
+import { SceneTypeOracle } from '../SceneTypeOracle';
+import type { ConnectionVerdict, PortDirection, PortRef, TypeOracle } from '../type-oracle';
+
+import {
+  assertDescribesKnownPort,
+  assertPermitsKnownGoodWire,
+  assertRejectsKnownBadWire,
+  assertUndefinedForUnknownPort,
+  runTypeOracleConformanceSuite,
+  type TypeOracleConformanceCase,
+} from './type-oracle-conformance.contract';
+
+registerAllBlocks();
+
+// =============================================================================
+// V1 provider — a compiled patch with a known-good and known-bad real wire.
+// tMs (a resolved time signal) drives Ellipse.rx (float) — permitted; the same
+// tMs into Ellipse.resolution (a count) contradicts — rejected. (An UNWIRED
+// Const.out has no resolved type, so the cheap gate would reject it too — the
+// permitted pair must be one whose source type actually resolves.)
+// =============================================================================
+
+function v1Case(): TypeOracleConformanceCase {
+  const frontend = new FrontendResultStore();
+  let timeId!: BlockId;
+  let ellipseId!: BlockId;
+  const patch = buildPatch((b) => {
+    timeId = b.addBlock('InfiniteTimeRoot');
+    ellipseId = b.addBlock('Ellipse');
+  });
+  frontend.updateFromFrontendResult(compileFrontend(patch), 1);
+
+  return {
+    name: 'V1TypeOracle',
+    oracle: new V1TypeOracle(patch, frontend),
+    permitted: {
+      source: { blockId: timeId, portId: 'tMs' },
+      target: { blockId: ellipseId, portId: 'rx' },
+    },
+    rejected: {
+      source: { blockId: timeId, portId: 'tMs' },
+      target: { blockId: ellipseId, portId: 'resolution' },
+    },
+    knownPort: { ref: { blockId: ellipseId, portId: 'rx' }, direction: 'input' },
+  };
+}
+
+// =============================================================================
+// Pillar provider — the self-seeded grid-of-squares patch.
+// (grid.instances → color.primary is instanceBundle→instanceBundle; draw.draw is
+//  a materialShell, which mismatches color.primary's instanceBundle.)
+// =============================================================================
+
+function sceneCase(): TypeOracleConformanceCase {
+  const store = new PillarPatchStore();
+  return {
+    name: 'SceneTypeOracle',
+    oracle: new SceneTypeOracle(store),
+    permitted: {
+      source: { blockId: 'grid', portId: 'instances' },
+      target: { blockId: 'color', portId: 'primary' },
+    },
+    rejected: {
+      source: { blockId: 'draw', portId: 'draw' },
+      target: { blockId: 'color', portId: 'primary' },
+    },
+    knownPort: { ref: { blockId: 'grid', portId: 'instances' }, direction: 'output' },
+  };
+}
+
+runTypeOracleConformanceSuite(v1Case());
+runTypeOracleConformanceSuite(sceneCase());
+
+// =============================================================================
+// Negative control — deliberately-broken oracles the contract MUST reject.
+//
+// If the assertions passed these, they would be vacuous. Each `expect(...).toThrow`
+// pins a distinct invariant to the assertion that enforces it. [LAW:verifiable-goals]
+// =============================================================================
+
+const DUMMY_REFS = {
+  permitted: { source: { blockId: 'a', portId: 'o' }, target: { blockId: 'b', portId: 'i' } },
+  rejected: { source: { blockId: 'a', portId: 'o' }, target: { blockId: 'b', portId: 'i' } },
+  knownPort: { ref: { blockId: 'a', portId: 'o' }, direction: 'output' as PortDirection },
+} as const;
+
+/**
+ * Permits every wire and invents a malformed type for every port — so it permits
+ * the known-bad wire, types the unknown port, and its "type" is not presentable.
+ */
+const brokenPermissive: TypeOracle = {
+  canConnect: (): ConnectionVerdict => ({ kind: 'allowed' }),
+  describePort: (_ref: PortRef, _dir: PortDirection) => ({
+    label: '',
+    tooltip: '',
+    color: '',
+    compatibilityToken: '',
+  }),
+};
+
+/** Rejects every wire — so it rejects the known-good wire too. */
+const brokenRejecting: TypeOracle = {
+  canConnect: (): ConnectionVerdict => ({ kind: 'rejected', reason: 'always' }),
+  describePort: () => undefined,
+};
+
+const brokenPermissiveCase: TypeOracleConformanceCase = { name: 'BrokenPermissive', oracle: brokenPermissive, ...DUMMY_REFS };
+const brokenRejectingCase: TypeOracleConformanceCase = { name: 'BrokenRejecting', oracle: brokenRejecting, ...DUMMY_REFS };
+
+describe('type-oracle conformance contract rejects a non-conforming oracle (negative control)', () => {
+  it('rejects an oracle that permits a known-bad wire', () => {
+    expect(() => assertRejectsKnownBadWire(brokenPermissiveCase)).toThrow();
+  });
+
+  it('rejects an oracle that invents a type for an unknown port', () => {
+    expect(() => assertUndefinedForUnknownPort(brokenPermissiveCase)).toThrow();
+  });
+
+  it('rejects an oracle whose known-port type is not presentable', () => {
+    expect(() => assertDescribesKnownPort(brokenPermissiveCase)).toThrow();
+  });
+
+  it('rejects an oracle that refuses a known-good wire', () => {
+    expect(() => assertPermitsKnownGoodWire(brokenRejectingCase)).toThrow();
+  });
+});

--- a/src/ui/graphEditor/__tests__/type-oracle-conformance.test.ts
+++ b/src/ui/graphEditor/__tests__/type-oracle-conformance.test.ts
@@ -20,6 +20,7 @@ import type { BlockId } from '../../../types';
 
 import { V1TypeOracle } from '../V1TypeOracle';
 import { SceneTypeOracle } from '../SceneTypeOracle';
+import { permissiveTypeOracle, verdictPermits } from '../type-oracle';
 import type { ConnectionVerdict, PortDirection, PortRef, TypeOracle } from '../type-oracle';
 
 import {
@@ -143,5 +144,28 @@ describe('type-oracle conformance contract rejects a non-conforming oracle (nega
 
   it('rejects an oracle that refuses a known-good wire', () => {
     expect(() => assertPermitsKnownGoodWire(brokenRejectingCase)).toThrow();
+  });
+});
+
+// =============================================================================
+// permissiveTypeOracle — pinned directly, because it is the one provider the
+// conformance contract structurally cannot cover: it rejects no wire and types no
+// port, so it supplies no known-bad / known-port fixture. It is nonetheless
+// production code (the composite editor), so its two invariants are asserted here
+// to guard against a future guard leaking a display or a reject. [LAW:verifiable-goals]
+// =============================================================================
+
+describe('permissiveTypeOracle', () => {
+  it('permits every wire', () => {
+    const verdict = permissiveTypeOracle.canConnect(
+      { blockId: 'a', portId: 'out' },
+      { blockId: 'b', portId: 'in' },
+    );
+    expect(verdictPermits(verdict)).toBe(true);
+  });
+
+  it('reports no type for any port, in either direction', () => {
+    expect(permissiveTypeOracle.describePort({ blockId: 'a', portId: 'out' }, 'output')).toBeUndefined();
+    expect(permissiveTypeOracle.describePort({ blockId: 'b', portId: 'in' }, 'input')).toBeUndefined();
   });
 });

--- a/src/ui/graphEditor/__tests__/type-oracle-parity.test.ts
+++ b/src/ui/graphEditor/__tests__/type-oracle-parity.test.ts
@@ -1,0 +1,145 @@
+/**
+ * type-oracle-parity.test — the acceptance gate: the oracle's wire verdict equals
+ * what the era's compiler would accept, over a fixture MATRIX of real port pairs,
+ * in BOTH boots.
+ *
+ * This is the whole point of the seam: the editor's drag feedback is not a second
+ * opinion about types — it is the compiler's own acceptance, wrapped. So for every
+ * (output, input) pair we assert the oracle agrees with the era's authority:
+ *   - V1: `validateSemanticConnection` (→ the frontend `maySatisfyConnectionTypes`
+ *         over resolved types) — the exact gate the V1 editor validated with.
+ *   - pillar: `compareScenePorts` — the algebra `validateScenePatch` reports against.
+ * Each matrix is required to contain BOTH a permitted and a rejected pair, so the
+ * agreement is proven against a discriminating authority, never a vacuous one.
+ * [LAW:one-source-of-truth] [LAW:verifiable-goals]
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { registerAllBlocks } from '../../../blocks/all';
+import { buildPatch } from '../../../graph';
+import { compileFrontend } from '../../../compiler/frontend';
+import { FrontendResultStore } from '../../../stores/FrontendResultStore';
+import { requireAnyBlockDef } from '../../../blocks/registry';
+import { PillarPatchStore } from '../../../stores/PillarPatchStore';
+import { compareScenePorts } from '../../../pillars/scene/port-compatibility';
+import { validateSemanticConnection } from '../../authoring/semanticQueries';
+
+import { V1TypeOracle } from '../V1TypeOracle';
+import { SceneTypeOracle } from '../SceneTypeOracle';
+import { verdictPermits } from '../type-oracle';
+
+registerAllBlocks();
+
+/** Assert a matrix agreed everywhere and actually exercised both outcomes. */
+function expectDiscriminatingAgreement(
+  disagreements: readonly string[],
+  permitted: number,
+  rejected: number,
+): void {
+  expect(disagreements).toEqual([]);
+  expect(permitted, 'matrix has permitted pairs').toBeGreaterThan(0);
+  expect(rejected, 'matrix has rejected pairs').toBeGreaterThan(0);
+}
+
+describe('type-oracle parity: oracle verdict == era compile acceptance', () => {
+  it('V1 — the oracle agrees with validateSemanticConnection on every real pair', () => {
+    const frontend = new FrontendResultStore();
+    const patch = buildPatch((b) => {
+      b.addBlock('InfiniteTimeRoot');
+      b.addBlock('Ellipse');
+      b.addBlock('Const');
+      b.addBlock('Noise');
+    });
+    frontend.updateFromFrontendResult(compileFrontend(patch), 1);
+    const oracle = new V1TypeOracle(patch, frontend);
+
+    const blocks = Array.from(patch.blocks.entries());
+    const disagreements: string[] = [];
+    let permitted = 0;
+    let rejected = 0;
+
+    for (const [sourceId, sourceBlock] of blocks) {
+      const outputs = Object.entries(requireAnyBlockDef(sourceBlock.type).outputs).filter(
+        ([, o]) => !o.hidden,
+      );
+      for (const [targetId, targetBlock] of blocks) {
+        if (sourceId === targetId) continue;
+        const inputs = Object.entries(requireAnyBlockDef(targetBlock.type).inputs).filter(
+          ([, i]) => i.exposedAsPort !== false,
+        );
+        for (const [outPort] of outputs) {
+          for (const [inPort] of inputs) {
+            const authority = validateSemanticConnection(
+              patch,
+              sourceId,
+              outPort,
+              targetId,
+              inPort,
+              { frontend },
+            ).valid;
+            const oraclePermits = verdictPermits(
+              oracle.canConnect(
+                { blockId: sourceId, portId: outPort },
+                { blockId: targetId, portId: inPort },
+              ),
+            );
+            if (oraclePermits !== authority) {
+              disagreements.push(
+                `${sourceBlock.type}.${outPort} -> ${targetBlock.type}.${inPort}: oracle=${oraclePermits} authority=${authority}`,
+              );
+            }
+            if (authority) permitted++;
+            else rejected++;
+          }
+        }
+      }
+    }
+
+    expectDiscriminatingAgreement(disagreements, permitted, rejected);
+  });
+
+  it('pillar — the oracle agrees with compareScenePorts on every real pair', () => {
+    const store = new PillarPatchStore();
+    const oracle = new SceneTypeOracle(store);
+
+    const blocks = store.patch.blocks;
+    const disagreements: string[] = [];
+    let permitted = 0;
+    let rejected = 0;
+
+    for (const sourceBlock of blocks) {
+      const outputs = (store.registry.get(sourceBlock.type)?.catalog.ports ?? []).filter(
+        (p) => p.direction === 'output',
+      );
+      for (const targetBlock of blocks) {
+        if (sourceBlock.id === targetBlock.id) continue;
+        const inputs = (store.registry.get(targetBlock.type)?.catalog.ports ?? []).filter(
+          (p) => p.direction === 'input',
+        );
+        for (const outPort of outputs) {
+          for (const inPort of inputs) {
+            const authorityPermits = ['compatible', 'adaptationNeeded'].includes(
+              compareScenePorts(outPort.value, inPort.value).kind,
+            );
+            const oraclePermits = verdictPermits(
+              oracle.canConnect(
+                { blockId: sourceBlock.id, portId: outPort.id },
+                { blockId: targetBlock.id, portId: inPort.id },
+              ),
+            );
+            if (oraclePermits !== authorityPermits) {
+              disagreements.push(
+                `${sourceBlock.type}.${outPort.id} -> ${targetBlock.type}.${inPort.id}: oracle=${oraclePermits} authority=${authorityPermits}`,
+              );
+            }
+            if (authorityPermits) permitted++;
+            else rejected++;
+          }
+        }
+      }
+    }
+
+    expectDiscriminatingAgreement(disagreements, permitted, rejected);
+  });
+});

--- a/src/ui/graphEditor/__tests__/type-oracle-seam-gate.test.ts
+++ b/src/ui/graphEditor/__tests__/type-oracle-seam-gate.test.ts
@@ -1,0 +1,54 @@
+/**
+ * type-oracle-seam-gate — the seam's coupling gate.
+ *
+ * The point of the TypeOracle seam is that the editor's wiring gate never reasons
+ * about types in an era's own language — it asks the neutral oracle "can these
+ * connect?" and renders the verdict. This test enforces that mechanically for the
+ * consumer this ticket converted: GraphEditorCore reaches its wire verdict through
+ * the oracle seam and imports no era-specific type surface (the V1
+ * `semanticQueries` gate, `InferenceCanonicalType`, or the pillar scene port kinds)
+ * — proving it went THROUGH the seam rather than keeping a private type opinion.
+ *
+ * SCOPE: this is the type-oracle seam's gate, not the whole editor's. Other files
+ * in `src/ui` still read era-specific type surfaces for OTHER concerns owned by
+ * sibling seams — the connection picker / context menus (candidate enumeration),
+ * edge decorations (lenses), the inspectors, and the info popovers' richer detail.
+ * Reseating those onto this oracle is each of those tickets' job; fusing them here
+ * would be a decomposition error. The provider files (V1TypeOracle, SceneTypeOracle)
+ * are where the era-specific surfaces legitimately live — behind the seam.
+ * [LAW:decomposition] [LAW:single-enforcer] [LAW:verifiable-goals]
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// This file lives at src/ui/graphEditor/__tests__; the converted consumer is a sibling.
+const GRAPH_EDITOR = join(__dirname, '..');
+
+function read(rel: string): string {
+  return readFileSync(join(GRAPH_EDITOR, rel), 'utf8');
+}
+
+const CONVERTED_CONSUMER = 'GraphEditorCore.tsx';
+
+/** Era-specific type surfaces a UI consumer must not import — it goes through the oracle. */
+const FORBIDDEN_IMPORT_PATTERNS: readonly RegExp[] = [
+  /from\s+['"][^'"]*authoring\/semanticQueries['"]/,
+  /from\s+['"][^'"]*core\/inference-types['"]/,
+  /from\s+['"][^'"]*scene\/port-compatibility['"]/,
+  /from\s+['"][^'"]*scene\/scene-block['"]/,
+];
+
+describe('TypeOracle seam — coupling gate', () => {
+  it('the converted consumer imports no era-specific type surface', () => {
+    const src = read(CONVERTED_CONSUMER);
+    const offenders = FORBIDDEN_IMPORT_PATTERNS.filter((re) => re.test(src)).map((re) => re.source);
+    expect(offenders).toEqual([]);
+  });
+
+  it('the converted consumer reaches its wire verdict through the oracle seam', () => {
+    const src = read(CONVERTED_CONSUMER);
+    expect(/from\s+['"]\.\/type-oracle['"]/.test(src)).toBe(true);
+  });
+});

--- a/src/ui/graphEditor/type-oracle.ts
+++ b/src/ui/graphEditor/type-oracle.ts
@@ -50,9 +50,25 @@ export type ConnectionVerdict =
  * Whether a verdict permits the wire (a direct match or an adapter-bridged one).
  * The single place "does this verdict let the wire happen?" is decided, so the
  * drag gate and any future picker read it the same way. [LAW:one-source-of-truth]
+ *
+ * A positive, exhaustive dispatch — not a `!== 'rejected'` negative check — so a
+ * new ConnectionVerdict kind is a compile error here that forces an explicit
+ * permit decision, rather than being silently permitted. This is what protects
+ * callers that read only `verdictPermits` (the drag gate) and never switch on the
+ * verdict themselves. [LAW:types-are-the-program]
  */
 export function verdictPermits(verdict: ConnectionVerdict): boolean {
-  return verdict.kind !== 'rejected';
+  switch (verdict.kind) {
+    case 'allowed':
+    case 'allowedViaAdapter':
+      return true;
+    case 'rejected':
+      return false;
+    default: {
+      const _exhaustive: never = verdict;
+      throw new Error(`Unhandled ConnectionVerdict kind: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
 }
 
 // =============================================================================

--- a/src/ui/graphEditor/type-oracle.ts
+++ b/src/ui/graphEditor/type-oracle.ts
@@ -1,0 +1,98 @@
+/**
+ * TypeOracle — the editor's neutral authority on port types.
+ *
+ * The editor asks exactly two type questions about the ports in the graph it is
+ * showing: "can this output feed that input?" (wiring legality) and "what is this
+ * port's type?" (display). Both require reading the era's real type model, so both
+ * belong to ONE seam — otherwise every consumer would re-implement the
+ * blockId+portId → era-type resolution. Each era supplies a provider that answers
+ * in the editor's neutral vocabulary; the UI renders the verdicts and labels
+ * without holding a single type opinion, so the drag feedback can never disagree
+ * with what that era's compiler accepts. [FRAMING:representation] [LAW:one-source-of-truth]
+ *
+ * This is the sibling of GraphDataAdapter (what is IN the graph) and BlockCatalog
+ * (what could be ADDED): the oracle answers what the graph's ports MEAN. Unlike the
+ * catalog (a static registry projection) it reads the live graph, so — like the
+ * adapter — a provider wraps the era's store and is constructed per editor mount.
+ * [LAW:decomposition]
+ */
+
+import type { PortTypeDisplay } from './types';
+
+// =============================================================================
+// Neutral vocabulary
+// =============================================================================
+
+export type PortDirection = 'input' | 'output';
+
+/** A reference to one port on one block in the graph the editor is showing. */
+export interface PortRef {
+  readonly blockId: string;
+  readonly portId: string;
+}
+
+/**
+ * The verdict for wiring one OUTPUT port (`source`) to one INPUT port (`target`).
+ * A discriminated value, not a bare boolean, so a consumer stays exhaustive and a
+ * new outcome forces a decision rather than a silent fall-through.
+ * [LAW:types-are-the-program]
+ *
+ * `allowedViaAdapter` marks a wire that is legal only because an adapter bridges
+ * the two types — the drag gate permits it, and a consumer may name the adapter.
+ * `rejected` carries a human reason for the same feedback surfaces.
+ */
+export type ConnectionVerdict =
+  | { readonly kind: 'allowed' }
+  | { readonly kind: 'allowedViaAdapter'; readonly adapterLabel: string }
+  | { readonly kind: 'rejected'; readonly reason: string };
+
+/**
+ * Whether a verdict permits the wire (a direct match or an adapter-bridged one).
+ * The single place "does this verdict let the wire happen?" is decided, so the
+ * drag gate and any future picker read it the same way. [LAW:one-source-of-truth]
+ */
+export function verdictPermits(verdict: ConnectionVerdict): boolean {
+  return verdict.kind !== 'rejected';
+}
+
+// =============================================================================
+// TypeOracle interface
+// =============================================================================
+
+/**
+ * The editor-owned type authority for one graph. A provider resolves each port
+ * reference to its era's type internally; the UI passes only neutral ids and reads
+ * neutral answers. [LAW:one-way-deps]
+ */
+export interface TypeOracle {
+  /**
+   * Can the OUTPUT port `source` feed the INPUT port `target`? The atomic wiring
+   * verdict — the sole authority the editor consults for wire legality.
+   */
+  canConnect(source: PortRef, target: PortRef): ConnectionVerdict;
+
+  /**
+   * The port's neutral, presentation-ready type, or `undefined` when the era has
+   * no type for it (an unknown port, or an era with no type model). The
+   * format-for-display half of the type authority. `direction` disambiguates when
+   * an input and an output on the same block share a port id.
+   */
+  describePort(ref: PortRef, direction: PortDirection): PortTypeDisplay | undefined;
+}
+
+// =============================================================================
+// Permissive provider
+// =============================================================================
+
+/**
+ * The oracle for an editor surface that imposes NO wiring constraints and has no
+ * type model — today, the composite editor, which edits a subgraph definition
+ * before any instance-level type resolution exists. Making "no validation here" an
+ * explicit provider value keeps it out of the drag gate as a hidden `if (!types)`
+ * branch: the variability lives in which oracle a mount supplies, not in whether
+ * the gate runs. [LAW:dataflow-not-control-flow] [LAW:no-silent-failure]
+ */
+export const permissiveTypeOracle: TypeOracle = {
+  canConnect: () => ({ kind: 'allowed' }),
+  describePort: () => undefined,
+};

--- a/src/ui/nativeEditor/NativeMatureGraphCanvas.tsx
+++ b/src/ui/nativeEditor/NativeMatureGraphCanvas.tsx
@@ -20,6 +20,7 @@ import React, { useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStores } from '../../stores';
 import { PillarPatchAdapter } from '../graphEditor/PillarPatchAdapter';
+import { SceneTypeOracle } from '../graphEditor/SceneTypeOracle';
 import { GraphEditorCore } from '../graphEditor/GraphEditorCore';
 
 export const NativeMatureGraphCanvas: React.FC = observer(() => {
@@ -30,13 +31,14 @@ export const NativeMatureGraphCanvas: React.FC = observer(() => {
   // graph is readable on first paint and GraphEditorCore's own fitView frames
   // it — no post-mount auto-layout pass, hence no timing/ref race to manage.
   //
-  // Connection validation: no `patch` is passed, so GraphEditorCore permits any
-  // wire. Pillar wiring validity (type compatibility) is owned by the type-oracle
-  // seam (oscilla-editor-ux-8lsn.17); this spike intentionally leaves it open
-  // rather than duplicate that boundary here.
+  // Connection validation: the scene type oracle judges every wire by the pillar
+  // port-compatibility algebra (compareScenePorts) — the same one validateScenePatch
+  // reports against — so the drag gate agrees with the compiler. [LAW:one-source-of-truth]
+  const oracle = useMemo(() => new SceneTypeOracle(pillarPatch), [pillarPatch]);
+
   return (
     <div style={{ height: '100%', width: '100%' }}>
-      <GraphEditorCore adapter={adapter} />
+      <GraphEditorCore adapter={adapter} oracle={oracle} />
     </div>
   );
 });

--- a/src/ui/reactFlowEditor/ReactFlowEditor.tsx
+++ b/src/ui/reactFlowEditor/ReactFlowEditor.tsx
@@ -24,6 +24,7 @@ import type { EditorHandle } from '../editorCommon';
 import { GraphEditorCore, type GraphEditorCoreHandle } from '../graphEditor/GraphEditorCore';
 import type { PortContextMenuRequest } from '../graphEditor/GraphEditorContext';
 import { PatchStoreAdapter } from '../graphEditor/PatchStoreAdapter';
+import { V1TypeOracle } from '../graphEditor/V1TypeOracle';
 import { BlockContextMenu } from './menus/BlockContextMenu';
 import { EdgeContextMenu } from './menus/EdgeContextMenu';
 import { PortContextMenu } from './menus/PortContextMenu';
@@ -137,6 +138,13 @@ const ReactFlowEditorInner: React.FC<ReactFlowEditorProps> = observer(({
   const adapter = useMemo(
     () => new PatchStoreAdapter(patchStore, layoutStore, frontend),
     [patchStore, layoutStore, frontend]
+  );
+
+  // The V1 type authority for the wiring drag gate — wraps the same
+  // frontend-resolved compatibility the editor validated with before the seam.
+  const oracle = useMemo(
+    () => new V1TypeOracle(patchStore.patch, frontend),
+    [patchStore.patch, frontend]
   );
 
   // Port context menu handler - called from UnifiedNode via GraphEditorContext
@@ -346,8 +354,7 @@ const ReactFlowEditorInner: React.FC<ReactFlowEditorProps> = observer(({
           portHighlight={portHighlight}
           diagnostics={diagnostics}
           debug={debug}
-          frontend={frontend}
-          patch={patchStore.patch}
+          oracle={oracle}
           onNodeContextMenu={handleNodeContextMenu}
           onEdgeContextMenu={handleEdgeContextMenu}
           onPortContextMenu={handlePortContextMenu}


### PR DESCRIPTION
## Ticket
`oscilla-editor-ux-8lsn.17` — Type oracle seam (wiring compatibility + type display)

## What
Extracts the editor's port-type authority into one neutral seam, **`TypeOracle`**, the sibling of `GraphDataAdapter` (what is IN the graph) and `BlockCatalog` (what could be ADDED): the oracle answers **what the graph's ports MEAN**. Two operations — `canConnect(source, target): ConnectionVerdict` (atomic wiring legality) and `describePort(ref, direction): PortTypeDisplay | undefined` (format-for-display) — with a provider per era. The UI holds **zero type opinions**: it renders verdicts and labels the oracle produces, so drag feedback can never disagree with what the compiler accepts. [LAW:one-source-of-truth]

## Providers
- **`V1TypeOracle`** — wraps the *same live authority the V1 editor already gated with* (`validateSemanticConnection` → the frontend `maySatisfyConnectionTypes` over resolved types) + `typeDisplayFor`. No new type opinion.
- **`SceneTypeOracle`** — wraps the pillar algebra (`compareScenePorts` over `SceneValueKind`) + `sceneTypeDisplay`. **Closes the pillar wiring gap**: the mature ReactFlow editor previously mounted the pillar patch with no `patch`, so `isValidConnection` permitted *any* wire; now it asks this oracle.
- **`permissiveTypeOracle`** — the composite editor edits a subgraph definition with no instance-level type resolution, so it imposes no wiring constraints. Stated as an explicit provider value, not a hidden `if (!patch)`.

## Reseat
`GraphEditorCore.isValidConnection` → `oracle.canConnect`. Its validation-only `patch`/`frontend` props collapse into one **required `oracle` prop**, deleting the `if (!patch) return true` branch that *was* the pillar gap. [LAW:dataflow-not-control-flow] All three mounts supply their oracle.

## Acceptance (verified)
- **`type-oracle-parity`** — `oracle verdict == era authority` over a real port-pair **matrix** in **both boots**, each matrix required to contain permitted AND rejected pairs (discriminating, not vacuous).
- **`type-oracle-conformance`** — the contract stated once (contract + case per era + negative control proving teeth).
- **`type-oracle-seam-gate`** — the converted consumer imports no era-specific type surface and routes through the oracle. Scoped to this seam (sibling seams documented), mirroring the block-catalog gate.
- All existing graphEditor / reactFlowEditor / nativeEditor / components tests pass; architecture guardrails pass; typecheck + build clean; both boots mount error-free.

## Deferred to sibling seams (documented in the gate)
Popover type-lines (.5), context menus / connection picker (.4), edge decorations / lenses (.18) consume this oracle when their seams land — the epic-wide "no era-specific type imports in `src/ui`" gate closes with the last of them.

https://claude.ai/code/session_01EGosPatPPdVDtmaYt9RXMR