### PR TITLE
EdgeDecorator seam — V1 lenses + pillar transform chains, one edge-decoration concept, both eras (8lsn.18)

### DIFF
--- a/src/ui/components/CompositeEditor.tsx
+++ b/src/ui/components/CompositeEditor.tsx
@@ -25,6 +25,7 @@ import { GraphEditorCore, type GraphEditorCoreHandle } from '../graphEditor/Grap
 import type { PortContextMenuRequest } from '../graphEditor/GraphEditorContext';
 import { CompositeStoreAdapter } from '../graphEditor/CompositeStoreAdapter';
 import { permissiveTypeOracle } from '../graphEditor/type-oracle';
+import { noEdgeDecorator } from '../graphEditor/edge-decorations';
 import { ContextMenu, type ContextMenuItem } from '../reactFlowEditor/ContextMenu';
 import { CompositeEditorDslSidebar } from './CompositeEditorDslSidebar';
 import { useEditor, type EditorHandle } from '../editorCommon';
@@ -530,6 +531,7 @@ export const CompositeEditor = observer(function CompositeEditor() {
             // instance-level type resolution, so it imposes no wiring constraints
             // — stated as an explicit permissive oracle, not a hidden null-patch.
             oracle={permissiveTypeOracle}
+            decorator={noEdgeDecorator}
             onNodeContextMenu={handleNodeContextMenu}
             onEdgeContextMenu={handleEdgeContextMenu}
             onPortContextMenu={handlePortContextMenu}

--- a/src/ui/graphEditor/DecorationParamControls.tsx
+++ b/src/ui/graphEditor/DecorationParamControls.tsx
@@ -37,6 +37,13 @@ function fallbackNumericRange(paramId: string): NumericRange {
   return { min: -100, max: 100, step: 0.01 };
 }
 
+/** Readable rendering of a fallback value — objects/arrays as JSON, never `[object Object]`. */
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
 function numericRangeFromHint(paramId: string, hint?: UIControlHint): NumericRange {
   if (hint?.kind === 'slider') {
     return { min: hint.min, max: hint.max, step: hint.step };
@@ -131,9 +138,13 @@ export function DecorationParamControls({
           );
         }
 
+        // Read-only fallback for a param with no dedicated inline widget (e.g. a
+        // `kind:'xy'` hint, or an object value). `formatValue` keeps it honest —
+        // an object renders as readable JSON, never `[object Object]`. When a real
+        // xy param appears in the domain, its editor is added above. [LAW:composability]
         return (
           <div key={id} style={{ fontSize: 12, opacity: 0.8 }}>
-            {label}: {String(value)}
+            {label}: {formatValue(value)}
           </div>
         );
       })}

--- a/src/ui/graphEditor/DecorationParamControls.tsx
+++ b/src/ui/graphEditor/DecorationParamControls.tsx
@@ -76,14 +76,19 @@ export function DecorationParamControls({
     <div style={{ display: 'flex', flexDirection: 'column', gap: compact ? 6 : 10 }}>
       {params.map((param) => {
         const { id, label, value, hint } = param;
+        const kind = hint?.kind;
 
-        if (typeof value === 'number') {
+        // Hint is the authoritative widget signal; the value's runtime type only
+        // decides when NO hint is declared. So a numeric value under a boolean or
+        // select hint renders the hinted widget, never a slider by accident.
+        // [LAW:types-are-the-program]
+        if (kind === 'slider' || kind === 'int' || kind === 'float' || (kind === undefined && typeof value === 'number')) {
           const range = numericRangeFromHint(id, hint);
           return (
             <SliderWithInput
               key={id}
               label={label}
-              value={value}
+              value={typeof value === 'number' ? value : 0}
               onChange={(next) => onChange(id, next)}
               min={range.min}
               max={range.max}
@@ -93,7 +98,7 @@ export function DecorationParamControls({
           );
         }
 
-        if (hint?.kind === 'boolean' || typeof value === 'boolean') {
+        if (kind === 'boolean' || (kind === undefined && typeof value === 'boolean')) {
           return (
             <CheckboxInput
               key={id}
@@ -116,7 +121,7 @@ export function DecorationParamControls({
           );
         }
 
-        if (hint?.kind === 'color') {
+        if (kind === 'color') {
           return (
             <ColorInput
               key={id}
@@ -127,7 +132,7 @@ export function DecorationParamControls({
           );
         }
 
-        if (hint?.kind === 'text' || typeof value === 'string') {
+        if (kind === 'text' || (kind === undefined && typeof value === 'string')) {
           return (
             <TextInput
               key={id}

--- a/src/ui/graphEditor/DecorationParamControls.tsx
+++ b/src/ui/graphEditor/DecorationParamControls.tsx
@@ -78,17 +78,24 @@ export function DecorationParamControls({
         const { id, label, value, hint } = param;
         const kind = hint?.kind;
 
-        // Hint is the authoritative widget signal; the value's runtime type only
-        // decides when NO hint is declared. So a numeric value under a boolean or
-        // select hint renders the hinted widget, never a slider by accident.
-        // [LAW:types-are-the-program]
-        if (kind === 'slider' || kind === 'int' || kind === 'float' || (kind === undefined && typeof value === 'number')) {
+        // The hint selects the widget, but a widget renders ONLY when `value` is the
+        // type it can faithfully edit. A hint/value type mismatch (a numeric hint over
+        // a string, a color hint over a non-string) or an absent value is a data
+        // problem surfaced by the read-only fallback below — never hidden behind a
+        // fabricated default (`0`, `#ffffff`) that would let the widget lie about, or
+        // silently overwrite, the stored value. Free-text likewise requires an explicit
+        // `text` hint: an un-hinted string is ambiguous about its constraint (it may
+        // back a select/asset whose hint the seam flattened to `undefined`), so it is
+        // shown read-only rather than made freely editable in this lightweight popover.
+        // [LAW:types-are-the-program] [LAW:no-silent-failure]
+        const numeric = kind === 'slider' || kind === 'int' || kind === 'float';
+        if (typeof value === 'number' && (numeric || kind === undefined)) {
           const range = numericRangeFromHint(id, hint);
           return (
             <SliderWithInput
               key={id}
               label={label}
-              value={typeof value === 'number' ? value : 0}
+              value={value}
               onChange={(next) => onChange(id, next)}
               min={range.min}
               max={range.max}
@@ -98,61 +105,55 @@ export function DecorationParamControls({
           );
         }
 
-        if (kind === 'boolean' || (kind === undefined && typeof value === 'boolean')) {
+        if (typeof value === 'boolean' && (kind === 'boolean' || kind === undefined)) {
           return (
             <CheckboxInput
               key={id}
               label={label}
-              checked={Boolean(value)}
+              checked={value}
               onChange={(next) => onChange(id, next)}
             />
           );
         }
 
-        if (hint?.kind === 'select') {
+        if (hint?.kind === 'select' && typeof value === 'string') {
           return (
             <SelectInput
               key={id}
               label={label}
-              value={String(value ?? '')}
+              value={value}
               options={hint.options}
               onChange={(next) => onChange(id, next)}
             />
           );
         }
 
-        if (kind === 'color') {
+        if (kind === 'color' && typeof value === 'string') {
           return (
             <ColorInput
               key={id}
               label={label}
-              value={typeof value === 'string' ? value : '#ffffff'}
+              value={value}
               onChange={(next) => onChange(id, next)}
             />
           );
         }
 
-        // Free-text editing requires an EXPLICIT text hint. An un-hinted string is
-        // ambiguous about its constraint — it may back a select/asset the seam could
-        // not represent (its hint flattened to `undefined`) — so it renders read-only
-        // rather than a TextInput that would let the popover write an off-constraint
-        // value the authoritative editor (e.g. the Modulation Table) would reject.
-        // [LAW:no-silent-failure]
-        if (kind === 'text') {
+        if (kind === 'text' && typeof value === 'string') {
           return (
             <TextInput
               key={id}
               label={label}
-              value={String(value ?? '')}
+              value={value}
               onChange={(next) => onChange(id, next)}
             />
           );
         }
 
-        // Read-only fallback for a param with no dedicated inline widget (e.g. a
-        // `kind:'xy'` hint, or an object value). `formatValue` keeps it honest —
-        // an object renders as readable JSON, never `[object Object]`. When a real
-        // xy param appears in the domain, its editor is added above. [LAW:composability]
+        // Read-only fallback: a param whose value doesn't match an editable widget
+        // (mismatched type, unset, a `kind:'xy'` hint, or an object). `formatValue`
+        // renders the ACTUAL value readably (objects as JSON, absent as '—'), never a
+        // fabricated stand-in. [LAW:no-silent-failure] [LAW:composability]
         return (
           <div key={id} style={{ fontSize: 12, opacity: 0.8 }}>
             {label}: {formatValue(value)}

--- a/src/ui/graphEditor/DecorationParamControls.tsx
+++ b/src/ui/graphEditor/DecorationParamControls.tsx
@@ -1,0 +1,142 @@
+/**
+ * DecorationParamControls — the neutral in-place editor for an edge decoration's
+ * params.
+ *
+ * This is the widget-dispatch that used to live inside `LensParamControls`, lifted
+ * to speak the editor's neutral `DecorationParam` vocabulary instead of a V1
+ * `LensAttachment`. It renders one control per param — the SAME dispatch by value
+ * type / `UIControlHint` a block param uses — and reports edits through a single
+ * `onChange(paramId, value)`. It holds no store: the caller routes the change to
+ * the era's provider (`EdgeDecorator.setParam`), so one component edits a V1 lens
+ * and a pillar transform identically. [LAW:one-type-per-behavior]
+ * [LAW:effects-at-boundaries]
+ */
+
+import React from 'react';
+import type { UIControlHint } from '../../types';
+import {
+  SliderWithInput,
+  SelectInput,
+  CheckboxInput,
+  TextInput,
+  ColorInput,
+} from '../components/common';
+import type { DecorationParam } from './edge-decorations';
+
+interface NumericRange {
+  min: number;
+  max: number;
+  step: number;
+}
+
+/** Sensible numeric bounds when a param carries no explicit slider hint. */
+function fallbackNumericRange(paramId: string): NumericRange {
+  const key = paramId.toLowerCase();
+  if (key.includes('scale')) return { min: 0, max: 4, step: 0.01 };
+  if (key.includes('bias') || key.includes('offset')) return { min: -2, max: 2, step: 0.01 };
+  return { min: -100, max: 100, step: 0.01 };
+}
+
+function numericRangeFromHint(paramId: string, hint?: UIControlHint): NumericRange {
+  if (hint?.kind === 'slider') {
+    return { min: hint.min, max: hint.max, step: hint.step };
+  }
+  if (hint?.kind === 'int' || hint?.kind === 'float') {
+    const fallback = fallbackNumericRange(paramId);
+    return {
+      min: hint.min ?? fallback.min,
+      max: hint.max ?? fallback.max,
+      step: hint.step ?? (hint.kind === 'int' ? 1 : fallback.step),
+    };
+  }
+  return fallbackNumericRange(paramId);
+}
+
+interface DecorationParamControlsProps {
+  readonly params: readonly DecorationParam[];
+  readonly onChange: (paramId: string, value: unknown) => void;
+  readonly compact?: boolean;
+}
+
+export function DecorationParamControls({
+  params,
+  onChange,
+  compact = false,
+}: DecorationParamControlsProps): React.ReactElement | null {
+  if (params.length === 0) return null;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: compact ? 6 : 10 }}>
+      {params.map((param) => {
+        const { id, label, value, hint } = param;
+
+        if (typeof value === 'number') {
+          const range = numericRangeFromHint(id, hint);
+          return (
+            <SliderWithInput
+              key={id}
+              label={label}
+              value={value}
+              onChange={(next) => onChange(id, next)}
+              min={range.min}
+              max={range.max}
+              step={range.step}
+              editableBounds
+            />
+          );
+        }
+
+        if (hint?.kind === 'boolean' || typeof value === 'boolean') {
+          return (
+            <CheckboxInput
+              key={id}
+              label={label}
+              checked={Boolean(value)}
+              onChange={(next) => onChange(id, next)}
+            />
+          );
+        }
+
+        if (hint?.kind === 'select') {
+          return (
+            <SelectInput
+              key={id}
+              label={label}
+              value={String(value ?? '')}
+              options={hint.options}
+              onChange={(next) => onChange(id, next)}
+            />
+          );
+        }
+
+        if (hint?.kind === 'color') {
+          return (
+            <ColorInput
+              key={id}
+              label={label}
+              value={typeof value === 'string' ? value : '#ffffff'}
+              onChange={(next) => onChange(id, next)}
+            />
+          );
+        }
+
+        if (hint?.kind === 'text' || typeof value === 'string') {
+          return (
+            <TextInput
+              key={id}
+              label={label}
+              value={String(value ?? '')}
+              onChange={(next) => onChange(id, next)}
+            />
+          );
+        }
+
+        return (
+          <div key={id} style={{ fontSize: 12, opacity: 0.8 }}>
+            {label}: {String(value)}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/ui/graphEditor/DecorationParamControls.tsx
+++ b/src/ui/graphEditor/DecorationParamControls.tsx
@@ -132,7 +132,13 @@ export function DecorationParamControls({
           );
         }
 
-        if (kind === 'text' || (kind === undefined && typeof value === 'string')) {
+        // Free-text editing requires an EXPLICIT text hint. An un-hinted string is
+        // ambiguous about its constraint — it may back a select/asset the seam could
+        // not represent (its hint flattened to `undefined`) — so it renders read-only
+        // rather than a TextInput that would let the popover write an off-constraint
+        // value the authoritative editor (e.g. the Modulation Table) would reject.
+        // [LAW:no-silent-failure]
+        if (kind === 'text') {
           return (
             <TextInput
               key={id}

--- a/src/ui/graphEditor/GraphEditorContext.tsx
+++ b/src/ui/graphEditor/GraphEditorContext.tsx
@@ -11,6 +11,7 @@
 
 import { createContext, useContext, type ReactNode } from 'react';
 import type { GraphDataAdapter } from './types';
+import type { EdgeDecorator } from './edge-decorations';
 import type { SelectionStore } from '../../stores/SelectionStore';
 import type { PortHighlightStore } from '../../stores/PortHighlightStore';
 import type { DiagnosticsStore } from '../../stores/DiagnosticsStore';
@@ -36,6 +37,14 @@ export type PortContextMenuHandler = (request: PortContextMenuRequest) => void;
 export interface GraphEditorContextValue {
   /** Data adapter for graph operations */
   adapter: GraphDataAdapter;
+
+  /**
+   * The era's authority on an edge's transform chain (V1 lenses / pillar transform
+   * blocks). The edge renderer reads it for chips + param editing, so it holds no
+   * lens/era opinion. Every mount supplies one — a V1 decorator, a scene decorator,
+   * or the explicit empty decorator. [LAW:one-source-of-truth]
+   */
+  decorator: EdgeDecorator;
 
   // Feature flags
   /** Enable inline parameter editing in nodes */

--- a/src/ui/graphEditor/GraphEditorCore.tsx
+++ b/src/ui/graphEditor/GraphEditorCore.tsx
@@ -48,6 +48,7 @@ import type { OscillaEdgeData } from '../reactFlowEditor/nodes';
 import { getLayoutedElements } from '../reactFlowEditor/layout';
 import type { TypeOracle } from './type-oracle';
 import { verdictPermits } from './type-oracle';
+import type { EdgeDecorator } from './edge-decorations';
 // import { ErrorBadgeOverlay } from './ErrorBadgeOverlay'; // DISABLED: Errors now shown in port popovers
 import type { SelectionStore } from '../../stores/SelectionStore';
 import type { PortHighlightStore } from '../../stores/PortHighlightStore';
@@ -104,6 +105,14 @@ export interface GraphEditorCoreProps {
    * always asks the oracle and never falls back to "permit everything" implicitly.
    */
   oracle: TypeOracle;
+
+  /**
+   * The era's authority on an edge's transform chain (V1 lenses / pillar transform
+   * blocks). Every mount supplies one — a V1 decorator, a scene decorator, or the
+   * explicit empty decorator — so the edge renderer reads decorations through the
+   * seam and never past it into a store. [LAW:one-source-of-truth]
+   */
+  decorator: EdgeDecorator;
 
   /** Custom node types map (default: { unified: UnifiedNode }) */
   nodeTypes?: NodeTypes;
@@ -186,6 +195,7 @@ export const GraphEditorCoreInner = observer(
         diagnostics = null,
         debug = null,
         oracle,
+        decorator,
         nodeTypes: customNodeTypes,
         onEditorReady,
         onNodeContextMenu,
@@ -297,6 +307,7 @@ export const GraphEditorCoreInner = observer(
       const contextValue: GraphEditorContextValue = useMemo(
         () => ({
           adapter,
+          decorator,
           enableParamEditing: mergedFeatures.enableParamEditing,
           enableDebugMode: mergedFeatures.enableDebugMode,
           enableContextMenus: mergedFeatures.enableContextMenus,
@@ -308,7 +319,7 @@ export const GraphEditorCoreInner = observer(
           diagnostics,
           debug,
         }),
-        [adapter, mergedFeatures, onPortContextMenu, selection, portHighlight, diagnostics, debug]
+        [adapter, decorator, mergedFeatures, onPortContextMenu, selection, portHighlight, diagnostics, debug]
       );
 
       // -------------------------------------------------------------------------

--- a/src/ui/graphEditor/SceneEdgeDecorator.ts
+++ b/src/ui/graphEditor/SceneEdgeDecorator.ts
@@ -52,7 +52,27 @@ export class SceneEdgeDecorator implements EdgeDecorator {
     }));
   }
 
-  setParam(_edge: EdgeRef, decorationId: string, paramId: string, value: unknown): void {
+  setParam(edge: EdgeRef, decorationId: string, paramId: string, value: unknown): void {
+    // Edge-scope the write symmetrically with the V1 provider. A pillar decoration id
+    // is a globally-unique block id, so `updateConfig` alone would happily mutate a
+    // transform from an UNRELATED edge; the contract is that `decorationId` names a
+    // step on THIS edge. Verify it against the edge's traced chain and throw on a
+    // mismatch — the same loud rejection V1's `updateLensParams` gives for a lens not
+    // on the target port — rather than silently writing the wrong block's config.
+    // [LAW:no-silent-failure]
+    const route = traceRoute(
+      this.store.patch,
+      this.store.registry,
+      edge.targetBlockId,
+      edge.targetPortId,
+    );
+    const onEdge = route?.transforms.some((t) => t.blockId === decorationId) ?? false;
+    if (!onEdge) {
+      throw new Error(
+        `EdgeDecorator.setParam: decoration "${decorationId}" is not on edge ` +
+          `${edge.sourceBlockId}.${edge.sourcePortId} -> ${edge.targetBlockId}.${edge.targetPortId}`,
+      );
+    }
     this.store.updateConfig(decorationId, paramId, value);
   }
 }

--- a/src/ui/graphEditor/SceneEdgeDecorator.ts
+++ b/src/ui/graphEditor/SceneEdgeDecorator.ts
@@ -1,0 +1,88 @@
+/**
+ * SceneEdgeDecorator — the pillar provider of the EdgeDecorator seam.
+ *
+ * The pillar model stores no chain on an edge; a scalar route reaches an input
+ * through inline `'transform'`-category blocks (Scale / Offset / Clamp). This
+ * provider reuses the ONE trace that the Modulation Table reads — `traceRoute` —
+ * to recover the chain feeding an edge's target input, and projects each transform
+ * block to a neutral step whose params are the block's config fields. A param write
+ * routes to `PillarPatchStore.updateConfig`, the same authored-config mutation the
+ * table performs, so a chip edit and a table edit are the same store operation on
+ * the same source of truth. [LAW:one-source-of-truth]
+ *
+ * Because a transform block feeds exactly one input and the route is traced from
+ * that input, a non-empty chain surfaces on precisely the final input edge of the
+ * route — the edge whose target is the consuming input — mirroring where V1 paints
+ * its lens chips. A direct wire traces to an empty chain and shows nothing.
+ */
+
+import type { PillarPatchStore } from '../../stores/PillarPatchStore';
+import { traceRoute } from '../nativeEditor/modulationTable';
+import type { SceneConfigControl } from '../../pillars/scene';
+import type { UIControlHint } from '../../types';
+import type { EdgeDecoration, EdgeDecorator, EdgeRef, DecorationParam } from './edge-decorations';
+
+/** Chip color for a pillar transform step. */
+const TRANSFORM_CHIP_COLOR = '#3fb6c4';
+
+export class SceneEdgeDecorator implements EdgeDecorator {
+  constructor(private readonly store: PillarPatchStore) {}
+
+  decorations(edge: EdgeRef): readonly EdgeDecoration[] {
+    const route = traceRoute(
+      this.store.patch,
+      this.store.registry,
+      edge.targetBlockId,
+      edge.targetPortId,
+    );
+    if (route === null) return [];
+    return route.transforms.map((transform) => ({
+      id: transform.blockId,
+      label: transform.displayName,
+      color: TRANSFORM_CHIP_COLOR,
+      tooltip: `${transform.displayName} (${transform.type})`,
+      params: transform.fields.map(
+        (field): DecorationParam => ({
+          id: field.key,
+          label: field.label,
+          value: field.value,
+          hint: controlToHint(field.control),
+        }),
+      ),
+    }));
+  }
+
+  setParam(_edge: EdgeRef, decorationId: string, paramId: string, value: unknown): void {
+    this.store.updateConfig(decorationId, paramId, value);
+  }
+}
+
+/**
+ * Map a scene config control to the editor's neutral widget hint. The numeric and
+ * boolean/color controls that transform blocks actually use map exactly; controls
+ * that carry data the route projection does not surface (`select` options, asset
+ * pickers) return undefined, so the neutral editor falls back to a value-directed
+ * widget rather than inventing an empty picker — an explicit deferral, not a silent
+ * gap. A new SceneConfigControl is a compile error here, forcing a decision.
+ * [LAW:no-silent-failure]
+ */
+function controlToHint(control: SceneConfigControl): UIControlHint | undefined {
+  switch (control) {
+    case 'number':
+      return { kind: 'float' };
+    case 'integer':
+      return { kind: 'int' };
+    case 'color':
+      return { kind: 'color' };
+    case 'toggle':
+      return { kind: 'boolean' };
+    case 'select':
+    case 'asset':
+    case 'colorList':
+      return undefined;
+    default: {
+      const _exhaustive: never = control;
+      throw new Error(`Unhandled SceneConfigControl: ${JSON.stringify(_exhaustive)}`);
+    }
+  }
+}

--- a/src/ui/graphEditor/V1EdgeDecorator.ts
+++ b/src/ui/graphEditor/V1EdgeDecorator.ts
@@ -12,7 +12,7 @@
  */
 
 import type { PatchStore } from '../../stores/PatchStore';
-import { requireAnyBlockDef } from '../../blocks/registry';
+import { getAnyBlockDefinition } from '../../blocks/registry';
 import type { BlockId } from '../../types';
 import { getLensLabel, lensTargetsConnection } from '../reactFlowEditor/lensUtils';
 import type { EdgeDecoration, EdgeDecorator, EdgeRef, DecorationParam } from './edge-decorations';
@@ -58,7 +58,13 @@ function lensParams(
   lensType: string,
   params: Record<string, unknown> | undefined,
 ): readonly DecorationParam[] {
-  const def = requireAnyBlockDef(lensType);
+  // Non-throwing lookup: `decorations()` runs for every edge on every render, so an
+  // orphaned lens type (a def unregistered since the patch was authored) must not
+  // crash the edge renderer. The chip still renders — `getLensLabel` falls back to a
+  // derived label — so the broken lens stays visible; it just carries no editable
+  // params. Honest degradation, not a silent drop or a crash. [LAW:no-silent-failure]
+  const def = getAnyBlockDefinition(lensType);
+  if (!def) return [];
   return Object.entries(def.inputs)
     .filter(([inputId]) => inputId !== 'in')
     .map(([paramId, inputDef]) => ({

--- a/src/ui/graphEditor/V1EdgeDecorator.ts
+++ b/src/ui/graphEditor/V1EdgeDecorator.ts
@@ -64,7 +64,11 @@ function lensParams(
     .map(([paramId, inputDef]) => ({
       id: paramId,
       label: inputDef.label ?? paramId,
-      value: params?.[paramId] ?? inputDef.defaultValue ?? 0,
+      // The value stays `unknown` — no fabricated `0`. A boolean/color param with
+      // no default must not read back a number, or the value-first widget dispatch
+      // in DecorationParamControls would render a slider for it. An absent value is
+      // chosen by the honest hint/value dispatch instead. [LAW:types-are-the-program]
+      value: params?.[paramId] ?? inputDef.defaultValue,
       hint: inputDef.uiHint,
     }));
 }

--- a/src/ui/graphEditor/V1EdgeDecorator.ts
+++ b/src/ui/graphEditor/V1EdgeDecorator.ts
@@ -1,0 +1,70 @@
+/**
+ * V1EdgeDecorator — the V1 provider of the EdgeDecorator seam.
+ *
+ * Wraps the SAME lens machinery the V1 editor already reads: the target input
+ * port's `LensAttachment` records (filtered to the ones targeting this edge's
+ * source, exactly as `OscillaEdge` did through its former direct-store bypass),
+ * projected to neutral steps. Each step's params come from the lens block def's
+ * non-`in` inputs (values from the attachment); a param write routes straight to
+ * `PatchStore.updateLensParams`. It adds no concept of its own — it translates the
+ * lens subsystem into the neutral vocabulary so the edge renderer holds no lens
+ * opinion. [LAW:one-source-of-truth]
+ */
+
+import type { PatchStore } from '../../stores/PatchStore';
+import { requireAnyBlockDef } from '../../blocks/registry';
+import type { BlockId } from '../../types';
+import { getLensLabel, lensTargetsConnection } from '../reactFlowEditor/lensUtils';
+import type { EdgeDecoration, EdgeDecorator, EdgeRef, DecorationParam } from './edge-decorations';
+
+/** Chip color for a V1 lens step — the amber the edge chips have always used. */
+const LENS_CHIP_COLOR = '#f0a020';
+
+export class V1EdgeDecorator implements EdgeDecorator {
+  constructor(private readonly patch: PatchStore) {}
+
+  decorations(edge: EdgeRef): readonly EdgeDecoration[] {
+    const sourceDisplayName = this.patch.blocks.get(edge.sourceBlockId as BlockId)?.displayName;
+    const lenses = this.patch.getLensesForPort(edge.targetBlockId as BlockId, edge.targetPortId);
+    return lenses
+      .filter((lens) =>
+        lensTargetsConnection(lens, edge.sourceBlockId, edge.sourcePortId, sourceDisplayName),
+      )
+      .slice()
+      .sort((a, b) => a.sortKey - b.sortKey)
+      .map((lens) => ({
+        id: lens.id,
+        label: getLensLabel(lens.lensType),
+        color: LENS_CHIP_COLOR,
+        tooltip: `${getLensLabel(lens.lensType)} (${lens.lensType})`,
+        params: lensParams(lens.lensType, lens.params),
+      }));
+  }
+
+  setParam(edge: EdgeRef, decorationId: string, paramId: string, value: unknown): void {
+    this.patch.updateLensParams(edge.targetBlockId as BlockId, edge.targetPortId, decorationId, {
+      [paramId]: value,
+    });
+  }
+}
+
+/**
+ * Project a lens block def's editable inputs (everything but its `in` value port)
+ * to neutral params, reading current values from the attachment and falling back
+ * to the def default — the exact projection `LensParamControls` performed inline,
+ * lifted behind the seam so the neutral param editor can render it. [LAW:decomposition]
+ */
+function lensParams(
+  lensType: string,
+  params: Record<string, unknown> | undefined,
+): readonly DecorationParam[] {
+  const def = requireAnyBlockDef(lensType);
+  return Object.entries(def.inputs)
+    .filter(([inputId]) => inputId !== 'in')
+    .map(([paramId, inputDef]) => ({
+      id: paramId,
+      label: inputDef.label ?? paramId,
+      value: params?.[paramId] ?? inputDef.defaultValue ?? 0,
+      hint: inputDef.uiHint,
+    }));
+}

--- a/src/ui/graphEditor/__tests__/edge-decorator-conformance.contract.ts
+++ b/src/ui/graphEditor/__tests__/edge-decorator-conformance.contract.ts
@@ -1,0 +1,94 @@
+/**
+ * edge-decorator-conformance.contract — the EdgeDecorator contract, stated once, as
+ * executable assertions.
+ *
+ * This file IS the specification of what makes a decorator "editor-usable". Every
+ * provider (V1EdgeDecorator, SceneEdgeDecorator, the empty decorator, and any future
+ * backend) is checked against this one contract; a behavior this file does not
+ * assert is not part of the contract, and a provider that passes every assertion
+ * here is presumed drop-in for the edge renderer's chips + in-place param editor.
+ * [LAW:single-enforcer] [LAW:verifiable-goals]
+ *
+ * DECOMPOSITION: an `EdgeDecoratorConformanceCase` carries the whole truth a
+ * provider must supply to be checkable — the decorator, plus an edge its era is
+ * known to decorate, an edge it is known NOT to decorate, and one editable param on
+ * the decorated edge. The `assert*` functions know only the neutral vocabulary
+ * (`EdgeDecorator` / `EdgeDecoration` / `EdgeRef`); they never import a store or an
+ * era-specific model. That is what lets one contract check heterogeneous providers.
+ * [LAW:decomposition] [LAW:one-way-deps]
+ *
+ * The `assert*` functions are also the negative control's instrument: aimed at a
+ * deliberately-broken decorator they must throw, proving the suite has teeth rather
+ * than vacuously passing.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { EdgeDecoration, EdgeDecorator, EdgeRef } from '../edge-decorations';
+
+/** Everything a provider must supply to be run through the conformance contract. */
+export interface EdgeDecoratorConformanceCase {
+  readonly name: string;
+  /** The decorator under test, over a graph the provider has seeded. */
+  readonly decorator: EdgeDecorator;
+  /** An edge whose target input this era is known to decorate with a chain. */
+  readonly decoratedEdge: EdgeRef;
+  /** An edge this era is known to leave undecorated (a direct/bare wire). */
+  readonly bareEdge: EdgeRef;
+  /** One editable param on the decorated edge, with a value to write and read back. */
+  readonly editable: {
+    readonly decorationId: string;
+    readonly paramId: string;
+    readonly value: number;
+  };
+}
+
+/** A decoration is a fully-formed chip: non-empty id/label/color, well-formed params. */
+function assertDecorationWellFormed(d: EdgeDecoration, label: string): void {
+  expect(d.id.length, `${label}: decoration has an id`).toBeGreaterThan(0);
+  expect(d.label.length, `${label}: decoration has a label`).toBeGreaterThan(0);
+  expect(d.color.length, `${label}: decoration has a color`).toBeGreaterThan(0);
+  for (const p of d.params) {
+    expect(p.id.length, `${label}: param has an id`).toBeGreaterThan(0);
+    expect(p.label.length, `${label}: param has a label`).toBeGreaterThan(0);
+  }
+}
+
+/** The known-decorated edge yields a non-empty, well-formed chain. */
+export function assertDecoratesKnownEdge(c: EdgeDecoratorConformanceCase): void {
+  const decorations = c.decorator.decorations(c.decoratedEdge);
+  expect(decorations.length, `${c.name}: decorated edge has a chain`).toBeGreaterThan(0);
+  decorations.forEach((d, i) => assertDecorationWellFormed(d, `${c.name}: decoration ${i}`));
+}
+
+/** The known-bare edge yields no decorations — a decorator never invents a chain. */
+export function assertBareEdgeUndecorated(c: EdgeDecoratorConformanceCase): void {
+  const decorations = c.decorator.decorations(c.bareEdge);
+  expect(decorations, `${c.name}: bare edge has no chain`).toHaveLength(0);
+}
+
+/**
+ * A param write round-trips: after `setParam`, the same param on the decorated edge
+ * reads back the written value. This is what makes the neutral in-place editor real
+ * — the provider's setParam is the era's own mutation, and the chain re-derives it.
+ */
+export function assertParamRoundTrips(c: EdgeDecoratorConformanceCase): void {
+  c.decorator.setParam(c.decoratedEdge, c.editable.decorationId, c.editable.paramId, c.editable.value);
+  const decoration = c.decorator
+    .decorations(c.decoratedEdge)
+    .find((d) => d.id === c.editable.decorationId);
+  expect(decoration, `${c.name}: edited decoration still present`).toBeDefined();
+  const param = decoration?.params.find((p) => p.id === c.editable.paramId);
+  expect(param?.value, `${c.name}: param reflects the written value`).toBe(c.editable.value);
+}
+
+/**
+ * Register the whole contract against one provider. A future backend is drop-in
+ * verifiable: build an EdgeDecoratorConformanceCase for it and call this.
+ */
+export function runEdgeDecoratorConformanceSuite(c: EdgeDecoratorConformanceCase): void {
+  describe(`EdgeDecorator conformance: ${c.name}`, () => {
+    it('decorates a known edge with a well-formed chain', () => assertDecoratesKnownEdge(c));
+    it('leaves a bare edge undecorated', () => assertBareEdgeUndecorated(c));
+    it('round-trips a param edit', () => assertParamRoundTrips(c));
+  });
+}

--- a/src/ui/graphEditor/__tests__/edge-decorator-conformance.test.ts
+++ b/src/ui/graphEditor/__tests__/edge-decorator-conformance.test.ts
@@ -149,3 +149,46 @@ describe('noEdgeDecorator', () => {
     expect(() => noEdgeDecorator.setParam(edge, 'd', 'p', 1)).not.toThrow();
   });
 });
+
+// =============================================================================
+// SceneEdgeDecorator edge-scopes the write — a pillar decoration id is a globally
+// unique block id, so `setParam` must reject a decoration that is not on the given
+// edge's chain rather than silently mutating an unrelated block (symmetric with V1).
+// =============================================================================
+
+describe('SceneEdgeDecorator edge-scopes setParam', () => {
+  function transformRoute() {
+    const store = new PillarPatchStore({ blocks: [], edges: [] });
+    const constId = store.addBlock('Constant');
+    const waveId = store.addBlock('WaveOffset');
+    const scaleId = store.addBlock('Scale');
+    store.addEdge(constId, scaleId, 'in');
+    store.addEdge(scaleId, waveId, 'amplitude');
+    return { decorator: new SceneEdgeDecorator(store), constId, waveId, scaleId };
+  }
+
+  it('throws when the decoration is not on the given edge', () => {
+    const { decorator, constId, scaleId } = transformRoute();
+    // Scale is a decoration on (Scale.out -> amplitude), NOT on (Constant -> Scale.in).
+    expect(() =>
+      decorator.setParam(
+        { sourceBlockId: constId, sourcePortId: 'value', targetBlockId: scaleId, targetPortId: 'in' },
+        scaleId,
+        'factor',
+        9,
+      ),
+    ).toThrow();
+  });
+
+  it('accepts the write on the edge the decoration actually decorates', () => {
+    const { decorator, waveId, scaleId } = transformRoute();
+    expect(() =>
+      decorator.setParam(
+        { sourceBlockId: scaleId, sourcePortId: 'out', targetBlockId: waveId, targetPortId: 'amplitude' },
+        scaleId,
+        'factor',
+        9,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/ui/graphEditor/__tests__/edge-decorator-conformance.test.ts
+++ b/src/ui/graphEditor/__tests__/edge-decorator-conformance.test.ts
@@ -1,0 +1,151 @@
+/**
+ * edge-decorator-conformance.test — the EdgeDecorator contract run against every
+ * provider, plus a negative control proving the contract rejects.
+ *
+ * The contract itself lives in ./edge-decorator-conformance.contract. Here we supply
+ * one `EdgeDecoratorConformanceCase` per provider (seeding it in that provider's own
+ * vocabulary — a V1 patch with a lens on an edge, a pillar patch with a transform on
+ * a route) and run the shared suite over each. A future backend becomes drop-in
+ * verifiable by adding one case below. [LAW:verifiable-goals]
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { registerAllBlocks } from '../../../blocks/all';
+import { PatchStore } from '../../../stores/PatchStore';
+import { PillarPatchStore } from '../../../stores/PillarPatchStore';
+
+import { V1EdgeDecorator } from '../V1EdgeDecorator';
+import { SceneEdgeDecorator } from '../SceneEdgeDecorator';
+import { noEdgeDecorator } from '../edge-decorations';
+import type { EdgeDecorator } from '../edge-decorations';
+
+import {
+  assertBareEdgeUndecorated,
+  assertDecoratesKnownEdge,
+  assertParamRoundTrips,
+  runEdgeDecoratorConformanceSuite,
+  type EdgeDecoratorConformanceCase,
+} from './edge-decorator-conformance.contract';
+
+registerAllBlocks();
+
+// =============================================================================
+// V1 provider — a time signal drives Ellipse.rx, with a ScaleBias lens on that
+// connection. The rx edge decorates to [ScaleBias]; the resolution edge is bare.
+// =============================================================================
+
+function v1Case(): EdgeDecoratorConformanceCase {
+  const store = new PatchStore();
+  const timeId = store.addBlock('InfiniteTimeRoot');
+  const ellipseId = store.addBlock('Ellipse');
+  store.addEdge(
+    { kind: 'port', blockId: timeId, slotId: 'tMs' },
+    { kind: 'port', blockId: ellipseId, slotId: 'rx' },
+  );
+  const lensId = store.addLens(
+    ellipseId,
+    'rx',
+    'ScaleBias',
+    `v1:blocks.${timeId}.outputs.tMs`,
+    { scale: 2 },
+  );
+
+  return {
+    name: 'V1EdgeDecorator',
+    decorator: new V1EdgeDecorator(store),
+    decoratedEdge: { sourceBlockId: timeId, sourcePortId: 'tMs', targetBlockId: ellipseId, targetPortId: 'rx' },
+    bareEdge: { sourceBlockId: timeId, sourcePortId: 'tMs', targetBlockId: ellipseId, targetPortId: 'resolution' },
+    editable: { decorationId: lensId, paramId: 'scale', value: 3 },
+  };
+}
+
+// =============================================================================
+// Pillar provider — Constant → Scale → WaveOffset.amplitude. The Scale.out edge
+// decorates to [Scale]; the Constant → Scale.in edge is a bare (direct) wire.
+// =============================================================================
+
+function sceneCase(): EdgeDecoratorConformanceCase {
+  const store = new PillarPatchStore({ blocks: [], edges: [] });
+  const constId = store.addBlock('Constant');
+  const waveId = store.addBlock('WaveOffset');
+  const scaleId = store.addBlock('Scale');
+  store.addEdge(constId, scaleId, 'in');
+  store.addEdge(scaleId, waveId, 'amplitude');
+
+  return {
+    name: 'SceneEdgeDecorator',
+    decorator: new SceneEdgeDecorator(store),
+    decoratedEdge: { sourceBlockId: scaleId, sourcePortId: 'out', targetBlockId: waveId, targetPortId: 'amplitude' },
+    bareEdge: { sourceBlockId: constId, sourcePortId: 'value', targetBlockId: scaleId, targetPortId: 'in' },
+    editable: { decorationId: scaleId, paramId: 'factor', value: 2.5 },
+  };
+}
+
+runEdgeDecoratorConformanceSuite(v1Case());
+runEdgeDecoratorConformanceSuite(sceneCase());
+
+// =============================================================================
+// Negative control — deliberately-broken decorators the contract MUST reject.
+// Each `expect(...).toThrow` pins a distinct invariant to the assertion that
+// enforces it, so no assertion can pass vacuously. [LAW:verifiable-goals]
+// =============================================================================
+
+const DUMMY = {
+  decoratedEdge: { sourceBlockId: 'a', sourcePortId: 'o', targetBlockId: 'b', targetPortId: 'i' },
+  bareEdge: { sourceBlockId: 'a', sourcePortId: 'o', targetBlockId: 'b', targetPortId: 'i' },
+  editable: { decorationId: 'd', paramId: 'p', value: 9 },
+} as const;
+
+/** Returns a chain for EVERY edge — so it decorates the bare edge too. */
+const brokenAlwaysDecorates: EdgeDecorator = {
+  decorations: () => [{ id: 'x', label: 'x', color: '#fff', tooltip: '', params: [] }],
+  setParam: () => {},
+};
+
+/** Returns a decoration with empty id/label/color — not a presentable chip. */
+const brokenMalformed: EdgeDecorator = {
+  decorations: () => [{ id: '', label: '', color: '', tooltip: '', params: [] }],
+  setParam: () => {},
+};
+
+/** Reports a param but ignores writes — so an edit never reads back. */
+const brokenIgnoresSetParam: EdgeDecorator = {
+  decorations: () => [
+    { id: 'd', label: 'D', color: '#fff', tooltip: '', params: [{ id: 'p', label: 'P', value: 0 }] },
+  ],
+  setParam: () => {},
+};
+
+describe('edge-decorator conformance contract rejects a non-conforming decorator (negative control)', () => {
+  it('rejects a decorator that invents a chain for a bare edge', () => {
+    expect(() => assertBareEdgeUndecorated({ name: 'x', decorator: brokenAlwaysDecorates, ...DUMMY })).toThrow();
+  });
+
+  it('rejects a decorator whose decoration is not a presentable chip', () => {
+    expect(() => assertDecoratesKnownEdge({ name: 'x', decorator: brokenMalformed, ...DUMMY })).toThrow();
+  });
+
+  it('rejects a decorator that ignores a param write', () => {
+    expect(() => assertParamRoundTrips({ name: 'x', decorator: brokenIgnoresSetParam, ...DUMMY })).toThrow();
+  });
+});
+
+// =============================================================================
+// noEdgeDecorator — pinned directly, because it is the one provider the conformance
+// contract structurally cannot cover: it decorates no edge, so it supplies no
+// decorated-edge / editable-param fixture. It is nonetheless production code (the
+// composite editor), so its invariants are asserted here. [LAW:verifiable-goals]
+// =============================================================================
+
+describe('noEdgeDecorator', () => {
+  const edge = { sourceBlockId: 'a', sourcePortId: 'o', targetBlockId: 'b', targetPortId: 'i' };
+
+  it('decorates no edge', () => {
+    expect(noEdgeDecorator.decorations(edge)).toHaveLength(0);
+  });
+
+  it('accepts a param write as a no-op without throwing', () => {
+    expect(() => noEdgeDecorator.setParam(edge, 'd', 'p', 1)).not.toThrow();
+  });
+});

--- a/src/ui/graphEditor/__tests__/edge-decorator-parity.test.ts
+++ b/src/ui/graphEditor/__tests__/edge-decorator-parity.test.ts
@@ -1,0 +1,108 @@
+/**
+ * edge-decorator-parity.test — the acceptance gate: the decorator's chain equals
+ * what the era's OWN editor authority reports for the same edge, in BOTH boots.
+ *
+ * This is the whole point of the seam: the canvas edge chips are not a second
+ * opinion about an edge's transforms — they ARE the era's own chain, wrapped. So
+ * for each era we assert the decorator agrees with its authority:
+ *   - V1: the port's lenses filtered by `lensTargetsConnection` (exactly what
+ *         OscillaEdge computed before the seam, sorted by `sortKey`).
+ *   - pillar: the traced transform chain the Modulation Table renders
+ *         (`buildModulationTable` → the row's route).
+ * Each era asserts BOTH a decorated edge (non-empty, agreeing) and a bare edge
+ * (empty), so the agreement is proven against a discriminating authority, never a
+ * vacuous one. [LAW:one-source-of-truth] [LAW:verifiable-goals]
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { registerAllBlocks } from '../../../blocks/all';
+import { PatchStore } from '../../../stores/PatchStore';
+import { PillarPatchStore } from '../../../stores/PillarPatchStore';
+import { lensTargetsConnection } from '../../reactFlowEditor/lensUtils';
+import { buildModulationTable } from '../../nativeEditor/modulationTable';
+
+import { V1EdgeDecorator } from '../V1EdgeDecorator';
+import { SceneEdgeDecorator } from '../SceneEdgeDecorator';
+
+registerAllBlocks();
+
+describe('edge-decorator parity: chain == era authority', () => {
+  it('V1 — the decorator chain equals the lenses the era targets to this connection', () => {
+    const store = new PatchStore();
+    const timeId = store.addBlock('InfiniteTimeRoot');
+    const ellipseId = store.addBlock('Ellipse');
+    store.addEdge(
+      { kind: 'port', blockId: timeId, slotId: 'tMs' },
+      { kind: 'port', blockId: ellipseId, slotId: 'rx' },
+    );
+    store.addLens(ellipseId, 'rx', 'ScaleBias', `v1:blocks.${timeId}.outputs.tMs`, { scale: 2 });
+    const decorator = new V1EdgeDecorator(store);
+
+    // The era's own authority for "which lenses show on this edge".
+    const sourceDisplayName = store.blocks.get(timeId)?.displayName;
+    const authorityIds = store
+      .getLensesForPort(ellipseId, 'rx')
+      .filter((lens) => lensTargetsConnection(lens, timeId, 'tMs', sourceDisplayName))
+      .slice()
+      .sort((a, b) => a.sortKey - b.sortKey)
+      .map((lens) => lens.id);
+
+    const decorated = decorator.decorations({
+      sourceBlockId: timeId,
+      sourcePortId: 'tMs',
+      targetBlockId: ellipseId,
+      targetPortId: 'rx',
+    });
+    expect(decorated.map((d) => d.id)).toEqual(authorityIds);
+    expect(authorityIds.length, 'decorated edge exercises a non-empty chain').toBeGreaterThan(0);
+    // The param value is the attachment's, not a default.
+    expect(decorated[0].params.find((p) => p.id === 'scale')?.value).toBe(2);
+
+    // A port the era attaches no lens to is bare.
+    const bare = decorator.decorations({
+      sourceBlockId: timeId,
+      sourcePortId: 'tMs',
+      targetBlockId: ellipseId,
+      targetPortId: 'resolution',
+    });
+    expect(bare, 'bare edge exercises the empty case').toHaveLength(0);
+  });
+
+  it('pillar — the decorator chain equals the Modulation Table route it traces', () => {
+    const store = new PillarPatchStore({ blocks: [], edges: [] });
+    const constId = store.addBlock('Constant');
+    const waveId = store.addBlock('WaveOffset');
+    const scaleId = store.addBlock('Scale');
+    store.addEdge(constId, scaleId, 'in');
+    store.addEdge(scaleId, waveId, 'amplitude');
+    const decorator = new SceneEdgeDecorator(store);
+
+    // The era's own authority: the route the Modulation Table shows for that input.
+    const model = buildModulationTable(store.patch, store.registry);
+    const rowIndex = model.rows.findIndex((r) => r.blockId === waveId && r.portId === 'amplitude');
+    const rowRoute = model.cells[rowIndex][0]?.rowRoute ?? null;
+    const authorityIds = rowRoute?.transforms.map((t) => t.blockId) ?? [];
+
+    const decorated = decorator.decorations({
+      sourceBlockId: scaleId,
+      sourcePortId: 'out',
+      targetBlockId: waveId,
+      targetPortId: 'amplitude',
+    });
+    expect(decorated.map((d) => d.id)).toEqual(authorityIds);
+    expect(decorated.map((d) => d.id), 'decorated edge exercises a non-empty chain').toEqual([scaleId]);
+    // The param value is the transform block's config.
+    const configFactor = store.patch.blocks.find((b) => b.id === scaleId)?.config.factor;
+    expect(decorated[0].params.find((p) => p.id === 'factor')?.value).toBe(configFactor);
+
+    // The upstream (direct) wire into the transform is bare.
+    const bare = decorator.decorations({
+      sourceBlockId: constId,
+      sourcePortId: 'value',
+      targetBlockId: scaleId,
+      targetPortId: 'in',
+    });
+    expect(bare, 'bare edge exercises the empty case').toHaveLength(0);
+  });
+});

--- a/src/ui/graphEditor/__tests__/edge-decorator-seam-gate.test.ts
+++ b/src/ui/graphEditor/__tests__/edge-decorator-seam-gate.test.ts
@@ -1,0 +1,55 @@
+/**
+ * edge-decorator-seam-gate — the seam's coupling gate.
+ *
+ * The point of the EdgeDecorator seam is that the shared edge renderer never reads
+ * an era's transform machinery in that era's own language — it asks the neutral
+ * decorator "what decorates this edge?" and paints the chips + param editor from the
+ * answer. This test enforces that mechanically for the consumer this ticket
+ * converted: OscillaEdge (the single edge type GraphEditorCore registers for BOTH
+ * boots) reaches its decorations through the seam and imports no V1 lens surface —
+ * no `lensUtils`, no `LensParamControls`, and none of the `inputPorts…lenses`
+ * direct-store bypass it used before.
+ *
+ * SCOPE: this is the edge-decorator seam's gate, not the whole editor's. Other files
+ * still read the lens model for OTHER concerns owned by sibling tickets — the edge
+ * inspector's lens management (inspector-panels ticket), lens chain growth
+ * (scene-adapters). Reseating those is each ticket's job; the provider files
+ * (V1EdgeDecorator) are where the lens surface legitimately lives — behind the seam.
+ * [LAW:decomposition] [LAW:single-enforcer] [LAW:verifiable-goals]
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// This file lives at src/ui/graphEditor/__tests__; the converted consumer is under src/ui/reactFlowEditor.
+const UI_ROOT = join(__dirname, '..', '..');
+
+function read(rel: string): string {
+  return readFileSync(join(UI_ROOT, rel), 'utf8');
+}
+
+const CONVERTED_CONSUMER = 'reactFlowEditor/OscillaEdge.tsx';
+
+/** V1 lens surfaces a UI consumer must not touch — it goes through the decorator. */
+const FORBIDDEN_PATTERNS: readonly RegExp[] = [
+  /from\s+['"][^'"]*\/lensUtils['"]/,
+  /from\s+['"][^'"]*\/LensParamControls['"]/,
+  // The former direct-store bypass: reading lenses off a port on the patch model.
+  /inputPorts\.get\(/,
+  /\.lenses\b/,
+];
+
+describe('EdgeDecorator seam — coupling gate', () => {
+  it('the converted consumer imports no V1 lens surface', () => {
+    const src = read(CONVERTED_CONSUMER);
+    const offenders = FORBIDDEN_PATTERNS.filter((re) => re.test(src)).map((re) => re.source);
+    expect(offenders).toEqual([]);
+  });
+
+  it('the converted consumer reaches its decorations through the seam', () => {
+    const src = read(CONVERTED_CONSUMER);
+    expect(/from\s+['"][^'"]*\/edge-decorations['"]/.test(src)).toBe(true);
+    expect(/decorator\.decorations\(/.test(src)).toBe(true);
+  });
+});

--- a/src/ui/graphEditor/edge-decorations.ts
+++ b/src/ui/graphEditor/edge-decorations.ts
@@ -1,0 +1,127 @@
+/**
+ * EdgeDecorator — the editor's neutral authority on an edge's transform chain.
+ *
+ * A value arriving at an input can be reshaped on the way in by an ordered chain
+ * of parameterized transforms. Two eras realize this concept in completely
+ * different machinery: V1 stores `LensAttachment` records ON the target input
+ * port; the pillar model has no edge field at all and reconstructs the chain by
+ * tracing backward through `'transform'`-category blocks. Yet the EDITOR-FACING
+ * behavior is identical — an ordered list of transform steps decorating one edge,
+ * each shown as a chip and each with editable params. That single behavior is one
+ * seam; each era supplies a provider, and the mechanism difference becomes residue
+ * inside the provider. [LAW:one-type-per-behavior] [FRAMING:representation]
+ *
+ * This is the sibling of TypeOracle (what a port MEANS) and BlockCatalog (what
+ * could be ADDED): the decorator answers what an edge DOES to the value passing
+ * through it. Like the oracle and the adapter it reads the live graph, so a
+ * provider wraps the era's store and is constructed per editor mount, reached by
+ * the ReactFlow-instantiated edge renderer through the GraphEditor context.
+ * [LAW:decomposition] [LAW:one-way-deps]
+ *
+ * SCOPE — this seam owns exactly "describe an edge's chain, and retune a step's
+ * params". Growing a chain (add / remove / reorder / palette) is a separate
+ * concern owned by the scene-adapters epic; the edge inspector is owned by the
+ * inspector-panels ticket; block-param-control neutrality by the typed-control
+ * ticket. Fusing any of those here would make the part do more than one thing.
+ * [LAW:composability]
+ */
+
+import type { UIControlHint } from '../../types';
+
+// =============================================================================
+// Neutral vocabulary
+// =============================================================================
+
+/**
+ * A reference to one edge in the graph the editor is showing, addressed by its
+ * endpoints rather than an era-specific edge id — the endpoints are what both a
+ * V1 lens (keyed by target port + source address) and a pillar route (keyed by
+ * the input slot it feeds) resolve against, so the neutral seam speaks the fact
+ * both providers actually key on. [FRAMING:representation]
+ */
+export interface EdgeRef {
+  readonly sourceBlockId: string;
+  readonly sourcePortId: string;
+  readonly targetBlockId: string;
+  readonly targetPortId: string;
+}
+
+/**
+ * One editable parameter of a decoration step, projected to the editor's neutral
+ * control vocabulary — the same `UIControlHint` every other inline control in the
+ * editor uses, so a decoration param and a block param render through identical
+ * widgets. The provider reads the current value from its era's model; the editor
+ * writes back through `EdgeDecorator.setParam`. [LAW:one-source-of-truth]
+ */
+export interface DecorationParam {
+  /** Stable within the step; the id handed back to `setParam`. */
+  readonly id: string;
+  /** Display label for the control. */
+  readonly label: string;
+  /** Current value (number | boolean | string | …), read from the era's model. */
+  readonly value: unknown;
+  /** Widget hint; absent falls back to type-directed widget selection. */
+  readonly hint?: UIControlHint;
+}
+
+/**
+ * One transform step decorating an edge: its chip presentation plus the params
+ * the in-place editor exposes. Self-describing — the editor paints the chip and
+ * renders the param controls without knowing whether it came from a V1 lens or a
+ * pillar transform block. [LAW:composability]
+ */
+export interface EdgeDecoration {
+  /** Stable within the edge's chain; the id handed back to `setParam`. */
+  readonly id: string;
+  /** Chip text (e.g. the transform's name). */
+  readonly label: string;
+  /** Chip color (any CSS color string). */
+  readonly color: string;
+  /** Chip hover tooltip. */
+  readonly tooltip: string;
+  /** Editable params, in display order; empty for a param-less transform. */
+  readonly params: readonly DecorationParam[];
+}
+
+// =============================================================================
+// EdgeDecorator interface
+// =============================================================================
+
+/**
+ * The editor-owned authority on one graph's edge transform chains. A provider
+ * resolves each edge to its era's chain internally; the editor passes only
+ * neutral endpoint refs and reads neutral steps. [LAW:one-way-deps]
+ */
+export interface EdgeDecorator {
+  /**
+   * The ordered transform chain decorating `edge`, source→target order, or an
+   * empty list when the edge carries none. The whole read half — the chips and
+   * the params both derive from this one call, so they can never disagree.
+   * [LAW:one-source-of-truth]
+   */
+  decorations(edge: EdgeRef): readonly EdgeDecoration[];
+
+  /**
+   * Retune one param of one step on `edge`. The era-neutral write: the provider
+   * routes it to its own store (V1 → `updateLensParams`, pillar → block config),
+   * so the editor performs no era-specific mutation. [LAW:effects-at-boundaries]
+   */
+  setParam(edge: EdgeRef, decorationId: string, paramId: string, value: unknown): void;
+}
+
+// =============================================================================
+// Empty provider
+// =============================================================================
+
+/**
+ * The decorator for an editor surface with no transform-chain concept — today,
+ * the composite editor, which edits a subgraph definition where value transforms
+ * are not authored. Making "no decorations here" an explicit provider value keeps
+ * it out of the edge renderer as a hidden `if (!decorator)` branch: the
+ * variability lives in which decorator a mount supplies, not in whether the
+ * renderer runs. [LAW:dataflow-not-control-flow] [LAW:no-silent-failure]
+ */
+export const noEdgeDecorator: EdgeDecorator = {
+  decorations: () => [],
+  setParam: () => {},
+};

--- a/src/ui/nativeEditor/NativeMatureGraphCanvas.tsx
+++ b/src/ui/nativeEditor/NativeMatureGraphCanvas.tsx
@@ -21,6 +21,7 @@ import { observer } from 'mobx-react-lite';
 import { useStores } from '../../stores';
 import { PillarPatchAdapter } from '../graphEditor/PillarPatchAdapter';
 import { SceneTypeOracle } from '../graphEditor/SceneTypeOracle';
+import { SceneEdgeDecorator } from '../graphEditor/SceneEdgeDecorator';
 import { GraphEditorCore } from '../graphEditor/GraphEditorCore';
 
 export const NativeMatureGraphCanvas: React.FC = observer(() => {
@@ -36,9 +37,14 @@ export const NativeMatureGraphCanvas: React.FC = observer(() => {
   // reports against — so the drag gate agrees with the compiler. [LAW:one-source-of-truth]
   const oracle = useMemo(() => new SceneTypeOracle(pillarPatch), [pillarPatch]);
 
+  // Edge decorations: the scene decorator traces each edge's pillar transform
+  // chain (Scale/Offset/Clamp) — the same chain the Modulation Table reads — so
+  // the mature canvas shows and edits it as edge chips. [LAW:one-source-of-truth]
+  const decorator = useMemo(() => new SceneEdgeDecorator(pillarPatch), [pillarPatch]);
+
   return (
     <div style={{ height: '100%', width: '100%' }}>
-      <GraphEditorCore adapter={adapter} oracle={oracle} />
+      <GraphEditorCore adapter={adapter} oracle={oracle} decorator={decorator} />
     </div>
   );
 });

--- a/src/ui/nativeEditor/modulationTable.ts
+++ b/src/ui/nativeEditor/modulationTable.ts
@@ -262,8 +262,13 @@ export function buildModulationTable(
  * unwired, or when the chain dangles at a transform whose own input is unwired (a
  * broken route the compiler surfaces as a diagnostic — the grid, which can only
  * place a route under a source column, shows nothing rather than a phantom source).
+ *
+ * Exported because it is the ONE trace of a pillar transform chain: the Modulation
+ * Table reads it here, and the editor's `SceneEdgeDecorator` reads it to project
+ * the same chain as edge chips. Both views therefore report identical chains from
+ * one implementation, never two that can drift. [LAW:one-source-of-truth]
  */
-function traceRoute(
+export function traceRoute(
   patch: PillarPatch,
   registry: SceneRegistry,
   inputBlockId: string,

--- a/src/ui/reactFlowEditor/OscillaEdge.tsx
+++ b/src/ui/reactFlowEditor/OscillaEdge.tsx
@@ -11,13 +11,12 @@ import { BaseEdge, EdgeLabelRenderer, getBezierPath, type EdgeProps } from 'reac
 import React, { useEffect, useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import type { OscillaEdgeData } from './nodes';
-import { getLensLabel } from './lensUtils';
-import { lensTargetsConnection } from './lensUtils';
 import { BasePopover, POPUP_SURFACE_STYLE, usePinPopoverState } from './BasePopover';
 import type { Diagnostic } from '../../diagnostics/types';
-import type { BlockId, PortId } from '../../types';
 import { useStores } from '../../stores';
-import { LensParamControls } from '../components/LensParamControls';
+import { useGraphEditor } from '../graphEditor/GraphEditorContext';
+import { DecorationParamControls } from '../graphEditor/DecorationParamControls';
+import type { EdgeRef } from '../graphEditor/edge-decorations';
 import { graphColors } from '../graphEditor/graph-tokens';
 import { useDebugMiniView, useDebugPortMiniView, type MiniViewData } from '../debug-viz/useDebugMiniView';
 import type { HistoryView } from '../debug-viz/types';
@@ -40,9 +39,9 @@ interface LensImpactPreviewProps {
   afterLabel: string;
 }
 
-interface LensPopoverContext {
-  lensId: string;
-  lensIndex: number;
+interface DecorationPopoverContext {
+  decorationId: string;
+  decorationIndex: number;
   targetPortId: string;
 }
 
@@ -296,9 +295,10 @@ export const OscillaEdge = observer(function OscillaEdge(
   const targetHandle = (props as { targetHandle?: string; targetHandleId?: string }).targetHandle
     ?? (props as { targetHandleId?: string }).targetHandleId
     ?? '';
-  const { selection, frontend, patch, debug } = useStores();
-  const lensPopover = usePinPopoverState<LensPopoverContext>({
-    isSame: (a, b) => a.lensId === b.lensId && a.targetPortId === b.targetPortId,
+  const { selection, frontend, debug } = useStores();
+  const { decorator } = useGraphEditor();
+  const decoPopover = usePinPopoverState<DecorationPopoverContext>({
+    isSame: (a, b) => a.decorationId === b.decorationId && a.targetPortId === b.targetPortId,
   });
 
   // Compute bezier path
@@ -322,27 +322,18 @@ export const OscillaEdge = observer(function OscillaEdge(
     strokeWidth: hasDiagnostics ? 2.5 : (style.strokeWidth ?? 2),
   };
 
-  const sourceDisplayName = patch.blocks.get(source as BlockId)?.displayName;
-
-  // [LAW:one-way-deps] OscillaEdge reads the V1 PatchStore directly here (as it
-  // already did for `sourceDisplayName`/`adapterCount`) — a pre-existing bypass.
-  // For pillar edges these lookups miss and the chips simply don't render. The
-  // edge-decoration seam (oscilla-editor-ux-8lsn.18) inverts this dependency by
-  // moving all V1 reads behind a neutral per-edge decoration provider; until
-  // then the neutral edge vocabulary deliberately does not carry V1 lenses.
-  const targetPortLenses = targetHandle
-    ? patch.blocks.get(target as BlockId)?.inputPorts.get(targetHandle as PortId)?.lenses
-    : undefined;
-
-  const edgeLenses = useMemo(
-    () =>
-      (targetPortLenses ?? []).filter((lens) =>
-        lensTargetsConnection(lens, source, sourceHandle ?? '', sourceDisplayName),
-      ),
-    [targetPortLenses, source, sourceHandle, sourceDisplayName],
-  );
-
-  const hasLenses = edgeLenses.length > 0;
+  // [LAW:one-way-deps] The former direct read of `patch.blocks…inputPorts…lenses`
+  // is inverted: an edge's transform chain now comes from the neutral per-mount
+  // `EdgeDecorator`, so this renderer holds no lens/era opinion and lights up for
+  // both boots (V1 lenses, pillar transform chains) through one code path.
+  const edgeRef: EdgeRef = {
+    sourceBlockId: source,
+    sourcePortId: sourceHandle,
+    targetBlockId: target,
+    targetPortId: targetHandle,
+  };
+  const decorations = decorator.decorations(edgeRef);
+  const hasDecorations = decorations.length > 0;
 
   const adapterCount = useMemo(() => {
     if (!targetHandle) return 0;
@@ -351,7 +342,7 @@ export const OscillaEdge = observer(function OscillaEdge(
     return provenance.chain.filter((step) => step.kind === 'adapter').length;
   }, [frontend, target, targetHandle]);
 
-  const hasTransforms = hasLenses || adapterCount > 0;
+  const hasTransforms = hasDecorations || adapterCount > 0;
 
   // Compute position for lens indicator (near target port)
   // Place it at 90% along the edge path, biased toward the target
@@ -366,18 +357,18 @@ export const OscillaEdge = observer(function OscillaEdge(
       .join('\n');
   } else if (hasTransforms) {
     const labels = [
-      ...edgeLenses.map((lens) => getLensLabel(lens.lensType)),
+      ...decorations.map((deco) => deco.label),
       ...(adapterCount > 0 ? [`Adapters x${adapterCount}`] : []),
     ];
     tooltipText = labels.join(', ');
   }
 
-  const lensContext = lensPopover.active?.data ?? null;
-  const activeLens = edgeLenses.find((lens) => lens.id === lensContext?.lensId) ?? null;
-  const activeTargetPortId = lensContext?.targetPortId ?? '';
+  const decoContext = decoPopover.active?.data ?? null;
+  const activeDecoration = decorations.find((deco) => deco.id === decoContext?.decorationId) ?? null;
+  const activeTargetPortId = decoContext?.targetPortId ?? '';
 
   useEffect(() => {
-    if (lensPopover.active) {
+    if (decoPopover.active) {
       debug.setHoveredLensEdge(id);
       return () => {
         if (debug.hoveredLensEdgeId === id) {
@@ -389,7 +380,7 @@ export const OscillaEdge = observer(function OscillaEdge(
       debug.setHoveredLensEdge(null);
     }
     return undefined;
-  }, [lensPopover.active, debug, id]);
+  }, [decoPopover.active, debug, id]);
 
   return (
     <>
@@ -421,26 +412,26 @@ export const OscillaEdge = observer(function OscillaEdge(
             }}
             title={tooltipText}
           >
-            {edgeLenses.map((lens, lensIndex) => (
+            {decorations.map((deco, decoIndex) => (
               <button
-                key={lens.id}
+                key={deco.id}
                 onMouseDown={(event) => {
                   event.stopPropagation();
                   debug.markSuppressNextEdgePopoverPin();
                 }}
                 onMouseEnter={(event) => {
                   if (!targetHandle) return;
-                  lensPopover.setHover({
+                  decoPopover.setHover({
                     data: {
-                      lensId: lens.id,
-                      lensIndex,
+                      decorationId: deco.id,
+                      decorationIndex: decoIndex,
                       targetPortId: targetHandle,
                     },
                     anchorPosition: { top: event.clientY + 12, left: event.clientX + 12 },
                   });
                 }}
                 onMouseLeave={() => {
-                  lensPopover.clearHover();
+                  decoPopover.clearHover();
                 }}
                 onClick={(event) => {
                   event.stopPropagation();
@@ -448,10 +439,10 @@ export const OscillaEdge = observer(function OscillaEdge(
                   if (!targetHandle) return;
                   const nextPosition = { top: event.clientY + 12, left: event.clientX + 12 };
                   // [LAW:single-enforcer] Click-pin capability is centralized in BasePopover; state remains local here.
-                  lensPopover.togglePinned({
+                  decoPopover.togglePinned({
                     data: {
-                      lensId: lens.id,
-                      lensIndex,
+                      decorationId: deco.id,
+                      decorationIndex: decoIndex,
                       targetPortId: targetHandle,
                     },
                     anchorPosition: nextPosition,
@@ -461,8 +452,8 @@ export const OscillaEdge = observer(function OscillaEdge(
                   minHeight: 26,
                   minWidth: 74,
                   borderRadius: 13,
-                  background: graphColors.lensBadge,
-                  border: '1px solid #d97706',
+                  background: deco.color,
+                  border: '1px solid rgba(0,0,0,0.35)',
                   fontSize: 10,
                   fontWeight: 700,
                   color: '#111',
@@ -477,9 +468,9 @@ export const OscillaEdge = observer(function OscillaEdge(
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
                 }}
-                title={`${getLensLabel(lens.lensType)} (click: preview + edit)`}
+                title={`${deco.tooltip} (click: preview + edit)`}
               >
-                {getLensLabel(lens.lensType)}
+                {deco.label}
               </button>
             ))}
 
@@ -518,11 +509,11 @@ export const OscillaEdge = observer(function OscillaEdge(
       )}
 
       <BasePopover
-        open={Boolean(lensPopover.active && activeLens && activeTargetPortId)}
-        anchorPosition={lensPopover.active?.anchorPosition ?? null}
-        interactive={lensPopover.interactive}
+        open={Boolean(decoPopover.active && activeDecoration && activeTargetPortId)}
+        anchorPosition={decoPopover.active?.anchorPosition ?? null}
+        interactive={decoPopover.interactive}
         onClose={() => {
-          lensPopover.closeAll();
+          decoPopover.closeAll();
           debug.setHoveredLensEdge(null);
         }}
         paperStyle={{
@@ -532,7 +523,7 @@ export const OscillaEdge = observer(function OscillaEdge(
           padding: 14,
         }}
       >
-        {activeLens && activeTargetPortId && (
+        {activeDecoration && activeTargetPortId && (
           <div
             style={{
               display: 'flex',
@@ -541,7 +532,7 @@ export const OscillaEdge = observer(function OscillaEdge(
             }}
           >
             <div style={{ fontSize: 12, fontWeight: 700, marginBottom: 8 }}>
-              Lens: {getLensLabel(activeLens.lensType)}
+              Transform: {activeDecoration.label}
             </div>
 
             <div
@@ -553,23 +544,24 @@ export const OscillaEdge = observer(function OscillaEdge(
               }}
             >
               <LensImpactPreview
-                beforeEdgeId={lensContext?.lensIndex === 0 ? id : null}
-                beforeBlockId={lensContext?.lensIndex === 0 ? null : target}
-                beforePortId={lensContext?.lensIndex === 0 ? null : activeTargetPortId}
+                beforeEdgeId={decoContext?.decorationIndex === 0 ? id : null}
+                beforeBlockId={decoContext?.decorationIndex === 0 ? null : target}
+                beforePortId={decoContext?.decorationIndex === 0 ? null : activeTargetPortId}
                 afterBlockId={target}
                 afterPortId={activeTargetPortId}
-                beforeLabel={lensContext?.lensIndex === 0
+                beforeLabel={decoContext?.decorationIndex === 0
                   ? `before · ${source}.${sourceHandle}`
                   : `before · ${target}.${activeTargetPortId}`}
                 afterLabel={`after · ${target}.${activeTargetPortId}`}
               />
             </div>
 
-            {lensPopover.mode === 'pinned' && (
-              <LensParamControls
-                lens={activeLens}
-                targetBlockId={target as BlockId}
-                targetPortId={activeTargetPortId}
+            {decoPopover.mode === 'pinned' && (
+              <DecorationParamControls
+                params={activeDecoration.params}
+                onChange={(paramId, value) =>
+                  decorator.setParam(edgeRef, activeDecoration.id, paramId, value)
+                }
                 compact
               />
             )}

--- a/src/ui/reactFlowEditor/ReactFlowEditor.tsx
+++ b/src/ui/reactFlowEditor/ReactFlowEditor.tsx
@@ -25,6 +25,7 @@ import { GraphEditorCore, type GraphEditorCoreHandle } from '../graphEditor/Grap
 import type { PortContextMenuRequest } from '../graphEditor/GraphEditorContext';
 import { PatchStoreAdapter } from '../graphEditor/PatchStoreAdapter';
 import { V1TypeOracle } from '../graphEditor/V1TypeOracle';
+import { V1EdgeDecorator } from '../graphEditor/V1EdgeDecorator';
 import { BlockContextMenu } from './menus/BlockContextMenu';
 import { EdgeContextMenu } from './menus/EdgeContextMenu';
 import { PortContextMenu } from './menus/PortContextMenu';
@@ -146,6 +147,11 @@ const ReactFlowEditorInner: React.FC<ReactFlowEditorProps> = observer(({
     () => new V1TypeOracle(patchStore.patch, frontend),
     [patchStore.patch, frontend]
   );
+
+  // The V1 edge-decoration authority: wraps the port-attached lens records the
+  // edge chips + popover editor used to read directly, so the renderer goes
+  // through the seam. [LAW:one-source-of-truth]
+  const decorator = useMemo(() => new V1EdgeDecorator(patchStore), [patchStore]);
 
   // Port context menu handler - called from UnifiedNode via GraphEditorContext
   const handlePortContextMenu = useCallback(
@@ -355,6 +361,7 @@ const ReactFlowEditorInner: React.FC<ReactFlowEditorProps> = observer(({
           diagnostics={diagnostics}
           debug={debug}
           oracle={oracle}
+          decorator={decorator}
           onNodeContextMenu={handleNodeContextMenu}
           onEdgeContextMenu={handleEdgeContextMenu}
           onPortContextMenu={handlePortContextMenu}


### PR DESCRIPTION
## What

The next seam in the editor-parity epic (`oscilla-editor-ux-8lsn`), following the same pattern as the TypeOracle/BlockCatalog seams. An edge's **transform chain** is one editor-facing concept realized two utterly different ways — V1 stores `LensAttachment` records on the target input port; the pillar model has no edge field and reconstructs the chain by tracing back through `'transform'`-category blocks — so it becomes **one neutral seam with two providers**. `[LAW:one-type-per-behavior]`

## Shape

- **`edge-decorations.ts`** — neutral `EdgeDecorator` (`decorations(edge)` + `setParam`) + `noEdgeDecorator` (explicit empty provider). Scope is deliberately *describe + retune only*; chain **growth** stays with scene-adapters, the edge inspector with `.10`, block-param-control neutrality with `.23`. `[LAW:decomposition]`
- **`V1EdgeDecorator`** wraps the port-attached lenses (`lensTargetsConnection`/`getLensLabel`/`updateLensParams`). **`SceneEdgeDecorator`** reuses `traceRoute` (now exported — one trace impl shared with the Modulation Table) + `updateConfig`. `[LAW:one-source-of-truth]`
- **`OscillaEdge`** — the single edge type `GraphEditorCore` registers for **both boots** — reseated off the `patch.blocks…inputPorts…lenses` bypass onto the neutral decorator via context: chips + interactive param retune, both eras. The impact-preview interaction is preserved (driven by decoration index). `DecorationParamControls` lifts the `LensParamControls` widget dispatch to the neutral `DecorationParam` vocab.
- `decorator` threaded as a **required** `GraphEditorCore` prop → context; the three mounts wire V1 / scene / empty, mirroring the `oracle` seam.

## Closes the pillar gap

Pillar transform chains never rendered as edge chips before. Now they do — verified **live**: authoring `Constant → Scale → WaveOffset.amplitude` produced a `Scale` chip on the mature canvas (`rgb(63,182,196)` = the `SceneEdgeDecorator` color) through the neutral seam.

## Tests / verification

- **conformance** (contract + case-per-era + negative control + empty unit)
- **parity** — decorator chain `==` era authority (V1 lens filter / pillar mod-table route) — the acceptance gate
- **seam-gate** — `OscillaEdge` imports no V1 lens surface
- Full suite green (**2613 passed**); typecheck + lint clean; both boots render without errors.

https://claude.ai/code/session_01EGosPatPPdVDtmaYt9RXMR