### PR TITLE
feat(editor-ux 8lsn.21): undo/redo as one era-neutral history authority (both boots)

### DIFF
--- a/src/stores/GraphHistoryStore.ts
+++ b/src/stores/GraphHistoryStore.ts
@@ -73,14 +73,12 @@ export class GraphHistoryStore {
   private key: object | null = null;
   /** The current committed state — the checkpoint that would be pushed on next edit. */
   private baseline: GraphHistorySnapshot | null = null;
-  /** True while applying a restore, so the change-token reaction does not re-record it. */
-  private restoring = false;
   private disposeReaction: (() => void) | null = null;
 
   constructor() {
     makeObservable<
       GraphHistoryStore,
-      'past' | 'future' | 'onTokenChanged' | 'applyRestore'
+      'past' | 'future' | 'onTokenChanged' | 'applyRestore' | 'armReaction'
     >(this, {
       past: observable.shallow,
       future: observable.shallow,
@@ -88,10 +86,12 @@ export class GraphHistoryStore {
       canRedo: computed,
       bind: action,
       unbind: action,
+      dispose: action,
       undo: action,
       redo: action,
       onTokenChanged: action,
       applyRestore: action,
+      armReaction: action,
     });
   }
 
@@ -119,11 +119,7 @@ export class GraphHistoryStore {
 
     this.source = source;
     this.baseline = source.captureHistorySnapshot();
-    this.disposeReaction = reaction(
-      () => source.historyToken,
-      () => this.onTokenChanged(),
-      { equals: comparer.structural },
-    );
+    this.armReaction();
   }
 
   /**
@@ -137,6 +133,32 @@ export class GraphHistoryStore {
     this.disposeReaction = null;
     this.source = null;
     this.baseline = null;
+  }
+
+  /**
+   * Tear down for good (RootStore disposal / HMR): drop the reaction and detach the
+   * source so no watcher outlives the store. [LAW:no-ambient-temporal-coupling]
+   */
+  dispose(): void {
+    this.disposeReaction?.();
+    this.disposeReaction = null;
+    this.source = null;
+    this.baseline = null;
+  }
+
+  /** (Re)create the change-token reaction on the current source. */
+  private armReaction(): void {
+    this.disposeReaction?.();
+    const source = this.source;
+    if (source === null) {
+      this.disposeReaction = null;
+      return;
+    }
+    this.disposeReaction = reaction(
+      () => source.historyToken,
+      () => this.onTokenChanged(),
+      { equals: comparer.structural },
+    );
   }
 
   undo(): void {
@@ -161,14 +183,6 @@ export class GraphHistoryStore {
 
   /** A user edit landed in the model: the old baseline becomes history, redo is void. */
   private onTokenChanged(): void {
-    // MobX flushes this reaction at the end of the outermost action — for a restore
-    // that is AFTER undo()/redo() returns — so the flag cannot be reset synchronously
-    // around the restore. Instead the restore's own token change consumes it here, so
-    // exactly one post-restore change is swallowed and never recorded as a fresh edit.
-    if (this.restoring) {
-      this.restoring = false;
-      return;
-    }
     if (this.source === null || this.baseline === null) return;
     this.past.push(this.baseline);
     this.future = [];
@@ -176,15 +190,18 @@ export class GraphHistoryStore {
   }
 
   private applyRestore(snapshot: GraphHistorySnapshot): void {
-    // Every restore bumps the source's revision, so it produces exactly one token
-    // change for onTokenChanged to consume; the flag stays armed until then.
-    this.restoring = true;
+    // Suspend change observation across the restore so it is never seen as a fresh
+    // edit — no dependence on the restore happening to move the token, no flag that
+    // could stay armed and silently swallow the next real edit. Re-arm in `finally`
+    // on the current token so a throwing restore still leaves a live watcher.
+    // [LAW:no-ambient-temporal-coupling] [LAW:no-silent-failure]
+    this.disposeReaction?.();
+    this.disposeReaction = null;
     try {
       this.source!.restoreHistorySnapshot(snapshot);
       this.baseline = snapshot;
-    } catch (error) {
-      this.restoring = false;
-      throw error;
+    } finally {
+      this.armReaction();
     }
   }
 }

--- a/src/stores/GraphHistoryStore.ts
+++ b/src/stores/GraphHistoryStore.ts
@@ -1,0 +1,184 @@
+/**
+ * src/stores/GraphHistoryStore.ts
+ *
+ * The single undo/redo authority for the graph editor, era-neutral.
+ *
+ * [LAW:single-enforcer] [LAW:one-source-of-truth] History is a representation of
+ *   the sequence of authored-graph states. The only robust anchor is the authored
+ *   model itself — NOT any one of the many UI write-paths (canvas, context menus,
+ *   inspector, modulation table, hotkeys) that all converge on it. So this store
+ *   OBSERVES the bound source's authored-state change-token and checkpoints a whole
+ *   snapshot whenever it changes. Any edit through any path is captured; nothing can
+ *   bypass the one authority the way it could if we intercepted a privileged method.
+ *
+ * [LAW:dataflow-not-control-flow] [LAW:no-mode-explosion] One code path for every
+ *   mutation kind: snapshot before, restore on undo/redo. No per-kind inverse logic,
+ *   no branch on "which mutation happened" — the variability lives in WHICH snapshot,
+ *   a value, never in whether-we-record.
+ *
+ * [LAW:effects-at-boundaries] This store owns only the neutral stacks. Capturing and
+ *   restoring the era-specific model state is the bound GraphSnapshotSource's job,
+ *   performed at its own store boundary; the snapshot crosses this seam opaque.
+ *
+ * Ownership lives in RootStore, so the history survives editor-panel remounts
+ * (dockview rearrangement recreates the adapter, not this store). [LAW:no-ambient-temporal-coupling]
+ */
+
+import { makeObservable, observable, action, computed, reaction, comparer } from 'mobx';
+
+/**
+ * An opaque, structurally-complete snapshot of one era's authored graph (+ layout).
+ * Produced and consumed only by the SAME GraphSnapshotSource; this store treats it
+ * as a black box and never inspects it. [FRAMING:representation]
+ */
+declare const graphHistorySnapshotBrand: unique symbol;
+export interface GraphHistorySnapshot {
+  readonly [graphHistorySnapshotBrand]: true;
+}
+
+/**
+ * The capability an editor's data adapter exposes so its authored state can be
+ * checkpointed and restored. Neutral: the store depends on this interface, the
+ * era-specific adapter (UI layer) implements it and binds itself. [LAW:one-way-deps]
+ */
+export interface GraphSnapshotSource {
+  /**
+   * An observable change-token that takes a NEW (structurally-unequal) value iff the
+   * authored graph or its layout changes. The history store reacts to it to know when
+   * to checkpoint; it compares tokens structurally and never interprets the value.
+   * Derived, compile-only churn (ScenePlan, diagnostics) MUST NOT move this token —
+   * only authored edits do.
+   */
+  readonly historyToken: unknown;
+
+  /** Capture the current authored state as an opaque snapshot. */
+  captureHistorySnapshot(): GraphHistorySnapshot;
+
+  /**
+   * Restore a previously-captured snapshot as the current authored state. For the
+   * pillar era this is an ordinary model replacement, so the live preview hot-swaps
+   * through the normal recompile — continuity rules apply, no special undo path.
+   */
+  restoreHistorySnapshot(snapshot: GraphHistorySnapshot): void;
+}
+
+export class GraphHistoryStore {
+  /** Prior states, most-recent last. Observable so canUndo drives UI affordances. */
+  private past: GraphHistorySnapshot[] = [];
+  /** Undone states available to redo, most-recent last. */
+  private future: GraphHistorySnapshot[] = [];
+
+  /** The currently-bound editor source, and the model identity it belongs to. */
+  private source: GraphSnapshotSource | null = null;
+  private key: object | null = null;
+  /** The current committed state — the checkpoint that would be pushed on next edit. */
+  private baseline: GraphHistorySnapshot | null = null;
+  /** True while applying a restore, so the change-token reaction does not re-record it. */
+  private restoring = false;
+  private disposeReaction: (() => void) | null = null;
+
+  constructor() {
+    makeObservable<
+      GraphHistoryStore,
+      'past' | 'future' | 'onTokenChanged' | 'applyRestore'
+    >(this, {
+      past: observable.shallow,
+      future: observable.shallow,
+      canUndo: computed,
+      canRedo: computed,
+      bind: action,
+      unbind: action,
+      undo: action,
+      redo: action,
+      onTokenChanged: action,
+      applyRestore: action,
+    });
+  }
+
+  get canUndo(): boolean {
+    return this.past.length > 0;
+  }
+
+  get canRedo(): boolean {
+    return this.future.length > 0;
+  }
+
+  /**
+   * Bind the active editor's source. Keyed on the underlying model identity: the same
+   * model (a remounted panel over the same store) keeps its history; a different model
+   * starts fresh, so a restore can never target a source that cannot honor it.
+   */
+  bind(source: GraphSnapshotSource, key: object): void {
+    this.disposeReaction?.();
+
+    if (key !== this.key) {
+      this.past = [];
+      this.future = [];
+      this.key = key;
+    }
+
+    this.source = source;
+    this.baseline = source.captureHistorySnapshot();
+    this.disposeReaction = reaction(
+      () => source.historyToken,
+      () => this.onTokenChanged(),
+      { equals: comparer.structural },
+    );
+  }
+
+  /**
+   * Unbind a source on editor teardown. A no-op if a newer editor already rebound,
+   * so a late unmount cannot detach the live source. The stacks are kept so history
+   * survives the remount. [LAW:no-ambient-temporal-coupling]
+   */
+  unbind(source: GraphSnapshotSource): void {
+    if (this.source !== source) return;
+    this.disposeReaction?.();
+    this.disposeReaction = null;
+    this.source = null;
+    this.baseline = null;
+  }
+
+  undo(): void {
+    if (this.source === null || this.baseline === null || this.past.length === 0) return;
+    const previous = this.past.pop() as GraphHistorySnapshot;
+    this.future.push(this.baseline);
+    this.applyRestore(previous);
+  }
+
+  redo(): void {
+    if (this.source === null || this.baseline === null || this.future.length === 0) return;
+    const next = this.future.pop() as GraphHistorySnapshot;
+    this.past.push(this.baseline);
+    this.applyRestore(next);
+  }
+
+  /** A user edit landed in the model: the old baseline becomes history, redo is void. */
+  private onTokenChanged(): void {
+    // MobX flushes this reaction at the end of the outermost action — for a restore
+    // that is AFTER undo()/redo() returns — so the flag cannot be reset synchronously
+    // around the restore. Instead the restore's own token change consumes it here, so
+    // exactly one post-restore change is swallowed and never recorded as a fresh edit.
+    if (this.restoring) {
+      this.restoring = false;
+      return;
+    }
+    if (this.source === null || this.baseline === null) return;
+    this.past.push(this.baseline);
+    this.future = [];
+    this.baseline = this.source.captureHistorySnapshot();
+  }
+
+  private applyRestore(snapshot: GraphHistorySnapshot): void {
+    // Every restore bumps the source's revision, so it produces exactly one token
+    // change for onTokenChanged to consume; the flag stays armed until then.
+    this.restoring = true;
+    try {
+      this.source!.restoreHistorySnapshot(snapshot);
+      this.baseline = snapshot;
+    } catch (error) {
+      this.restoring = false;
+      throw error;
+    }
+  }
+}

--- a/src/stores/GraphHistoryStore.ts
+++ b/src/stores/GraphHistoryStore.ts
@@ -141,16 +141,22 @@ export class GraphHistoryStore {
 
   undo(): void {
     if (this.source === null || this.baseline === null || this.past.length === 0) return;
-    const previous = this.past.pop() as GraphHistorySnapshot;
-    this.future.push(this.baseline);
+    // Peek, restore, THEN mutate the stacks: a throwing restore leaves past/future and
+    // baseline untouched rather than losing the popped entry. [LAW:no-silent-failure]
+    const oldBaseline = this.baseline;
+    const previous = this.past[this.past.length - 1];
     this.applyRestore(previous);
+    this.past.pop();
+    this.future.push(oldBaseline);
   }
 
   redo(): void {
     if (this.source === null || this.baseline === null || this.future.length === 0) return;
-    const next = this.future.pop() as GraphHistorySnapshot;
-    this.past.push(this.baseline);
+    const oldBaseline = this.baseline;
+    const next = this.future[this.future.length - 1];
     this.applyRestore(next);
+    this.future.pop();
+    this.past.push(oldBaseline);
   }
 
   /** A user edit landed in the model: the old baseline becomes history, redo is void. */

--- a/src/stores/LayoutStore.ts
+++ b/src/stores/LayoutStore.ts
@@ -41,21 +41,30 @@ export class LayoutStore {
   }
 
   /**
-   * Sets position for a single node.
+   * Sets position for a single node. Bumps `revision` only on a real coordinate
+   * change, so a re-set to the same spot mints no spurious undo checkpoint.
+   * [LAW:dataflow-not-control-flow]
    */
   setPosition(blockId: BlockId, pos: NodePosition): void {
+    const prev = this.positions.get(blockId);
+    if (prev && prev.x === pos.x && prev.y === pos.y) return;
     this.positions.set(blockId, pos);
     this.revision++;
   }
 
   /**
-   * Bulk-sets positions (e.g., after ELK layout).
+   * Bulk-sets positions (e.g., after ELK layout). Bumps `revision` once iff at least
+   * one coordinate actually changed. [LAW:dataflow-not-control-flow]
    */
   setPositions(map: ReadonlyMap<BlockId, NodePosition>): void {
+    let changed = false;
     for (const [id, pos] of map) {
+      const prev = this.positions.get(id);
+      if (prev && prev.x === pos.x && prev.y === pos.y) continue;
       this.positions.set(id, pos);
+      changed = true;
     }
-    this.revision++;
+    if (changed) this.revision++;
   }
 
   /**
@@ -66,30 +75,35 @@ export class LayoutStore {
   }
 
   /**
-   * Removes position for a deleted node.
+   * Removes position for a deleted node. Bumps `revision` only if a position existed.
+   * [LAW:dataflow-not-control-flow]
    */
   removePosition(blockId: BlockId): void {
-    this.positions.delete(blockId);
-    this.revision++;
+    if (this.positions.delete(blockId)) this.revision++;
   }
 
   /**
    * Remove positions for blocks no longer in the graph.
-   * Call after block removal to prevent unbounded growth.
+   * Call after block removal to prevent unbounded growth. Bumps `revision` only if
+   * an orphan was actually removed. [LAW:dataflow-not-control-flow]
    */
   pruneOrphans(activeBlockIds: ReadonlySet<BlockId>): void {
+    let changed = false;
     for (const id of this.positions.keys()) {
       if (!activeBlockIds.has(id)) {
         this.positions.delete(id);
+        changed = true;
       }
     }
-    this.revision++;
+    if (changed) this.revision++;
   }
 
   /**
-   * Clears all stored positions (e.g., on patch load).
+   * Clears all stored positions (e.g., on patch load). Bumps `revision` only if there
+   * was anything to clear. [LAW:dataflow-not-control-flow]
    */
   clear(): void {
+    if (this.positions.size === 0) return;
     this.positions.clear();
     this.revision++;
   }

--- a/src/stores/LayoutStore.ts
+++ b/src/stores/LayoutStore.ts
@@ -20,9 +20,18 @@ export interface NodePosition {
 export class LayoutStore {
   positions: Map<BlockId, NodePosition> = new Map();
 
+  /**
+   * Monotonic counter bumped on every position mutation. Layout is UI state the
+   * undo history must track, but it lives here rather than in the patch — so this
+   * counter is the cheap observable the history change-token folds in, letting a
+   * drag-end be one checkpoint without deep-observing the map. [LAW:one-source-of-truth]
+   */
+  revision = 0;
+
   constructor() {
     makeObservable(this, {
       positions: observable,
+      revision: observable,
       setPosition: action,
       setPositions: action,
       removePosition: action,
@@ -36,6 +45,7 @@ export class LayoutStore {
    */
   setPosition(blockId: BlockId, pos: NodePosition): void {
     this.positions.set(blockId, pos);
+    this.revision++;
   }
 
   /**
@@ -45,6 +55,7 @@ export class LayoutStore {
     for (const [id, pos] of map) {
       this.positions.set(id, pos);
     }
+    this.revision++;
   }
 
   /**
@@ -59,6 +70,7 @@ export class LayoutStore {
    */
   removePosition(blockId: BlockId): void {
     this.positions.delete(blockId);
+    this.revision++;
   }
 
   /**
@@ -71,6 +83,7 @@ export class LayoutStore {
         this.positions.delete(id);
       }
     }
+    this.revision++;
   }
 
   /**
@@ -78,5 +91,6 @@ export class LayoutStore {
    */
   clear(): void {
     this.positions.clear();
+    this.revision++;
   }
 }

--- a/src/stores/PatchStore.ts
+++ b/src/stores/PatchStore.ts
@@ -426,6 +426,16 @@ export class PatchStore {
   // =============================================================================
 
   /**
+   * Monotonic revision bumped on every authored mutation to `_data` (structure,
+   * params, ports, lenses). Unlike the frontend's compile revision, this moves only
+   * on an actual edit — so the undo history can key its change-token on authored
+   * intent, never on derived compile churn. [LAW:one-source-of-truth]
+   */
+  get dataVersion(): number {
+    return this._dataVersion;
+  }
+
+  /**
    * Returns an immutable view of the patch.
    * This is the primary interface for reading patch data.
    *

--- a/src/stores/PillarPatchStore.ts
+++ b/src/stores/PillarPatchStore.ts
@@ -17,7 +17,7 @@
  *   data the runtime and UI read, not a branch this store takes.
  */
 
-import { makeAutoObservable, reaction } from 'mobx';
+import { makeAutoObservable, reaction, toJS } from 'mobx';
 
 import { makeGridOfSquaresPatch } from '../pillars/fixtures/grid-of-squares';
 import type { PillarBlock, PillarEdge, PillarPatch } from '../pillars/types';
@@ -37,6 +37,17 @@ import {
   type SceneValidation,
 } from '../pillars/scene';
 
+/**
+ * The full mutable authoring state of a PillarPatchStore, deep-cloned. Includes the
+ * id counter so a restore-then-edit can never remint an id a redo would reintroduce.
+ * Opaque to the undo history; captured and restored only by this store.
+ */
+export interface PillarPatchState {
+  readonly blocks: PillarBlock[];
+  readonly edges: PillarEdge[];
+  readonly idCounter: number;
+}
+
 export class PillarPatchStore {
   /** The scene block catalog the palette, inspector, and validation all read. */
   readonly registry: SceneRegistry = buildSceneRegistry(ALL_SCENE_BLOCKS);
@@ -44,6 +55,13 @@ export class PillarPatchStore {
   private blocks: PillarBlock[];
   private edges: PillarEdge[];
   private idCounter = 0;
+
+  /**
+   * Monotonic counter bumped on every authored mutation. The undo history keys its
+   * change-token on this, so a checkpoint fires on the edit itself and never on the
+   * derived `compiled`/`validation` recompute. [LAW:one-source-of-truth]
+   */
+  revision = 0;
 
   constructor(seed: PillarPatch = makeGridOfSquaresPatch()) {
     this.blocks = [...seed.blocks];
@@ -108,6 +126,7 @@ export class PillarPatchStore {
         config: defaultSceneConfig(def.catalog),
       },
     ];
+    this.revision++;
     return id;
   }
 
@@ -115,6 +134,7 @@ export class PillarPatchStore {
     this.blocks = this.blocks.filter((b) => b.id !== id);
     // Edges touching a removed block cannot resolve; drop them with the block.
     this.edges = this.edges.filter((e) => e.source !== id && e.target !== id);
+    this.revision++;
   }
 
   /**
@@ -126,6 +146,36 @@ export class PillarPatchStore {
     this.blocks = this.blocks.map((b) =>
       b.id === blockId ? { ...b, config: { ...b.config, [key]: value } } : b,
     );
+    this.revision++;
+  }
+
+  // ── History (undo/redo) ───────────────────────────────────────────────────
+
+  /**
+   * Capture the full authoring state as an independent deep copy, so later edits
+   * cannot mutate a held snapshot. [LAW:effects-at-boundaries]
+   */
+  captureState(): PillarPatchState {
+    // toJS strips the MobX observable wrappers to a plain, independent deep copy;
+    // later edits cannot mutate a held snapshot. [LAW:effects-at-boundaries]
+    return {
+      blocks: toJS(this.blocks),
+      edges: toJS(this.edges),
+      idCounter: this.idCounter,
+    };
+  }
+
+  /**
+   * Replace the authoring state with a previously-captured snapshot. Blocks/edges
+   * are copied again so the store never shares structure with the history stacks.
+   * The derived `compiled` ScenePlan recomputes and the live preview hot-swaps
+   * through the normal recompile — no special undo path. [LAW:one-source-of-truth]
+   */
+  restoreState(state: PillarPatchState): void {
+    this.blocks = structuredClone(state.blocks);
+    this.edges = structuredClone(state.edges);
+    this.idCounter = state.idCounter;
+    this.revision++;
   }
 
   // ── Edge operations ───────────────────────────────────────────────────────
@@ -159,11 +209,13 @@ export class PillarPatchStore {
       ),
       { id, source, target, inputSlot, role: edgeRoleForPort(port) },
     ];
+    this.revision++;
     return id;
   }
 
   removeEdge(id: string): void {
     this.edges = this.edges.filter((e) => e.id !== id);
+    this.revision++;
   }
 
   // ── Persistence ───────────────────────────────────────────────────────────

--- a/src/stores/RootStore.ts
+++ b/src/stores/RootStore.ts
@@ -29,6 +29,7 @@ import { DemoStore } from './DemoStore';
 import { HelpStore } from './HelpStore';
 import { ExpressionEditorStore } from './ExpressionEditorStore';
 import { PillarPatchStore } from './PillarPatchStore';
+import { GraphHistoryStore } from './GraphHistoryStore';
 import { executeAction, type ActionResult } from '../diagnostics/actionExecutor';
 import type { DiagnosticAction } from '../diagnostics/types';
 import {
@@ -149,6 +150,8 @@ export class RootStore {
   readonly expressionEditor: ExpressionEditorStore;
   // The authored native (ScenePlan-path) patch — SSOT for the native graph editor.
   readonly pillarPatch: PillarPatchStore;
+  // Single undo/redo authority; the active editor binds its adapter as the source.
+  readonly history: GraphHistoryStore;
 
   // Patch revision tracking (for diagnostics)
   private patchRevision: number = 0;
@@ -204,6 +207,9 @@ export class RootStore {
 
     // Create LayoutStore (node positions - UI state, not topology)
     this.layout = new LayoutStore();
+
+    // Single undo/redo authority (bound to the active editor's adapter at mount).
+    this.history = new GraphHistoryStore();
 
     // Create CameraStore (3D preview state - viewer only)
     this.camera = new CameraStore();

--- a/src/stores/RootStore.ts
+++ b/src/stores/RootStore.ts
@@ -373,6 +373,9 @@ export class RootStore {
     // Dispose PillarPatchStore persistence
     this.pillarPatch.stopPersistence();
 
+    // Dispose undo/redo history reaction
+    this.history.dispose();
+
     // Dispose DiagnosticHub
     this.diagnosticHub.dispose();
 

--- a/src/stores/__tests__/GraphHistoryStore.test.ts
+++ b/src/stores/__tests__/GraphHistoryStore.test.ts
@@ -1,0 +1,186 @@
+/**
+ * GraphHistoryStore — the single, era-neutral undo/redo authority.
+ *
+ * The same store drives both eras through the neutral GraphSnapshotSource, so these
+ * tests are the contract: undo/redo restores authored state across every mutation
+ * kind, redo is voided by a new edit, and the stacks survive a panel remount (rebind
+ * with the same model key). The pillar continuity case asserts that undo yields a
+ * frame-identical recompile — the "equivalent reinstall" the continuity epic gates on.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { FrontendResultStore } from '../FrontendResultStore';
+import { LayoutStore } from '../LayoutStore';
+import { PatchStore } from '../PatchStore';
+import { PillarPatchStore } from '../PillarPatchStore';
+import { GraphHistoryStore } from '../GraphHistoryStore';
+import { PatchStoreAdapter } from '../../ui/graphEditor/PatchStoreAdapter';
+import { PillarPatchAdapter } from '../../ui/graphEditor/PillarPatchAdapter';
+import type { BlockId } from '../../types';
+
+function makeV1() {
+  const patch = new PatchStore();
+  const layout = new LayoutStore();
+  const frontend = new FrontendResultStore();
+  const adapter = new PatchStoreAdapter(patch, layout, frontend);
+  return { patch, layout, adapter };
+}
+
+function makePillar() {
+  const store = new PillarPatchStore();
+  const adapter = new PillarPatchAdapter(store);
+  return { store, adapter };
+}
+
+describe('GraphHistoryStore', () => {
+  it('records nothing until the first edit', () => {
+    const history = new GraphHistoryStore();
+    const { adapter, patch } = makeV1();
+    history.bind(adapter, patch);
+
+    expect(history.canUndo).toBe(false);
+    expect(history.canRedo).toBe(false);
+  });
+
+  it('V1: undo/redo restores state across every adapter mutation kind', () => {
+    const history = new GraphHistoryStore();
+    const { adapter, patch, layout } = makeV1();
+    history.bind(adapter, patch);
+
+    // addBlock
+    const id = adapter.addBlock('Const', { x: 10, y: 20 });
+    expect(patch.blocks.size).toBe(1);
+
+    // setBlockPosition
+    adapter.setBlockPosition(id, { x: 99, y: 99 });
+    expect(layout.getPosition(id)).toEqual({ x: 99, y: 99 });
+
+    // updateBlockParams
+    adapter.updateBlockParams(id, { value: 7 });
+    expect(patch.blocks.get(id)?.params.value).toBe(7);
+
+    // updateBlockDisplayName
+    expect(adapter.updateBlockDisplayName(id, 'MyConst').error).toBeUndefined();
+    expect(patch.blocks.get(id)?.displayName).toBe('MyConst');
+
+    // Undo walks backward through each checkpoint.
+    history.undo(); // undo rename
+    expect(patch.blocks.get(id)?.displayName).not.toBe('MyConst');
+    history.undo(); // undo param
+    expect(patch.blocks.get(id)?.params.value).not.toBe(7);
+    history.undo(); // undo move
+    expect(layout.getPosition(id)).toEqual({ x: 10, y: 20 });
+    history.undo(); // undo add
+    expect(patch.blocks.size).toBe(0);
+    expect(history.canUndo).toBe(false);
+
+    // Redo replays forward to the final state.
+    history.redo();
+    history.redo();
+    history.redo();
+    history.redo();
+    expect(patch.blocks.size).toBe(1);
+    expect(patch.blocks.get(id)?.params.value).toBe(7);
+    expect(patch.blocks.get(id)?.displayName).toBe('MyConst');
+    expect(layout.getPosition(id)).toEqual({ x: 99, y: 99 });
+    expect(history.canRedo).toBe(false);
+  });
+
+  it('Pillar: undo/redo restores blocks, config, layout, and edges', () => {
+    const history = new GraphHistoryStore();
+    const { adapter, store } = makePillar();
+    history.bind(adapter, store);
+
+    const edgeCountBefore = store.patch.edges.length;
+    const blockCountBefore = store.patch.blocks.length;
+    const firstEdgeId = store.patch.edges[0].id;
+
+    // removeEdge
+    adapter.removeEdge(firstEdgeId);
+    expect(store.patch.edges.length).toBe(edgeCountBefore - 1);
+
+    // addBlock + config + position
+    const id = adapter.addBlock('ColorCycle', { x: 5, y: 5 });
+    expect(store.patch.blocks.length).toBe(blockCountBefore + 1);
+    adapter.updateBlockParams(id, { cycleSpeed: 0.9 });
+    expect(store.patch.blocks.find((b) => b.id === id)?.config.cycleSpeed).toBe(0.9);
+
+    // Undo everything.
+    history.undo(); // undo config
+    expect(store.patch.blocks.find((b) => b.id === id)?.config.cycleSpeed).not.toBe(0.9);
+    history.undo(); // undo addBlock
+    expect(store.patch.blocks.length).toBe(blockCountBefore);
+    history.undo(); // undo removeEdge
+    expect(store.patch.edges.length).toBe(edgeCountBefore);
+    expect(store.patch.edges.some((e) => e.id === firstEdgeId)).toBe(true);
+
+    // Redo back to the edited state.
+    history.redo();
+    history.redo();
+    history.redo();
+    expect(store.patch.edges.length).toBe(edgeCountBefore - 1);
+    expect(store.patch.blocks.find((b) => b.id === id)?.config.cycleSpeed).toBe(0.9);
+  });
+
+  it('a new edit clears the redo stack', () => {
+    const history = new GraphHistoryStore();
+    const { adapter, patch } = makeV1();
+    history.bind(adapter, patch);
+
+    adapter.addBlock('Const', { x: 0, y: 0 });
+    history.undo();
+    expect(history.canRedo).toBe(true);
+
+    // A fresh edit branches history; the undone future is discarded.
+    adapter.addBlock('Const', { x: 1, y: 1 });
+    expect(history.canRedo).toBe(false);
+  });
+
+  it('keeps its stacks when rebound to the same model (panel remount)', () => {
+    const history = new GraphHistoryStore();
+    const { adapter, patch, layout } = makeV1();
+    history.bind(adapter, patch);
+
+    adapter.addBlock('Const', { x: 0, y: 0 });
+    expect(history.canUndo).toBe(true);
+
+    // Dockview rearrangement recreates the adapter over the SAME stores.
+    history.unbind(adapter);
+    const remounted = new PatchStoreAdapter(patch, layout, new FrontendResultStore());
+    history.bind(remounted, patch);
+
+    expect(history.canUndo).toBe(true);
+    history.undo();
+    expect(patch.blocks.size).toBe(0);
+  });
+
+  it('resets its stacks when bound to a different model', () => {
+    const history = new GraphHistoryStore();
+    const v1 = makeV1();
+    history.bind(v1.adapter, v1.patch);
+    v1.adapter.addBlock('Const', { x: 0, y: 0 });
+    expect(history.canUndo).toBe(true);
+
+    const pillar = makePillar();
+    history.bind(pillar.adapter, pillar.store);
+    expect(history.canUndo).toBe(false);
+  });
+
+  it('Pillar continuity: undo yields a frame-identical recompile', () => {
+    const history = new GraphHistoryStore();
+    const { adapter, store } = makePillar();
+    history.bind(adapter, store);
+
+    // The compiled ScenePlan an undone edit must return to bit-for-bit — the
+    // "equivalent reinstall is frame-identical" continuity gate. [LAW:one-source-of-truth]
+    const planBefore = store.compiled;
+
+    // A structural edit changes the plan; undo must recompile back to the exact plan.
+    adapter.removeEdge(store.patch.edges[0].id);
+    expect(store.compiled).not.toEqual(planBefore);
+
+    history.undo();
+    expect(store.compiled).toEqual(planBefore);
+  });
+});

--- a/src/stores/__tests__/GraphHistoryStore.test.ts
+++ b/src/stores/__tests__/GraphHistoryStore.test.ts
@@ -14,7 +14,8 @@ import { FrontendResultStore } from '../FrontendResultStore';
 import { LayoutStore } from '../LayoutStore';
 import { PatchStore } from '../PatchStore';
 import { PillarPatchStore } from '../PillarPatchStore';
-import { GraphHistoryStore } from '../GraphHistoryStore';
+import { makeAutoObservable } from 'mobx';
+import { GraphHistoryStore, type GraphHistorySnapshot, type GraphSnapshotSource } from '../GraphHistoryStore';
 import { PatchStoreAdapter } from '../../ui/graphEditor/PatchStoreAdapter';
 import { PillarPatchAdapter } from '../../ui/graphEditor/PillarPatchAdapter';
 import type { BlockId } from '../../types';
@@ -31,6 +32,38 @@ function makePillar() {
   const store = new PillarPatchStore();
   const adapter = new PillarPatchAdapter(store);
   return { store, adapter };
+}
+
+/**
+ * A minimal source whose `restoreHistorySnapshot` deliberately does NOT move the
+ * token — the pathological case the old `restoring`-flag design could not survive.
+ * `value` is the authored state; `token` is bumped only by `edit()`, never by restore.
+ */
+class TokenFrozenSource implements GraphSnapshotSource {
+  value = 0;
+  private token = 0;
+
+  constructor() {
+    makeAutoObservable(this);
+  }
+
+  get historyToken(): number {
+    return this.token;
+  }
+
+  edit(next: number): void {
+    this.value = next;
+    this.token++;
+  }
+
+  captureHistorySnapshot(): GraphHistorySnapshot {
+    return { value: this.value } as unknown as GraphHistorySnapshot;
+  }
+
+  restoreHistorySnapshot(snapshot: GraphHistorySnapshot): void {
+    // Intentionally leaves `token` unchanged, exercising the restore-doesn't-move-token path.
+    this.value = (snapshot as unknown as { value: number }).value;
+  }
 }
 
 describe('GraphHistoryStore', () => {
@@ -164,6 +197,35 @@ describe('GraphHistoryStore', () => {
 
     const pillar = makePillar();
     history.bind(pillar.adapter, pillar.store);
+    expect(history.canUndo).toBe(false);
+  });
+
+  it('records the next edit even when a restore does not move the token', () => {
+    // Regression: the reaction is suspended across a restore and re-armed after, so
+    // there is no flag that could stay armed and swallow the following real edit.
+    const history = new GraphHistoryStore();
+    const source = new TokenFrozenSource();
+    history.bind(source, source);
+
+    source.edit(1);
+    expect(history.canUndo).toBe(true);
+    history.undo();
+    expect(source.value).toBe(0);
+
+    // The undo's restore left the token frozen; a fresh edit must still checkpoint.
+    source.edit(2);
+    expect(history.canUndo).toBe(true);
+    history.undo();
+    expect(source.value).toBe(0);
+  });
+
+  it('dispose stops observing further edits', () => {
+    const history = new GraphHistoryStore();
+    const source = new TokenFrozenSource();
+    history.bind(source, source);
+
+    history.dispose();
+    source.edit(1);
     expect(history.canUndo).toBe(false);
   });
 

--- a/src/ui/components/app/App.tsx
+++ b/src/ui/components/app/App.tsx
@@ -21,6 +21,7 @@ import { ExternalWriteBusContext } from '../../ExternalWriteBusContext';
 import { useShowPreview, resolveBootSelection } from '../../../testing/test-params';
 import { TestPreviewPanel } from '../../../testing/TestPreviewPanel';
 import { resolveEditorEra } from './editorEra';
+import { useHistoryHotkeys } from '../../hotkeys/useHistoryHotkeys';
 
 // Mantine dark theme configuration - gorgeous modern look
 const mantineTheme = createMantineTheme({
@@ -113,6 +114,10 @@ export const App: React.FC<AppProps> = ({ onCanvasReady, onStoreReady, onStatsSi
 
   // Get store from context and expose to non-React code via callback
   const rootStore = useStores();
+
+  // Era-neutral undo/redo, active in both boots (a no-op until an editor binds the
+  // history). The rest of the hotkeys are still wired per-shell. [LAW:single-enforcer]
+  useHistoryHotkeys();
 
   // [LAW:dataflow-not-control-flow] The era is one value resolved from the boot
   //   selection; App reads it and mounts `era.Shell`. Both the block catalog and

--- a/src/ui/dockview/panels/scene/SceneGraphEditorPanel.tsx
+++ b/src/ui/dockview/panels/scene/SceneGraphEditorPanel.tsx
@@ -20,6 +20,7 @@ import { PillarPatchAdapter } from '../../../graphEditor/PillarPatchAdapter';
 import { SceneTypeOracle } from '../../../graphEditor/SceneTypeOracle';
 import { SceneEdgeDecorator } from '../../../graphEditor/SceneEdgeDecorator';
 import { GraphEditorCore } from '../../../graphEditor/GraphEditorCore';
+import { useGraphHistoryBinding } from '../../../graphEditor/useGraphHistoryBinding';
 
 export const SceneGraphEditorPanel: React.FC<IDockviewPanelProps> = observer(() => {
   const { pillarPatch, selection } = useStores();
@@ -37,6 +38,9 @@ export const SceneGraphEditorPanel: React.FC<IDockviewPanelProps> = observer(() 
   // Clamp) — the same chain the modulation table reads — so the canvas shows and
   // edits it as edge chips. [LAW:one-source-of-truth]
   const decorator = useMemo(() => new SceneEdgeDecorator(pillarPatch), [pillarPatch]);
+
+  // Undo/redo: bind this era's adapter as the single history authority's source.
+  useGraphHistoryBinding(adapter, pillarPatch);
 
   return (
     <div style={{ height: '100%', width: '100%' }}>

--- a/src/ui/graphEditor/PatchStoreAdapter.ts
+++ b/src/ui/graphEditor/PatchStoreAdapter.ts
@@ -14,9 +14,13 @@
 
 import { makeObservable, computed, runInAction } from 'mobx';
 import type { BlockId, UIControlHint, DefaultSource } from '../../types';
-import type { PatchStore } from '../../stores/PatchStore';
-import type { LayoutStore } from '../../stores/LayoutStore';
+import type { ImmutablePatch, PatchStore } from '../../stores/PatchStore';
+import type { LayoutStore, NodePosition } from '../../stores/LayoutStore';
 import type { FrontendResultStore } from '../../stores/FrontendResultStore';
+import type {
+  GraphSnapshotSource,
+  GraphHistorySnapshot,
+} from '../../stores/GraphHistoryStore';
 import type { Block, InputPort } from '../../graph/Patch';
 import { getAnyBlockDefinition, type AnyBlockDef, type InputDef } from '../../blocks/registry';
 import { canonicalType, FLOAT } from '../../core/canonical-types';
@@ -39,10 +43,16 @@ import type {
   PortDecoration,
 } from './types';
 
+/** V1 authored state the undo history captures: the patch plus editor layout. */
+interface PatchStoreHistoryState {
+  readonly patch: ImmutablePatch;
+  readonly positions: ReadonlyMap<BlockId, NodePosition>;
+}
+
 /**
  * Adapter that exposes PatchStore + LayoutStore through GraphDataAdapter.
  */
-export class PatchStoreAdapter implements GraphDataAdapter<BlockId> {
+export class PatchStoreAdapter implements GraphDataAdapter<BlockId>, GraphSnapshotSource {
   constructor(
     private readonly patchStore: PatchStore,
     private readonly layoutStore: LayoutStore,
@@ -52,6 +62,7 @@ export class PatchStoreAdapter implements GraphDataAdapter<BlockId> {
       blocks: computed,
       edges: computed,
       dataVersion: computed,
+      historyToken: computed,
     });
   }
 
@@ -138,6 +149,38 @@ export class PatchStoreAdapter implements GraphDataAdapter<BlockId> {
 
   updateBlockDisplayName(id: BlockId, displayName: string): { error?: string } {
     return this.patchStore.updateBlockDisplayName(id, displayName);
+  }
+
+  // ---------------------------------------------------------------------------
+  // GraphSnapshotSource (undo/redo)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Structural change-token folding authored-patch and layout revisions. Moves only
+   * on an actual edit through ANY write-path (canvas, context menu, inspector,
+   * hotkey) — never on frontend compile churn. [LAW:one-source-of-truth]
+   */
+  get historyToken(): { patch: number; layout: number } {
+    return { patch: this.patchStore.dataVersion, layout: this.layoutStore.revision };
+  }
+
+  captureHistorySnapshot(): GraphHistorySnapshot {
+    // `patchStore.patch` is already a defensive, frozen clone per revision, so holding
+    // the reference is safe — later edits produce a fresh snapshot, never mutate this.
+    const state: PatchStoreHistoryState = {
+      patch: this.patchStore.patch,
+      positions: new Map(this.layoutStore.positions),
+    };
+    return state as unknown as GraphHistorySnapshot;
+  }
+
+  restoreHistorySnapshot(snapshot: GraphHistorySnapshot): void {
+    const state = snapshot as unknown as PatchStoreHistoryState;
+    runInAction(() => {
+      this.patchStore.loadPatch(state.patch);
+      this.layoutStore.clear();
+      this.layoutStore.setPositions(state.positions);
+    });
   }
 
   // ---------------------------------------------------------------------------

--- a/src/ui/graphEditor/PillarPatchAdapter.ts
+++ b/src/ui/graphEditor/PillarPatchAdapter.ts
@@ -123,6 +123,11 @@ export class PillarPatchAdapter implements GraphDataAdapter<string>, GraphSnapsh
 
   setBlockPosition(id: string, position: { x: number; y: number }): void {
     runInAction(() => {
+      // Bump the layout revision only on a real coordinate change, so a re-set to the
+      // same spot (or a bulk layout pass over unchanged nodes) mints no spurious undo
+      // checkpoint — mirroring LayoutStore.setPosition. [LAW:dataflow-not-control-flow]
+      const prev = this.positions.get(id);
+      if (prev && prev.x === position.x && prev.y === position.y) return;
       this.positions.set(id, position);
       this.positionsRevision++;
     });

--- a/src/ui/graphEditor/PillarPatchAdapter.ts
+++ b/src/ui/graphEditor/PillarPatchAdapter.ts
@@ -13,7 +13,7 @@
  */
 
 import { makeObservable, computed, observable, runInAction } from 'mobx';
-import type { PillarPatchStore } from '../../stores/PillarPatchStore';
+import type { PillarPatchStore, PillarPatchState } from '../../stores/PillarPatchStore';
 import type { PillarBlock } from '../../pillars/types/graph';
 import type { SceneCatalogMetadata } from '../../pillars/scene/scene-block';
 import type {
@@ -23,19 +23,34 @@ import type {
   InputPortLike,
   OutputPortLike,
 } from './types';
+import type {
+  GraphSnapshotSource,
+  GraphHistorySnapshot,
+} from '../../stores/GraphHistoryStore';
 import { sceneTypeDisplay } from './scene-projection';
+
+/** Pillar authored state the undo history captures: store state plus editor layout. */
+interface PillarHistoryState {
+  readonly store: PillarPatchState;
+  readonly positions: ReadonlyMap<string, { x: number; y: number }>;
+}
 
 /**
  * Adapter exposing PillarPatchStore through the neutral GraphDataAdapter.
  */
-export class PillarPatchAdapter implements GraphDataAdapter<string> {
+export class PillarPatchAdapter implements GraphDataAdapter<string>, GraphSnapshotSource {
   /** Editor layout positions (PillarPatchStore stores none). */
   private readonly positions = observable.map<string, { x: number; y: number }>();
 
+  /** Counter bumped on layout changes; the history token folds it with the store's. */
+  private positionsRevision = 0;
+
   constructor(private readonly store: PillarPatchStore) {
-    makeObservable(this, {
+    makeObservable<PillarPatchAdapter, 'positionsRevision'>(this, {
       blocks: computed,
       edges: computed,
+      positionsRevision: observable,
+      historyToken: computed,
     });
   }
 
@@ -81,6 +96,7 @@ export class PillarPatchAdapter implements GraphDataAdapter<string> {
     runInAction(() => {
       id = this.store.addBlock(type);
       this.positions.set(id, position);
+      this.positionsRevision++;
     });
     return id;
   }
@@ -89,6 +105,7 @@ export class PillarPatchAdapter implements GraphDataAdapter<string> {
     runInAction(() => {
       this.store.removeBlock(id);
       this.positions.delete(id);
+      this.positionsRevision++;
     });
   }
 
@@ -107,6 +124,7 @@ export class PillarPatchAdapter implements GraphDataAdapter<string> {
   setBlockPosition(id: string, position: { x: number; y: number }): void {
     runInAction(() => {
       this.positions.set(id, position);
+      this.positionsRevision++;
     });
   }
 
@@ -132,6 +150,36 @@ export class PillarPatchAdapter implements GraphDataAdapter<string> {
       for (const [key, value] of Object.entries(params)) {
         this.store.updateConfig(id, key, value);
       }
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // GraphSnapshotSource (undo/redo)
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Structural change-token folding the store's authored revision with layout. Moves
+   * on any edit through any write-path (canvas, modulation table, inspector) — never
+   * on the derived ScenePlan recompute. [LAW:one-source-of-truth]
+   */
+  get historyToken(): { store: number; layout: number } {
+    return { store: this.store.revision, layout: this.positionsRevision };
+  }
+
+  captureHistorySnapshot(): GraphHistorySnapshot {
+    const state: PillarHistoryState = {
+      store: this.store.captureState(),
+      positions: new Map(this.positions),
+    };
+    return state as unknown as GraphHistorySnapshot;
+  }
+
+  restoreHistorySnapshot(snapshot: GraphHistorySnapshot): void {
+    const state = snapshot as unknown as PillarHistoryState;
+    runInAction(() => {
+      this.store.restoreState(state.store);
+      this.positions.replace(new Map(state.positions));
+      this.positionsRevision++;
     });
   }
 

--- a/src/ui/graphEditor/__tests__/adapter-conformance.contract.ts
+++ b/src/ui/graphEditor/__tests__/adapter-conformance.contract.ts
@@ -25,6 +25,7 @@
 import { reaction } from 'mobx';
 import { describe, expect, it } from 'vitest';
 import type { GraphDataAdapter } from '../types';
+import type { GraphSnapshotSource } from '../../../stores/GraphHistoryStore';
 
 /**
  * Everything a provider must supply to be run through the conformance contract.
@@ -51,6 +52,8 @@ export interface ConformanceCase<Id = string> {
     readonly params: boolean;
     /** `updateBlockDisplayName` present and writes through. */
     readonly displayName: boolean;
+    /** Implements GraphSnapshotSource: authored state captures and restores for undo. */
+    readonly history: boolean;
   };
 }
 
@@ -251,6 +254,29 @@ export function assertDisplayNameDelegates<Id>(c: ConformanceCase<Id>): void {
 }
 
 /**
+ * GraphSnapshotSource round-trips: a captured snapshot restores the exact authored
+ * state, and the history token moves on an edit so the history authority checkpoints.
+ * This is the undo contract stated once, independent of the GraphHistoryStore. [LAW:single-enforcer]
+ */
+export function assertHistorySnapshotRoundtrips<Id>(c: ConformanceCase<Id>): void {
+  const adapter = c.setup().newAdapter();
+  const source = adapter as unknown as GraphSnapshotSource;
+  expect(typeof source.captureHistorySnapshot, `${c.name}: declares captureHistorySnapshot`).toBe('function');
+  expect(typeof source.restoreHistorySnapshot, `${c.name}: declares restoreHistorySnapshot`).toBe('function');
+
+  const before = adapter.blocks.size;
+  const tokenBefore = source.historyToken;
+  const snapshot = source.captureHistorySnapshot();
+
+  adapter.addBlock(c.addableType, { x: 0, y: 0 });
+  expect(adapter.blocks.size, `${c.name}: edit grows the graph`).toBe(before + 1);
+  expect(source.historyToken, `${c.name}: history token moves on an edit`).not.toEqual(tokenBefore);
+
+  source.restoreHistorySnapshot(snapshot);
+  expect(adapter.blocks.size, `${c.name}: restore returns to the captured state`).toBe(before);
+}
+
+/**
  * Register the whole contract against one provider. A future 4th provider is
  * drop-in verifiable: build a ConformanceCase for it and call this.
  */
@@ -270,5 +296,8 @@ export function runConformanceSuite<Id>(c: ConformanceCase<Id>): void {
 
     const displayNameIt = c.capabilities.displayName ? it : it.skip;
     displayNameIt('updateBlockDisplayName writes through to the store', () => assertDisplayNameDelegates(c));
+
+    const historyIt = c.capabilities.history ? it : it.skip;
+    historyIt('history snapshot captures and restores authored state', () => assertHistorySnapshotRoundtrips(c));
   });
 }

--- a/src/ui/graphEditor/__tests__/adapter-conformance.test.ts
+++ b/src/ui/graphEditor/__tests__/adapter-conformance.test.ts
@@ -27,6 +27,7 @@ import {
   assertAddBlockReadableAndBranded,
   assertBlocksSelfDescribing,
   assertEdgesAnchorToRealHandles,
+  assertHistorySnapshotRoundtrips,
   assertMutationsDelegateToStore,
   assertReactivity,
   runConformanceSuite,
@@ -184,5 +185,11 @@ describe('conformance contract rejects a non-conforming adapter (negative contro
 
   it('rejects mutations that break MobX reactivity', () => {
     expect(() => assertReactivity(brokenCase)).toThrow();
+  });
+
+  it('rejects an adapter that lacks the history snapshot capability', () => {
+    // BrokenAdapter implements no GraphSnapshotSource, so the assertion's capability
+    // guard must fire — proving the history contract has teeth. [LAW:verifiable-goals]
+    expect(() => assertHistorySnapshotRoundtrips(brokenCase)).toThrow();
   });
 });

--- a/src/ui/graphEditor/__tests__/adapter-conformance.test.ts
+++ b/src/ui/graphEditor/__tests__/adapter-conformance.test.ts
@@ -40,7 +40,7 @@ import {
 const patchStoreCase: ConformanceCase<BlockId> = {
   name: 'PatchStoreAdapter',
   addableType: 'Const',
-  capabilities: { params: true, displayName: true },
+  capabilities: { params: true, displayName: true, history: true },
   setup() {
     const patchStore = new PatchStore();
     const layoutStore = new LayoutStore();
@@ -61,7 +61,7 @@ const patchStoreCase: ConformanceCase<BlockId> = {
 const compositeStoreCase: ConformanceCase<InternalBlockId> = {
   name: 'CompositeStoreAdapter',
   addableType: 'Noise',
-  capabilities: { params: false, displayName: false },
+  capabilities: { params: false, displayName: false, history: false },
   setup() {
     const store = new CompositeEditorStore();
 
@@ -76,7 +76,7 @@ const compositeStoreCase: ConformanceCase<InternalBlockId> = {
 const pillarPatchCase: ConformanceCase<string> = {
   name: 'PillarPatchAdapter',
   addableType: 'Constant',
-  capabilities: { params: true, displayName: false },
+  capabilities: { params: true, displayName: false, history: true },
   setup() {
     // PillarPatchStore self-seeds the grid-of-squares patch (3 blocks, 2 edges).
     const store = new PillarPatchStore();
@@ -159,7 +159,7 @@ class BrokenAdapter implements GraphDataAdapter<string> {
 const brokenCase: ConformanceCase<string> = {
   name: 'BrokenAdapter',
   addableType: 'X',
-  capabilities: { params: false, displayName: false },
+  capabilities: { params: false, displayName: false, history: false },
   setup() {
     return { newAdapter: () => new BrokenAdapter() };
   },

--- a/src/ui/graphEditor/useGraphHistoryBinding.ts
+++ b/src/ui/graphEditor/useGraphHistoryBinding.ts
@@ -1,0 +1,30 @@
+/**
+ * useGraphHistoryBinding — binds the active editor's adapter to the single
+ * GraphHistoryStore for the lifetime of the editor mount.
+ *
+ * The history authority lives in RootStore, so it outlives the panel: when dockview
+ * rearrangement recreates the adapter, this rebinds the new source under the SAME
+ * model key and the undo stacks are kept. [LAW:one-source-of-truth]
+ * [LAW:no-ambient-temporal-coupling]
+ *
+ * Only the two full-editor eras (V1 patch, pillar patch) bind. The composite editor
+ * edits a different model with a restricted adapter that carries no history capability,
+ * so it is intentionally not wired here.
+ */
+
+import { useEffect } from 'react';
+import { useStores } from '../../stores';
+import type { GraphSnapshotSource } from '../../stores/GraphHistoryStore';
+
+/**
+ * @param source the editor's data adapter, which also implements GraphSnapshotSource
+ * @param key    the underlying model's stable identity; same key across a remount
+ *               keeps the history, a different key starts fresh
+ */
+export function useGraphHistoryBinding(source: GraphSnapshotSource, key: object): void {
+  const { history } = useStores();
+  useEffect(() => {
+    history.bind(source, key);
+    return () => history.unbind(source);
+  }, [history, source, key]);
+}

--- a/src/ui/hotkeys/hotkeyRegistry.ts
+++ b/src/ui/hotkeys/hotkeyRegistry.ts
@@ -25,7 +25,16 @@ export type HotkeyAction =
   | 'toggle-play'
   | 'reset-time'
   | 'zoom-fit'
-  | 'delete-selected';
+  | 'delete-selected'
+  | HistoryAction;
+
+/**
+ * Era-neutral history actions, owned by useHistoryHotkeys (mounted for both boots),
+ * not by the V1-only useGlobalHotkeys. Split out so each hook binds exactly its own
+ * actions with no double-binding. [LAW:single-enforcer]
+ */
+export type HistoryAction = 'undo' | 'redo';
+export const HISTORY_ACTIONS: readonly HistoryAction[] = ['undo', 'redo'];
 
 export const HOTKEY_REGISTRY: Record<HotkeyAction, HotkeyEntry> = {
   'export-patch': {
@@ -56,6 +65,16 @@ export const HOTKEY_REGISTRY: Record<HotkeyAction, HotkeyEntry> = {
   'delete-selected': {
     keys: 'Backspace',
     description: 'Delete selected block/edge',
+    category: 'editor',
+  },
+  undo: {
+    keys: 'mod+Z',
+    description: 'Undo last graph edit',
+    category: 'editor',
+  },
+  redo: {
+    keys: 'mod+shift+Z',
+    description: 'Redo last undone graph edit',
     category: 'editor',
   },
 };

--- a/src/ui/hotkeys/useGlobalHotkeys.ts
+++ b/src/ui/hotkeys/useGlobalHotkeys.ts
@@ -7,7 +7,10 @@
 
 import { useCallback } from 'react';
 import { useHotkeys, type HotkeyItem } from '@mantine/hooks';
-import { HOTKEY_REGISTRY, type HotkeyAction } from './hotkeyRegistry';
+import { HOTKEY_REGISTRY, type HotkeyAction, type HistoryAction } from './hotkeyRegistry';
+
+/** The registry actions this V1 shell hook owns — everything except era-neutral history. */
+type GlobalHotkeyAction = Exclude<HotkeyAction, HistoryAction>;
 import { useStores } from '../../stores';
 import { useEditor } from '../editorCommon';
 import { useExportPatch } from '../hooks/useExportPatch';
@@ -34,7 +37,7 @@ export function useGlobalHotkeys(options: UseGlobalHotkeysOptions = {}): void {
     [onFeedback],
   );
 
-  const handlers: Record<HotkeyAction, (event: KeyboardEvent) => void> = {
+  const handlers: Record<GlobalHotkeyAction, (event: KeyboardEvent) => void> = {
     'export-patch': async () => {
       const result = await exportPatch();
       showFeedback(result.message, result.success ? 'success' : 'error');
@@ -82,8 +85,10 @@ export function useGlobalHotkeys(options: UseGlobalHotkeysOptions = {}): void {
     },
   };
 
+  // History (undo/redo) is era-neutral and owned by useHistoryHotkeys, mounted for
+  // both boots; bind only this shell's non-history actions. [LAW:single-enforcer]
   const hotkeyItems: HotkeyItem[] = (
-    Object.keys(HOTKEY_REGISTRY) as HotkeyAction[]
+    Object.keys(handlers) as GlobalHotkeyAction[]
   ).map((action) => [
     HOTKEY_REGISTRY[action].keys,
     handlers[action],

--- a/src/ui/hotkeys/useHistoryHotkeys.ts
+++ b/src/ui/hotkeys/useHistoryHotkeys.ts
@@ -1,0 +1,39 @@
+/**
+ * History Hotkeys Hook
+ *
+ * Owns undo/redo keybinding for BOTH editor eras. Unlike the rest of the registry
+ * (whose handlers still reach into V1-specific stores and are wired only in the V1
+ * shell), undo/redo are era-neutral: they call the single GraphHistoryStore, which is
+ * bound to whichever era's adapter is active. So this hook mounts once at the app root
+ * and works in the native (pillar) boot and the V1 boot alike. [LAW:single-enforcer]
+ *
+ * The shortcuts themselves live in the shared HOTKEY_REGISTRY (one source of truth for
+ * key bindings); useGlobalHotkeys cedes these two actions to this owner. [LAW:one-source-of-truth]
+ */
+
+import { useHotkeys, type HotkeyItem } from '@mantine/hooks';
+import { HOTKEY_REGISTRY, HISTORY_ACTIONS, type HistoryAction } from './hotkeyRegistry';
+import { useStores } from '../../stores';
+
+export function useHistoryHotkeys(): void {
+  const { history } = useStores();
+
+  const handlers: Record<HistoryAction, (event: KeyboardEvent) => void> = {
+    undo: (event) => {
+      event.preventDefault();
+      history.undo();
+    },
+    redo: (event) => {
+      event.preventDefault();
+      history.redo();
+    },
+  };
+
+  const hotkeyItems: HotkeyItem[] = HISTORY_ACTIONS.map((action) => [
+    HOTKEY_REGISTRY[action].keys,
+    handlers[action],
+    { preventDefault: false },
+  ]);
+
+  useHotkeys(hotkeyItems);
+}

--- a/src/ui/reactFlowEditor/ReactFlowEditor.tsx
+++ b/src/ui/reactFlowEditor/ReactFlowEditor.tsx
@@ -24,6 +24,7 @@ import type { EditorHandle } from '../editorCommon';
 import { GraphEditorCore, type GraphEditorCoreHandle } from '../graphEditor/GraphEditorCore';
 import type { PortContextMenuRequest } from '../graphEditor/GraphEditorContext';
 import { PatchStoreAdapter } from '../graphEditor/PatchStoreAdapter';
+import { useGraphHistoryBinding } from '../graphEditor/useGraphHistoryBinding';
 import { V1TypeOracle } from '../graphEditor/V1TypeOracle';
 import { V1EdgeDecorator } from '../graphEditor/V1EdgeDecorator';
 import { BlockContextMenu } from './menus/BlockContextMenu';
@@ -140,6 +141,9 @@ const ReactFlowEditorInner: React.FC<ReactFlowEditorProps> = observer(({
     () => new PatchStoreAdapter(patchStore, layoutStore, frontend),
     [patchStore, layoutStore, frontend]
   );
+
+  // Undo/redo: bind this era's adapter as the single history authority's source.
+  useGraphHistoryBinding(adapter, patchStore);
 
   // The V1 type authority for the wiring drag gate — wraps the same
   // frontend-resolved compatibility the editor validated with before the seam.


### PR DESCRIPTION
## What

A single **GraphHistoryStore** is the sole undo/redo authority for the graph editor, era-neutral across the V1 and pillar boots. `mod+Z` / `mod+shift+Z`.

## Design (and where it deviates from the ticket)

Two findings changed the shape:

1. **No prior undo existed.** The epic's "undo (PatchStore)" parity claim and this ticket's "reconcile with existing undo (store-local one retires)" were both inaccurate prior-agent notes — `loadPatch` exists, but no history stack. So this builds the single authority from scratch; nothing to retire.
2. **The mutation surface is not funneled through the adapter.** V1 context menus, the delete hotkey, the expression editor, and the modulation table all mutate the stores *directly*. A decorator that only intercepted `adapter.*` calls (the ticket's literal "wrap mutations / inverse-or-snapshot per kind") would silently miss those.

So instead of intercepting a privileged write-path, history **anchors to the single source of truth** — the authored patch — by observing each adapter's change-token via a MobX reaction and checkpointing opaque whole-graph snapshots. Snapshot-based ⇒ one code path, no per-kind branching. `[LAW:single-enforcer]` `[LAW:one-source-of-truth]` `[LAW:dataflow-not-control-flow]` `[LAW:no-mode-explosion]`

- **`GraphSnapshotSource`** capability (neutral, at the boundary): `PatchStoreAdapter` and `PillarPatchAdapter` capture/restore their store + layout as opaque snapshots. `[LAW:effects-at-boundaries]`
- History lives in **RootStore**, so it survives dockview panel remounts; rebind under the same model key keeps the stacks. `[LAW:no-ambient-temporal-coupling]`
- Pillar undo restores the model → **normal recompile → continuity rules apply**; no special undo path.
- Hotkeys owned by an era-neutral `useHistoryHotkeys` mounted for both boots (`useGlobalHotkeys` cedes those two actions ⇒ no double-binding). The native editor's *other* hotkeys remain 8lsn.8's scope.
- Locked into the **adapter conformance contract** as a `history` capability, so future adapters are drop-in verifiable. `[LAW:verifiable-goals]`

## Verification

- **Unit**: `GraphHistoryStore.test.ts` (7) — undo/redo across every mutation kind for both eras, redo-cleared-on-new-edit, survives-rebind, resets-on-different-model, and a **continuity assertion** (undo yields a frame-identical ScenePlan — the equivalent-reinstall gate). Conformance suite extended.
- **Full suite**: 2649 pass, 0 regressions. Typecheck + lint clean.
- **Live, both boots**: default (pillar) add-via-native-button → undo → redo; V1 delete-via-Backspace → undo restores block + cascaded edge. Both edits were *direct store bypasses* of the adapter, captured correctly.

Closes oscilla-editor-ux-8lsn.21.

https://claude.ai/code/session_01UpzE9zvvMMUmuVz3dBbjN1